### PR TITLE
[FIX] solar_installation: remove message_partner_ids from repair order

### DIFF
--- a/eyewear_shop/demo/pos_order_line.xml
+++ b/eyewear_shop/demo/pos_order_line.xml
@@ -12,9 +12,7 @@
         <field name="product_uom_id" ref="uom.product_uom_unit"/>
         <field name="margin">23.5</field>
         <field name="price_unit">23.5</field>
-        <field name="tax_ids_after_fiscal_position" eval="[(6, 0, [ref('account.1_sale_tax_template')])]"/>
         <field name="price_subtotal_incl">27.03</field>
-        <field name="tax_ids" eval="[(6, 0, [ref('account.1_sale_tax_template')])]"/>
     </record>
     <record id="pos_order_line_13" model="pos.order.line">
         <field name="name">Eyewear Shop/0005</field>
@@ -28,9 +26,7 @@
         <field name="product_uom_id" ref="uom.product_uom_unit"/>
         <field name="margin">12.0</field>
         <field name="price_unit">12.0</field>
-        <field name="tax_ids_after_fiscal_position" eval="[(6, 0, [ref('account.1_sale_tax_template')])]"/>
         <field name="price_subtotal_incl">13.8</field>
-        <field name="tax_ids" eval="[(6, 0, [ref('account.1_sale_tax_template')])]"/>
     </record>
     <record id="pos_order_line_9" model="pos.order.line">
         <field name="name">Eyewear Shop/0001</field>
@@ -45,8 +41,6 @@
         <field name="product_uom_id" ref="uom.product_uom_unit"/>
         <field name="margin">55.0</field>
         <field name="price_unit">255.0</field>
-        <field name="tax_ids_after_fiscal_position" eval="[(6, 0, [ref('account.1_sale_tax_template')])]"/>
         <field name="price_subtotal_incl">293.25</field>
-        <field name="tax_ids" eval="[(6, 0, [ref('account.1_sale_tax_template')])]"/>
     </record>
 </odoo>

--- a/eyewear_shop/demo/website_view.xml
+++ b/eyewear_shop/demo/website_view.xml
@@ -221,67 +221,6 @@
             </t>
         </field>
     </record>
-    <record id="ir_ui_view_2608" model="ir.ui.view">
-        <field name="name">Template Header Default</field>
-        <field name="inherit_id" ref="website.layout"/>
-        <field name="website_id" ref="website.default_website"/>
-        <field name="key">website.template_header_default</field>
-        <field name="mode">extension</field>
-        <field name="type">qweb</field>
-        <field name="arch" type="xml">
-            <data inherit_id="website.layout" name="Template Header Default" active="True">
-                <xpath expr="//header//nav" position="replace">
-                    <t t-call="website.navbar">
-                        <t t-set="_navbar_classes" separator=" "/>
-                        <div id="top_menu_container" class="container justify-content-start justify-content-lg-between">
-                            <t t-call="website.placeholder_header_brand">
-                                <t t-set="_link_class" t-valuef="me-4"/>
-                            </t>
-                            <div id="top_menu_collapse" class="collapse navbar-collapse order-last order-lg-0">
-                                <t t-call="website.navbar_nav">
-                                    <t t-set="_nav_class" t-valuef="flex-grow-1 mx-auto ms-auto"/>
-                                    <t t-foreach="website.menu_id.child_id" t-as="submenu">
-                                        <t t-call="website.submenu">
-                                            <t t-set="item_class" t-valuef="nav-item"/>
-                                            <t t-set="link_class" t-valuef="nav-link"/>
-                                        </t>
-                                    </t>
-                                    <t t-call="website_sale.header_cart_link">
-                                        <t t-set="_icon" t-value="True"/>
-                                        <t t-set="_item_class" t-value="'nav-item mx-lg-3'"/>
-                                        <t t-set="_link_class" t-value="'nav-link'"/>
-                                    </t>
-                                    <t t-call="website_sale_wishlist.header_wishlist_link">
-                                        <t t-set="_icon" t-value="True"/>
-                                        <t t-set="_item_class" t-value="'nav-item me-lg-3'"/>
-                                        <t t-set="_link_class" t-value="'nav-link'"/>
-                                    </t>
-                                    <t t-call="portal.placeholder_user_sign_in">
-                                        <t t-set="_item_class" t-valuef="nav-item ms-lg-auto"/>
-                                        <t t-set="_link_class" t-valuef="nav-link fw-bold"/>
-                                    </t>
-                                    <t t-call="portal.user_dropdown">
-                                        <t t-set="_user_name" t-value="true"/>
-                                        <t t-set="_item_class" t-valuef="nav-item dropdown ms-lg-auto"/>
-                                        <t t-set="_link_class" t-valuef="nav-link fw-bold"/>
-                                    </t>
-                                    <t t-call="website.placeholder_header_language_selector">
-                                        <t t-set="_div_classes" t-valuef="nav-item my-auto ms-lg-2"/>
-                                    </t>
-                                </t>
-                            </div>
-                            <t t-call="website.placeholder_header_call_to_action">
-                                <t t-set="_div_classes" t-valuef="ms-lg-4"/>
-                            </t>
-                            <t t-call="website.navbar_toggler">
-                                <t t-set="_toggler_class" t-valuef="ms-auto"/>
-                            </t>
-                        </div>
-                    </t>
-                </xpath>
-            </data>
-        </field>
-    </record>
     <record id="ir_ui_view_2612" model="ir.ui.view">
         <field name="name">Default</field>
         <field name="inherit_id" ref="website.layout"/>

--- a/fmcg_store/demo/pos_order_line.xml
+++ b/fmcg_store/demo/pos_order_line.xml
@@ -10,8 +10,6 @@
         <field name="price_subtotal">2.0</field>
         <field name="margin">1.0</field>
         <field name="product_uom_id" ref="uom.product_uom_litre"/>
-        <field name="tax_ids" eval="[(6, 0, [ref('account.1_sale_tax_template')])]"/>
-        <field name="tax_ids_after_fiscal_position" eval="[(6, 0, [ref('account.1_sale_tax_template')])]"/>
         <field name="margin_percent">0.5</field>
         <field name="company_id" ref="base.main_company"/>
     </record>
@@ -26,8 +24,6 @@
         <field name="price_subtotal_incl">4.60</field>
         <field name="margin">2.0</field>
         <field name="product_uom_id" ref="uom.product_uom_litre"/>
-        <field name="tax_ids" eval="[(6, 0, [ref('account.1_sale_tax_template')])]"/>
-        <field name="tax_ids_after_fiscal_position" eval="[(6, 0, [ref('account.1_sale_tax_template')])]"/>
         <field name="margin_percent">0.5</field>
         <field name="company_id" ref="base.main_company"/>
     </record>
@@ -42,8 +38,6 @@
         <field name="price_subtotal_incl">23.0</field>
         <field name="margin">10.0</field>
         <field name="product_uom_id" ref="uom.product_uom_litre"/>
-        <field name="tax_ids" eval="[(6, 0, [ref('account.1_sale_tax_template')])]"/>
-        <field name="tax_ids_after_fiscal_position" eval="[(6, 0, [ref('account.1_sale_tax_template')])]"/>
         <field name="margin_percent">0.5</field>
         <field name="company_id" ref="base.main_company"/>
     </record>
@@ -56,8 +50,6 @@
         <field name="price_subtotal">4.0</field>
         <field name="margin">2.0</field>
         <field name="product_uom_id" ref="uom.product_uom_litre"/>
-        <field name="tax_ids" eval="[(6, 0, [ref('account.1_sale_tax_template')])]"/>
-        <field name="tax_ids_after_fiscal_position" eval="[(6, 0, [ref('account.1_sale_tax_template')])]"/>
         <field name="margin_percent">0.5</field>
         <field name="price_subtotal_incl">4.60</field>
         <field name="company_id" ref="base.main_company"/>
@@ -73,8 +65,6 @@
         <field name="price_subtotal_incl">9.20</field>
         <field name="margin">4.0</field>
         <field name="product_uom_id" ref="uom.product_uom_litre"/>
-        <field name="tax_ids" eval="[(6, 0, [ref('account.1_sale_tax_template')])]"/>
-        <field name="tax_ids_after_fiscal_position" eval="[(6, 0, [ref('account.1_sale_tax_template')])]"/>
         <field name="margin_percent">0.5</field>
         <field name="company_id" ref="base.main_company"/>
     </record>
@@ -89,8 +79,6 @@
         <field name="price_subtotal_incl">23.0</field>
         <field name="margin">10.0</field>
         <field name="product_uom_id" ref="uom.product_uom_litre"/>
-        <field name="tax_ids" eval="[(6, 0, [ref('account.1_sale_tax_template')])]"/>
-        <field name="tax_ids_after_fiscal_position" eval="[(6, 0, [ref('account.1_sale_tax_template')])]"/>
         <field name="margin_percent">0.5</field>
         <field name="company_id" ref="base.main_company"/>
     </record>

--- a/solar_installation/demo/repair_order.xml
+++ b/solar_installation/demo/repair_order.xml
@@ -29,7 +29,6 @@
         <field name="lot_id" ref="stock_lot_8"/>
         <field name="schedule_date" eval="datetime.now()"/>
         <field name="is_returned" eval="True"/>
-        <field name="message_partner_ids" eval="[(6, 0, [ref('base.partner_admin')])]"/>
         <field name="product_id" ref="product_product_10"/>
         <field name="company_id" ref="base.main_company"/>
     </record>
@@ -60,7 +59,6 @@
             ]]></field>
         <field name="lot_id" ref="stock_lot_9"/>
         <field name="schedule_date" eval="datetime.now()"/>
-        <field name="message_partner_ids" eval="[(6, 0, [ref('base.partner_admin')])]"/>
         <field name="user_id" eval="False"/>
         <field name="product_id" ref="product_product_10"/>
         <field name="company_id" ref="base.main_company"/>
@@ -95,7 +93,6 @@
             ]]></field>
         <field name="lot_id" ref="stock_lot_11"/>
         <field name="schedule_date" eval="datetime.now()"/>
-        <field name="message_partner_ids" eval="[(6, 0, [ref('base.partner_admin')])]"/>
         <field name="user_id" eval="False"/>
         <field name="product_id" ref="product_product_10"/>
         <field name="company_id" ref="base.main_company"/>


### PR DESCRIPTION
The field message_partner_ids should not be defined here as the admin is already a follower of the channel.

opw-4006335