### PR TITLE
[FIX] construction: fix project task types

### DIFF
--- a/construction/__manifest__.py
+++ b/construction/__manifest__.py
@@ -26,6 +26,7 @@ focusing on accurate quoting, efficient planning, seamless execution, and excell
         'data/documents_folder.xml',
         'data/res_config_settings.xml',
         'data/product_category.xml',
+        'data/project_task_type.xml',
         'data/project_project.xml',
         'data/ir_attachment_pre.xml',
         'data/uom_uom.xml',

--- a/construction/data/project_project.xml
+++ b/construction/data/project_project.xml
@@ -3,11 +3,12 @@
     <record id="project_project_3" model="project.project">
         <field name="name">Project Template</field>
         <field name="type_ids" eval="[(6, 0, [
-            ref('industry_fsm.planning_project_stage_0', raise_if_not_found=False),
-            ref('industry_fsm.planning_project_stage_1', raise_if_not_found=False),
-            ref('industry_fsm.planning_project_stage_2', raise_if_not_found=False),
-            ref('industry_fsm.planning_project_stage_3', raise_if_not_found=False),
-            ref('industry_fsm.planning_project_stage_4', raise_if_not_found=False)])]"/>
+            ref('planning_project_stage_0'),
+            ref('planning_project_stage_1'),
+            ref('planning_project_stage_2'),
+            ref('planning_project_stage_3'),
+            ref('planning_project_stage_4'),
+        ])]"/>
         <field name="stage_id" ref="project.project_project_stage_2"/>
         <field name="documents_folder_id" ref="documents_folder_11"/>
         <field name="analytic_account_id" ref="account_analytic_account_3"/>

--- a/construction/data/project_task_type.xml
+++ b/construction/data/project_task_type.xml
@@ -1,0 +1,29 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<odoo noupdate="1">
+    <record id="planning_project_stage_0" model="project.task.type">
+        <field name="sequence">1</field>
+        <field name="name">New</field>
+    </record>
+    <record id="planning_project_stage_1" model="project.task.type">
+        <field name="sequence">5</field>
+        <field name="name">Planned</field>
+    </record>
+    <record id="planning_project_stage_2" model="project.task.type">
+        <field name="sequence">10</field>
+        <field name="name">In Progress</field>
+    </record>
+    <record id="planning_project_stage_3" model="project.task.type">
+        <field name="sequence">20</field>
+        <field name="name">Done</field>
+        <field name="fold" eval="True"/>
+    </record>
+    <record id="planning_project_stage_4" model="project.task.type">
+        <field name="sequence">25</field>
+        <field name="name">Cancelled</field>
+        <field name="fold" eval="True"/>
+    </record>
+    <record id="internal_project_default_stage" model="project.task.type">
+        <field name="sequence">2</field>
+        <field name="name">Internal</field>
+    </record>
+</odoo>

--- a/construction/demo/project_project.xml
+++ b/construction/demo/project_project.xml
@@ -2,7 +2,7 @@
 <odoo noupdate="1">
     <record id="project_project_1" model="project.project">
         <field name="name">Internal</field>
-        <field name="type_ids" eval="[(6, 0, [ref('hr_timesheet.internal_project_default_stage', raise_if_not_found=False)])]"/>
+        <field name="type_ids" eval="[(6, 0, [ref('internal_project_default_stage')])]"/>
         <field name="stage_id" ref="project.project_project_stage_0"/>
         <field name="documents_folder_id" ref="documents_folder_8"/>
         <field name="analytic_account_id" ref="account_analytic_account_1"/>
@@ -12,11 +12,12 @@
         <field name="name">S00001 - VDK Project</field>
         <field name="partner_id" ref="res_partner_20"/>
         <field name="type_ids" eval="[(6, 0, [
-            ref('industry_fsm.planning_project_stage_0', raise_if_not_found=False),
-            ref('industry_fsm.planning_project_stage_1', raise_if_not_found=False),
-            ref('industry_fsm.planning_project_stage_2', raise_if_not_found=False),
-            ref('industry_fsm.planning_project_stage_3', raise_if_not_found=False),
-            ref('industry_fsm.planning_project_stage_4', raise_if_not_found=False)])]"/>
+            ref('planning_project_stage_0'),
+            ref('planning_project_stage_1'),
+            ref('planning_project_stage_2'),
+            ref('planning_project_stage_3'),
+            ref('planning_project_stage_4'),
+        ])]"/>
         <field name="stage_id" ref="project.project_project_stage_1"/>
         <field name="documents_folder_id" ref="documents_folder_12"/>
         <field name="analytic_account_id" ref="account_analytic_account_4"/>

--- a/construction/demo/project_task.xml
+++ b/construction/demo/project_task.xml
@@ -3,37 +3,37 @@
     <record id="project_task_1" model="project.task">
         <field name="name">Training</field>
         <field name="project_id" ref="project_project_1"/>
-        <field name="stage_id" search="[('id', '=', ref('hr_timesheet.internal_project_default_stage', raise_if_not_found=False))]"/>
+        <field name="stage_id" ref="internal_project_default_stage"/>
     </record>
     <record id="project_task_2" model="project.task">
         <field name="name">Meeting</field>
         <field name="project_id" ref="project_project_1"/>
-        <field name="stage_id" search="[('id', '=', ref('hr_timesheet.internal_project_default_stage', raise_if_not_found=False))]"/>
+        <field name="stage_id" ref="internal_project_default_stage"/>
     </record>
     <record id="project_task_3" model="project.task">
         <field name="name">Time Off</field>
         <field name="project_id" ref="project_project_1"/>
-        <field name="stage_id" search="[('id', '=', ref('hr_timesheet.internal_project_default_stage', raise_if_not_found=False))]"/>
+        <field name="stage_id" ref="internal_project_default_stage"/>
     </record>
     <record id="project_task_4" model="project.task">
         <field name="name">Work</field>
         <field name="user_ids" eval="[Command.set([ref('base.user_admin')])]"/>
         <field name="project_id" ref="project_project_3"/>
-        <field name="stage_id" search="[('id', '=', ref('industry_fsm.planning_project_stage_0', raise_if_not_found=False))]"/>
+        <field name="stage_id" ref="planning_project_stage_0"/>
         <field name="sequence">12</field>
     </record>
     <record id="project_task_5" model="project.task">
         <field name="name">Architect</field>
         <field name="user_ids" eval="[Command.set([ref('base.user_admin')])]"/>
         <field name="project_id" ref="project_project_3"/>
-        <field name="stage_id" search="[('id', '=', ref('industry_fsm.planning_project_stage_0', raise_if_not_found=False))]"/>
+        <field name="stage_id" ref="planning_project_stage_0"/>
         <field name="allocated_hours">8.0</field>
     </record>
     <record id="project_task_6" model="project.task">
         <field name="name">Down Payment</field>
         <field name="user_ids" eval="[Command.set([ref('base.user_admin')])]"/>
         <field name="project_id" ref="project_project_3"/>
-        <field name="stage_id" search="[('id', '=', ref('industry_fsm.planning_project_stage_0', raise_if_not_found=False))]"/>
+        <field name="stage_id" ref="planning_project_stage_0"/>
         <field name="sequence">11</field>
         <field name="allocated_hours">1.0</field>
     </record>
@@ -41,7 +41,7 @@
         <field name="name">Receipt</field>
         <field name="user_ids" eval="[Command.set([ref('base.user_admin')])]"/>
         <field name="project_id" ref="project_project_3"/>
-        <field name="stage_id" search="[('id', '=', ref('industry_fsm.planning_project_stage_0', raise_if_not_found=False))]"/>
+        <field name="stage_id" ref="planning_project_stage_0"/>
         <field name="sequence">14</field>
         <field name="allocated_hours">4.0</field>
     </record>
@@ -49,7 +49,7 @@
         <field name="name">Planification</field>
         <field name="user_ids" eval="[Command.set([ref('base.user_admin')])]"/>
         <field name="project_id" ref="project_project_3"/>
-        <field name="stage_id" search="[('id', '=', ref('industry_fsm.planning_project_stage_0', raise_if_not_found=False))]"/>
+        <field name="stage_id" ref="planning_project_stage_0"/>
         <field name="sequence">12</field>
         <field name="allocated_hours">7.0</field>
     </record>
@@ -57,7 +57,7 @@
         <field name="name">Architect</field>
         <field name="user_ids" eval="[Command.set([ref('base.user_admin')])]"/>
         <field name="project_id" ref="project_project_4"/>
-        <field name="stage_id" search="[('id', '=', ref('industry_fsm.planning_project_stage_3', raise_if_not_found=False))]"/>
+        <field name="stage_id" ref="planning_project_stage_3"/>
         <field name="allocated_hours">8.0</field>
         <field name="sale_line_id" ref="sale_order_line_4"/>
     </record>
@@ -65,7 +65,7 @@
         <field name="name">Down Payment</field>
         <field name="user_ids" eval="[Command.set([ref('base.user_admin')])]"/>
         <field name="project_id" ref="project_project_4"/>
-        <field name="stage_id" search="[('id', '=', ref('industry_fsm.planning_project_stage_3', raise_if_not_found=False))]"/>
+        <field name="stage_id" ref="planning_project_stage_3"/>
         <field name="allocated_hours">1.0</field>
         <field name="sale_line_id" ref="sale_order_line_4"/>
     </record>
@@ -73,7 +73,7 @@
         <field name="name">Planification</field>
         <field name="user_ids" eval="[Command.set([ref('base.user_admin')])]"/>
         <field name="project_id" ref="project_project_4"/>
-        <field name="stage_id" search="[('id', '=', ref('industry_fsm.planning_project_stage_3', raise_if_not_found=False))]"/>
+        <field name="stage_id" ref="planning_project_stage_3"/>
         <field name="allocated_hours">7.0</field>
         <field name="sale_line_id" ref="sale_order_line_4"/>
     </record>
@@ -81,7 +81,7 @@
         <field name="name">Work</field>
         <field name="user_ids" eval="[Command.set([ref('base.user_admin')])]"/>
         <field name="project_id" ref="project_project_4"/>
-        <field name="stage_id" search="[('id', '=', ref('industry_fsm.planning_project_stage_2', raise_if_not_found=False))]"/>
+        <field name="stage_id" ref="planning_project_stage_2"/>
         <field name="sequence">10</field>
         <field name="sale_line_id" ref="sale_order_line_4"/>
     </record>
@@ -89,7 +89,7 @@
         <field name="name">Receipt</field>
         <field name="user_ids" eval="[Command.set([ref('base.user_admin')])]"/>
         <field name="project_id" ref="project_project_4"/>
-        <field name="stage_id" search="[('id', '=', ref('industry_fsm.planning_project_stage_0', raise_if_not_found=False))]"/>
+        <field name="stage_id" ref="planning_project_stage_0"/>
         <field name="allocated_hours">4.0</field>
         <field name="sale_line_id" ref="sale_order_line_4"/>
     </record>
@@ -97,7 +97,7 @@
         <field name="name">The wall fell</field>
         <field name="user_ids" eval="[Command.set([ref('base.user_admin')])]"/>
         <field name="project_id" ref="industry_fsm.fsm_project"/>
-        <field name="stage_id" search="[('id', '=', ref('industry_fsm.planning_project_stage_0', raise_if_not_found=False))]"/>
+        <field name="stage_id" ref="planning_project_stage_0"/>
         <field name="allocated_hours">8.0</field>
         <field name="description">
             <![CDATA[

--- a/construction/demo/sale_order_confirm.xml
+++ b/construction/demo/sale_order_confirm.xml
@@ -30,7 +30,7 @@
     <!-- Assign sale order 1's tasks and Tasks progress-->
     <function name="write" model="project.task">
         <value model="project.task" eval="obj().search([('sale_line_id', 'in', [ref('sale_order_line_4'), ref('sale_order_line_5')])]).ids"/>
-        <value eval="{'user_ids': [Command.link(ref('base.user_admin'))], 'stage_id': ref('industry_fsm.planning_project_stage_2', raise_if_not_found=False)}"/>
+        <value eval="{'user_ids': [Command.link(ref('base.user_admin'))], 'stage_id': ref('planning_project_stage_2')}"/>
     </function>
 
     <!--Assign hours-->


### PR DESCRIPTION
Before this commit, the industry module was relying on master data from other modules (industry_fsm, hr_timesheet), but these data may not be available at the installation of the industry.
This commit defines the necessary project.task.type such that the module relies on its own data.

opw-4051179