### PR TITLE
[FIX] *: rolling release, migration to saas-17.1

### DIFF
--- a/art_craft/data/pos_config.xml
+++ b/art_craft/data/pos_config.xml
@@ -2,7 +2,6 @@
 <odoo noupdate="1">
     <record model="pos.config" id="point_of_sale.pos_config_main" forcecreate="0">
         <field name="name">The Arts &amp; Crafts Shop</field>
-        <field name="discount_product_id" ref="point_of_sale.product_product_consumable"/>
         <field name="available_pricelist_ids" eval="[Command.link(ref('product_pricelist_2')), Command.link(ref('product_pricelist_3'))]"/>
         <field name="limit_categories" eval="False"/>
         <field name="pricelist_id" ref="product_pricelist_3"/>

--- a/bar_and_lounge/demo/planning_slot.xml
+++ b/bar_and_lounge/demo/planning_slot.xml
@@ -5,7 +5,6 @@
         <field name="employee_id" ref="hr_employee_8" />
         <field name="sale_order_id" ref="sale_order_2" />
         <field name="sale_line_id" ref="sale_order_line_2" />
-        <field name="work_address_id" ref="base.main_partner" />
         <field name="start_datetime" eval="DateTime.today() - relativedelta(days=1)"/>
         <field name="end_datetime" eval="DateTime.today()"/>
         <field name="publication_warning" eval="True" />
@@ -16,7 +15,6 @@
         <field name="employee_id" ref="hr_employee_3" />
         <field name="sale_order_id" ref="sale_order_3" />
         <field name="sale_line_id" ref="sale_order_line_5" />
-        <field name="work_address_id" ref="base.main_partner" />
         <field name="start_datetime" eval="DateTime.today() - relativedelta(days=1)"/>
         <field name="end_datetime" eval="DateTime.today()"/>
     </record>
@@ -25,7 +23,6 @@
         <field name="employee_id" ref="hr_employee_8" />
         <field name="sale_order_id" ref="sale_order_3" />
         <field name="sale_line_id" ref="sale_order_line_4" />
-        <field name="work_address_id" ref="base.main_partner" />
         <field name="start_datetime" eval="DateTime.today() - relativedelta(days=1)"/>
         <field name="end_datetime" eval="DateTime.today()"/>
     </record>
@@ -34,7 +31,6 @@
         <field name="employee_id" ref="hr_employee_7" />
         <field name="sale_order_id" ref="sale_order_2" />
         <field name="sale_line_id" ref="sale_order_line_2" />
-        <field name="work_address_id" ref="base.main_partner" />
         <field name="start_datetime" eval="DateTime.today() - relativedelta(days=1)"/>
         <field name="end_datetime" eval="DateTime.today()"/>
     </record>

--- a/corporate_gifts/demo/planning_slot.xml
+++ b/corporate_gifts/demo/planning_slot.xml
@@ -7,7 +7,6 @@
         <field name="role_id" ref="planning_role_1" />
         <field name="resource_id" model="resource.resource" eval="obj().env.ref('corporate_gifts.hr_employee_2').resource_id.id" />
         <field name="employee_id" ref="hr_employee_2" />
-        <field name="work_address_id" ref="base.main_partner" />
         <field name="start_datetime" model="hr.employee" eval="
             pytz.timezone(obj().env.user.tz or 'UTC').localize(
                 DateTime.today().date() + relativedelta(weekday=0, hour=8)
@@ -27,7 +26,6 @@
         <field name="resource_id" model="resource.resource" eval="obj().env.ref('corporate_gifts.hr_employee_4').resource_id.id" />
         <field name="state">published</field>
         <field name="employee_id" ref="hr_employee_4" />
-        <field name="work_address_id" ref="base.main_partner" />
         <field name="start_datetime" model="hr.employee" eval="
             pytz.timezone(obj().env.user.tz or 'UTC').localize(
                 DateTime.today().date() + relativedelta(weekday=0, hour=8)
@@ -47,7 +45,6 @@
         <field name="resource_id" model="resource.resource" eval="obj().env.ref('corporate_gifts.hr_employee_4').resource_id.id" />
         <field name="state">published</field>
         <field name="employee_id" ref="hr_employee_4" />
-        <field name="work_address_id" ref="base.main_partner" />
         <field name="start_datetime" model="hr.employee" eval="
             pytz.timezone(obj().env.user.tz or 'UTC').localize(
                 DateTime.today().date() + relativedelta(weekday=0, hour=13)
@@ -68,7 +65,6 @@
         <field name="role_id" ref="planning_role_1" />
         <field name="resource_id" model="resource.resource" eval="obj().env.ref('corporate_gifts.hr_employee_3').resource_id.id" />
         <field name="employee_id" ref="hr_employee_3" />
-        <field name="work_address_id" ref="base.main_partner" />
         <field name="start_datetime" model="hr.employee" eval="
             pytz.timezone(obj().env.user.tz or 'UTC').localize(
                 DateTime.today().date() + relativedelta(weekday=1, hour=8)
@@ -85,7 +81,6 @@
         <field name="role_id" ref="planning_role_1" />
         <field name="resource_id" model="resource.resource" eval="obj().env.ref('corporate_gifts.hr_employee_2').resource_id.id" />
         <field name="employee_id" ref="hr_employee_2" />
-        <field name="work_address_id" ref="base.main_partner" />
         <field name="start_datetime" model="hr.employee" eval="
             pytz.timezone(obj().env.user.tz or 'UTC').localize(
                 DateTime.today().date() + relativedelta(weekday=1, hour=8)
@@ -105,7 +100,6 @@
         <field name="resource_id" model="resource.resource" eval="obj().env.ref('corporate_gifts.hr_employee_4').resource_id.id" />
         <field name="state">published</field>
         <field name="employee_id" ref="hr_employee_4" />
-        <field name="work_address_id" ref="base.main_partner" />
         <field name="start_datetime" model="hr.employee" eval="
             pytz.timezone(obj().env.user.tz or 'UTC').localize(
                 DateTime.today().date() + relativedelta(weekday=1, hour=8)
@@ -124,7 +118,6 @@
         <field name="role_id" ref="planning_role_2" />
         <field name="resource_id" model="resource.resource" eval="obj().env.ref('corporate_gifts.hr_employee_4').resource_id.id" />
         <field name="employee_id" ref="hr_employee_4" />
-        <field name="work_address_id" ref="base.main_partner" />
         <field name="start_datetime" model="hr.employee" eval="
             pytz.timezone(obj().env.user.tz or 'UTC').localize(
                 DateTime.today().date() + relativedelta(weekday=1, hour=13)
@@ -144,7 +137,6 @@
         <field name="resource_id" model="resource.resource" eval="obj().env.ref('corporate_gifts.hr_employee_3').resource_id.id" />
         <field name="employee_id" ref="hr_employee_3" />
         <field name="template_reset" eval="True" />
-        <field name="work_address_id" ref="base.main_partner" />
         <field name="start_datetime" model="hr.employee" eval="
             pytz.timezone(obj().env.user.tz or 'UTC').localize(
                 DateTime.today().date() + relativedelta(weekday=2, hour=8)
@@ -161,7 +153,6 @@
         <field name="role_id" ref="planning_role_1" />
         <field name="resource_id" model="resource.resource" eval="obj().env.ref('corporate_gifts.hr_employee_2').resource_id.id" />
         <field name="employee_id" ref="hr_employee_2" />
-        <field name="work_address_id" ref="base.main_partner" />
         <field name="start_datetime" model="hr.employee" eval="
             pytz.timezone(obj().env.user.tz or 'UTC').localize(
                 DateTime.today().date() + relativedelta(weekday=2, hour=8)
@@ -183,7 +174,6 @@
         <field name="resource_id" model="resource.resource" eval="obj().env.ref('corporate_gifts.hr_employee_3').resource_id.id" />
         <field name="state">published</field>
         <field name="employee_id" ref="hr_employee_3" />
-        <field name="work_address_id" ref="base.main_partner" />
         <field name="start_datetime" model="hr.employee" eval="
             pytz.timezone(obj().env.user.tz or 'UTC').localize(
                 DateTime.today().date() + relativedelta(weekday=3, hour=8)
@@ -201,7 +191,6 @@
         <field name="resource_id" model="resource.resource" eval="obj().env.ref('corporate_gifts.hr_employee_2').resource_id.id" />
         <field name="state">published</field>
         <field name="employee_id" ref="hr_employee_2" />
-        <field name="work_address_id" ref="base.main_partner" />
         <field name="publication_warning" eval="True" />
         <field name="start_datetime" model="hr.employee" eval="
             pytz.timezone(obj().env.user.tz or 'UTC').localize(
@@ -221,7 +210,6 @@
         <field name="role_id" ref="planning_role_1" />
         <field name="resource_id" model="resource.resource" eval="obj().env.ref('corporate_gifts.hr_employee_4').resource_id.id" />
         <field name="employee_id" ref="hr_employee_4" />
-        <field name="work_address_id" ref="base.main_partner" />
         <field name="start_datetime" model="hr.employee" eval="
             pytz.timezone(obj().env.user.tz or 'UTC').localize(
                 DateTime.today().date() + relativedelta(weekday=3, hour=8)
@@ -239,7 +227,6 @@
         <field name="role_id" ref="planning_role_2" />
         <field name="resource_id" model="resource.resource" eval="obj().env.ref('corporate_gifts.hr_employee_4').resource_id.id" />
         <field name="employee_id" ref="hr_employee_4" />
-        <field name="work_address_id" ref="base.main_partner" />
         <field name="start_datetime" model="hr.employee" eval="
             pytz.timezone(obj().env.user.tz or 'UTC').localize(
                 DateTime.today().date() + relativedelta(weekday=3, hour=13)
@@ -260,7 +247,6 @@
         <field name="state">published</field>
         <field name="employee_id" ref="hr_employee_3" />
         <field name="template_reset" eval="True" />
-        <field name="work_address_id" ref="base.main_partner" />
         <field name="start_datetime" model="hr.employee" eval="
             pytz.timezone(obj().env.user.tz or 'UTC').localize(
                 DateTime.today().date() + relativedelta(weekday=4, hour=8)
@@ -280,7 +266,6 @@
         <field name="resource_id" model="resource.resource" eval="obj().env.ref('corporate_gifts.hr_employee_2').resource_id.id" />
         <field name="state">published</field>
         <field name="employee_id" ref="hr_employee_2" />
-        <field name="work_address_id" ref="base.main_partner" />
         <field name="start_datetime" model="hr.employee" eval="
             pytz.timezone(obj().env.user.tz or 'UTC').localize(
                 DateTime.today().date() + relativedelta(weekday=4, hour=8)
@@ -301,7 +286,6 @@
         <field name="resource_id" model="resource.resource" eval="obj().env.ref('hr.employee_admin').resource_id.id" />
         <field name="state">published</field>
         <field name="employee_id" ref="hr.employee_admin" />
-        <field name="work_address_id" ref="base.main_partner" />
         <field name="start_datetime" model="hr.employee" eval="
             pytz.timezone(obj().env.user.tz or 'UTC').localize(
                 DateTime.today().date() + relativedelta(weekday=4, hour=8)

--- a/hair_salon/demo/appointment_type.xml
+++ b/hair_salon/demo/appointment_type.xml
@@ -20,7 +20,7 @@
             (0, 0, {'weekday': '5', 'start_hour': 14.0, 'end_hour': 17.0}),
             (0, 0, {'weekday': '6', 'start_hour': 9.0, 'end_hour': 17.0}),
         ]"/>
-        <field name="cover_properties">{"background_color_class": "o_cc3", "background-image": "url('/web/image/hair_salon.s_cover_default_image')", "opacity": "0.4", "resize_class": "o_record_has_cover o_half_screen_height"}</field>
+        <field name="image_1920" type="base64" file="hair_salon/static/src/binary/ir_attachment/391-website.s_cover_default_image"/>
     </record>
 
     <record id="appointment_type_2" model="appointment.type">
@@ -43,7 +43,7 @@
             (0, 0, {'weekday': '5', 'start_hour': 14.0, 'end_hour': 17.0}),
             (0, 0, {'weekday': '6', 'start_hour': 9.0, 'end_hour': 17.0}),
         ]"/>
-        <field name="cover_properties">{"background_color_class": "o_cc3", "background-image": "url('/web/image/hair_salon.s_cover_default_image')", "opacity": "0.4", "resize_class": "o_record_has_cover o_half_screen_height"}</field>
+        <field name="image_1920" type="base64" file="hair_salon/static/src/binary/ir_attachment/391-website.s_cover_default_image"/>
     </record>
 
     <record id="appointment_type_3" model="appointment.type">
@@ -66,7 +66,7 @@
             (0, 0, {'weekday': '5', 'start_hour': 14.0, 'end_hour': 17.0}),
             (0, 0, {'weekday': '6', 'start_hour': 9.0, 'end_hour': 17.0}),
         ]"/>
-        <field name="cover_properties">{"background_color_class": "o_cc3", "background-image": "url('/web/image/hair_salon.s_cover_default_image')", "opacity": "0.4", "resize_class": "o_record_has_cover o_half_screen_height"}</field>
+        <field name="image_1920" type="base64" file="hair_salon/static/src/binary/ir_attachment/391-website.s_cover_default_image"/>
     </record>
 
 </odoo>

--- a/hair_salon/demo/calendar_event.xml
+++ b/hair_salon/demo/calendar_event.xml
@@ -18,7 +18,6 @@
         <field name="alarm_ids" eval="[(6, 0, [ref('calendar.alarm_notif_1'), ref('calendar.alarm_mail_1'), ref('appointment_sms.calendar_alarm_data_1h_sms')])]" />
         <field name="user_id" ref="base.user_admin"/>
         <field name="partner_ids" eval="[(6, 0, [ref('hair_salon.res_partner_12'), ref('base.partner_admin')])]" />
-        <field name="categ_ids" eval="[(6, 0, [ref('appointment.calendar_event_type_data_online_appointment')])]" />
         <field name="description">&lt;ul&gt;&lt;li&gt;Email: customer3@odoo.test.com&lt;/li&gt;&lt;/ul&gt;</field>
     </record>
 
@@ -133,7 +132,6 @@
         <field name="location">Hair Salon Industry, Belgium</field>
         <field name="user_id" ref="res_users_7"/>
         <field name="partner_ids" eval="[(6, 0, [ref('hair_salon.res_partner_16'), ref('hair_salon.res_partner_8')])]" />
-        <field name="categ_ids" eval="[(6, 0, [ref('appointment.calendar_event_type_data_online_appointment')])]" />
         <field name="description">&lt;ul&gt;&lt;li&gt;Email: oliviaferrero@odoo.test.example.com&lt;/li&gt;&lt;/ul&gt;</field>
     </record>
 
@@ -208,7 +206,6 @@
         <field name="alarm_ids" eval="[(6, 0, [ref('calendar.alarm_notif_1'), ref('calendar.alarm_mail_1'), ref('appointment_sms.calendar_alarm_data_1h_sms')])]" />
         <field name="user_id" ref="res_users_7"/>
         <field name="partner_ids" eval="[(6, 0, [ref('hair_salon.res_partner_17'), ref('hair_salon.res_partner_8')])]" />
-        <field name="categ_ids" eval="[(6, 0, [ref('appointment.calendar_event_type_data_online_appointment')])]" />
         <field name="description">&lt;ul&gt;&lt;li&gt;Email: laura@odoo.test.example.com&lt;/li&gt;&lt;/ul&gt;</field>
     </record>
 
@@ -230,7 +227,6 @@
         <field name="alarm_ids" eval="[(6, 0, [ref('calendar.alarm_notif_1'), ref('calendar.alarm_mail_1'), ref('appointment_sms.calendar_alarm_data_1h_sms')])]" />
         <field name="user_id" ref="res_users_8"/>
         <field name="partner_ids" eval="[(6, 0, [ref('hair_salon.res_partner_11'), ref('hair_salon.res_partner_9')])]" />
-        <field name="categ_ids" eval="[(6, 0, [ref('appointment.calendar_event_type_data_online_appointment')])]" />
         <field name="description">&lt;ul&gt;&lt;li&gt;Email: customer2@odoo.test.example.com&lt;/li&gt;&lt;/ul&gt;</field>
     </record>
 

--- a/software_reseller/demo/planning_slot.xml
+++ b/software_reseller/demo/planning_slot.xml
@@ -4,7 +4,6 @@
         <field name="department_id" ref="hr.dep_administration" />
         <field name="role_id" ref="planning_role_1" />
         <field name="resource_id" model="resource.resource" eval="obj().env.ref('hr.employee_admin').resource_id.id" />
-        <field name="work_address_id" ref="base.main_partner" />
         <field name="start_datetime" eval="DateTime.today()"/>
         <field name="end_datetime" eval="DateTime.today() + relativedelta(days=4)"/>
         <field name="allocated_hours">40.0</field>
@@ -16,7 +15,6 @@
         <field name="department_id" ref="hr.dep_administration" />
         <field name="role_id" ref="planning_role_1" />
         <field name="resource_id" model="resource.resource" eval="obj().env.ref('hr.employee_admin').resource_id.id" />
-        <field name="work_address_id" ref="base.main_partner" />
         <field name="start_datetime" eval="DateTime.today()"/>
         <field name="end_datetime" eval="DateTime.today() + relativedelta(days=4)"/>
         <field name="allocated_hours">40.0</field>
@@ -28,7 +26,6 @@
         <field name="department_id" ref="hr.dep_administration" />
         <field name="role_id" ref="planning_role_1" />
         <field name="resource_id" model="resource.resource" eval="obj().env.ref('hr.employee_admin').resource_id.id" />
-        <field name="work_address_id" ref="base.main_partner" />
         <field name="start_datetime" eval="DateTime.today()"/>
         <field name="end_datetime" eval="DateTime.today() + relativedelta(days=3)"/>
         <field name="allocated_hours">32.0</field>
@@ -40,7 +37,6 @@
         <field name="department_id" ref="hr.dep_administration" />
         <field name="role_id" ref="planning_role_1" />
         <field name="resource_id" model="resource.resource" eval="obj().env.ref('hr.employee_admin').resource_id.id" />
-        <field name="work_address_id" ref="base.main_partner" />
         <field name="start_datetime" eval="DateTime.today()"/>
         <field name="end_datetime" eval="DateTime.today() + relativedelta(days=4)"/>
         <field name="allocated_hours">40.0</field>

--- a/sports_club/demo/planning_slot.xml
+++ b/sports_club/demo/planning_slot.xml
@@ -4,7 +4,6 @@
     <record id="planning_slot_morning" model="planning.slot">
         <field name="name">Morning Shift</field>
         <field name="role_id" ref="planning_role_1"/>
-        <field name="work_address_id" ref="base.main_partner" />
         <field name="start_datetime" model="res.users" eval="
             pytz.timezone(obj().env.ref('base.user_admin').tz or 'UTC').localize(
                 DateTime.today().date() + relativedelta(hour=8)
@@ -23,7 +22,6 @@
     <record id="planning_slot_afternoon" model="planning.slot">
         <field name="name">Afternoon Shift</field>
         <field name="role_id" ref="planning_role_1"/>
-        <field name="work_address_id" ref="base.main_partner" />
         <field name="start_datetime" model="res.users" eval="
             pytz.timezone(obj().env.ref('base.user_admin').tz or 'UTC').localize(
                 DateTime.today().date() + relativedelta(hour=16)


### PR DESCRIPTION
In odoo/enterprise@8bf1da4382ebda6ccc6, the field `work_address_id` was removed, as it was unused. This commit removes it from all industries.

Since https://github.com/odoo/enterprise/commit/e02ec53a9e9134342, `appointment.type` does not rely on `website.cover_properties.mixin` anymore, and is replaced by `image.mixin`. The field `image_1920` replaces the field `cover_properties`.

Since odoo/enterprise@44aea75a260048baf7fe7f7, the Appointment tag was removed from datas in calendar events.