### PR TITLE
[FIX] eyewear_shop: use lots to track inventory

### DIFF
--- a/eyewear_shop/__manifest__.py
+++ b/eyewear_shop/__manifest__.py
@@ -20,6 +20,7 @@ The sales process involves creating sale orders, managing deliveries and invoici
         'theme_paptic',
     ],
     'data': [
+        'data/res_config_settings.xml',
         'data/ir_attachment_pre.xml',
         'data/ir_model_fields.xml',
         'data/ir_ui_view.xml',

--- a/eyewear_shop/data/res_config_settings.xml
+++ b/eyewear_shop/data/res_config_settings.xml
@@ -1,0 +1,7 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<odoo noupdate="1">
+    <record id="res_config_settings_lot" model="res.config.settings">
+        <field name="group_stock_production_lot" eval="1"/>
+    </record>
+    <function name="execute" model="res.config.settings" eval="[ref('res_config_settings_lot')]"/>
+</odoo>


### PR DESCRIPTION
Before this commit, it is impossible to validate the reception in a purchase order with a lot. This commit fixes the issue by enabling the lots and serial numbers for the module.

Task-4070822