### PR TITLE
[FIX] certification_organism: fix stage for Certification project

### DIFF
--- a/certification_organism/data/project_project.xml
+++ b/certification_organism/data/project_project.xml
@@ -29,7 +29,7 @@
     <record id="certification_project" model="project.project">
         <field name="name">Certifications</field>
         <field name="is_fsm" eval="True"/>
-        <field name="stage_id" ref="project.project_project_stage_2"/>
+        <field name="stage_id" ref="project.project_project_stage_0"/>
         <field name="favorite_user_ids" eval="[(6, 0, [])]"/>
         <field name="company_id" ref="base.main_company"/>
         <field name="allow_billable" eval="True"/>


### PR DESCRIPTION
When confirming an SO with the Certification product, it creates a task in the Certification project. But this project is in the Done Stage which is folded. This commit moves the project in To Do.

Task-4072617