### PR TITLE
[FIX] sports_club: remove appointment_resource_ids from calendar.event

### DIFF
--- a/sports_club/demo/calendar_event.xml
+++ b/sports_club/demo/calendar_event.xml
@@ -9,7 +9,6 @@
         <field name="stop" model="appointment.type" eval="pytz.timezone(obj().env.ref('sports_club.appointment_type_1').appointment_tz).localize(
                 DateTime.today().date() + relativedelta(days=1, hours=13)
             ).astimezone(pytz.UTC).replace(tzinfo=None)"/>
-        <field name="appointment_resource_ids" eval="[(6, 0, [ref('appointment_resource_3')])]"/>
     </record>
     <record id="calendar_event_2" model="calendar.event">
         <field name="name">Joel Willis - Sport Court Booking</field>
@@ -20,7 +19,6 @@
         <field name="stop" model="appointment.type" eval="pytz.timezone(obj().env.ref('sports_club.appointment_type_1').appointment_tz).localize(
                 DateTime.today().date() + relativedelta(hours=17)
             ).astimezone(pytz.UTC).replace(tzinfo=None)"/>
-        <field name="appointment_resource_ids" eval="[(6, 0, [ref('appointment_resource_1')])]"/>
     </record>
     <record id="calendar_event_3" model="calendar.event">
         <field name="name">John Doe - Sport Court Booking</field>
@@ -31,7 +29,6 @@
         <field name="stop" model="appointment.type" eval="pytz.timezone(obj().env.ref('sports_club.appointment_type_2').appointment_tz).localize(
                 DateTime.today().date() + relativedelta(hours=10)
             ).astimezone(pytz.UTC).replace(tzinfo=None)"/>
-        <field name="appointment_resource_ids" eval="[(6, 0, [ref('appointment_resource_2')])]"/>
     </record>
     <record id="calendar_event_4" model="calendar.event">
         <field name="name">Joel Willis - Sport Court Booking</field>
@@ -42,7 +39,6 @@
         <field name="stop" model="appointment.type" eval="pytz.timezone(obj().env.ref('sports_club.appointment_type_1').appointment_tz).localize(
                 DateTime.today().date() + relativedelta(days=2, hours=13)
             ).astimezone(pytz.UTC).replace(tzinfo=None)"/>
-        <field name="appointment_resource_ids" eval="[(6, 0, [ref('appointment_resource_3')])]"/>
     </record>
     <record id="calendar_event_5" model="calendar.event">
         <field name="name">John Doe - Sport Court Booking</field>
@@ -53,7 +49,6 @@
         <field name="stop" model="appointment.type" eval="pytz.timezone(obj().env.ref('sports_club.appointment_type_1').appointment_tz).localize(
                 DateTime.today().date() + relativedelta(hours=19)
             ).astimezone(pytz.UTC).replace(tzinfo=None)"/>
-        <field name="appointment_resource_ids" eval="[(6, 0, [ref('appointment_resource_1')])]"/>
     </record>
     <record id="calendar_event_6" model="calendar.event">
         <field name="name">Joel Willis - Friday Night Free Play</field>
@@ -64,7 +59,6 @@
         <field name="stop" model="appointment.type" eval="pytz.timezone(obj().env.ref('sports_club.appointment_type_2').appointment_tz).localize(
                 DateTime.today().date() + relativedelta(days=4, hours=10)
             ).astimezone(pytz.UTC).replace(tzinfo=None)"/>
-        <field name="appointment_resource_ids" eval="[(6, 0, [ref('appointment_resource_2')])]"/>
     </record>
     <record id="calendar_event_7" model="calendar.event">
         <field name="name">Joel Willis - Sport Court Booking</field>
@@ -75,7 +69,6 @@
         <field name="stop" model="appointment.type" eval="pytz.timezone(obj().env.ref('sports_club.appointment_type_1').appointment_tz).localize(
                 DateTime.today().date() + relativedelta(hours=21)
             ).astimezone(pytz.UTC).replace(tzinfo=None)"/>
-        <field name="appointment_resource_ids" eval="[(6, 0, [ref('appointment_resource_4')])]"/>
     </record>
     <record id="calendar_event_8" model="calendar.event">
         <field name="name">John Doe - Friday Night Free Play</field>
@@ -86,6 +79,5 @@
         <field name="stop" model="appointment.type" eval="pytz.timezone(obj().env.ref('sports_club.appointment_type_2').appointment_tz).localize(
                 DateTime.today().date() + relativedelta(hours=10)
             ).astimezone(pytz.UTC).replace(tzinfo=None)"/>
-        <field name="appointment_resource_ids" eval="[(6, 0, [ref('appointment_resource_5')])]"/>
     </record>
 </odoo>


### PR DESCRIPTION
Since odoo/enterprise@064e0da976edd7ef501, the field `appointment_resource_ids` should ne be given to a `calender.event` if the resource is set to manage the capacity.