### PR TITLE
[FIX] hair_salon: missing class oe_unremovable on website header

### DIFF
--- a/hair_salon/demo/website_view.xml
+++ b/hair_salon/demo/website_view.xml
@@ -10,7 +10,7 @@
                     <div t-attf-class="oe_structure oe_structure_solo #{_div_class}">
                         <section class="oe_unremovable oe_unmovable s_text_block" data-snippet="s_text_block" data-name="Text">
                             <div class="container">
-                                <a href="/appointment" class="btn btn-primary btn_cta">Schedule an appointment</a>
+                                <a href="/appointment" class="oe_unremovable btn btn-primary btn_cta">Schedule an appointment</a>
                             </div>
                         </section>
                     </div>


### PR DESCRIPTION
500: Internal Server Error when trying to access the industry with demo data.

odoo.addons.base.models.ir_qweb.QWebException: Error while render the template
ValueError: Element '' cannot be located in parent view
Template: website.template_header_mobile
Path: /t/t/div/div/div[2]/ul[2]/t[4]
Node: <t t-call="website.header_call_to_action_large"/>