### PR TITLE
[FIX] *: force all ir.ui.views active for updates and upgrades

### DIFF
--- a/architects/data/ir_ui_view.xml
+++ b/architects/data/ir_ui_view.xml
@@ -3,6 +3,7 @@
     <record id="default_map_view_for_project_architects" model="ir.ui.view">
         <field name="name">Default.map.view.for.project</field>
         <field name="model">project.project</field>
+        <field name="active" eval="True"/>
         <field name="type">map</field>
         <field name="arch" type="xml">
             <map res_partner="x_associated_location" />
@@ -14,6 +15,7 @@
         <field name="type">kanban</field>
         <field name="inherit_id" ref="crm.crm_case_kanban_view_leads" />
         <field name="mode">extension</field>
+        <field name="active" eval="True"/>
         <field name="priority">320</field>
         <field name="arch" type="xml">
             <data>
@@ -31,6 +33,7 @@
     <record id="crm_lead_form_customization_architects" model="ir.ui.view">
         <field name="name">crm.lead.form.customization.architects</field>
         <field name="model">crm.lead</field>
+        <field name="active" eval="True"/>
         <field name="type">form</field>
         <field name="inherit_id" ref="crm.crm_lead_view_form" />
         <field name="mode">extension</field>
@@ -52,6 +55,7 @@
     <record id="project_kanban_customization_architects" model="ir.ui.view">
         <field name="name">project.project.kanban.customization.architects</field>
         <field name="model">project.project</field>
+        <field name="active" eval="True"/>
         <field name="type">kanban</field>
         <field name="inherit_id" ref="project.view_project_kanban" />
         <field name="mode">extension</field>
@@ -67,6 +71,7 @@
     <record id="project_form_customization_architects" model="ir.ui.view">
         <field name="name">project.project.form.customization.architects</field>
         <field name="model">project.project</field>
+        <field name="active" eval="True"/>
         <field name="type">form</field>
         <field name="inherit_id" ref="project.edit_project" />
         <field name="mode">extension</field>
@@ -89,6 +94,7 @@
     <record id="res_partner_form_customization_architects" model="ir.ui.view">
         <field name="name">res.partner.form.customization.architects</field>
         <field name="model">res.partner</field>
+        <field name="active" eval="True"/>
         <field name="type">form</field>
         <field name="inherit_id" ref="base.view_partner_form" />
         <field name="mode">extension</field>
@@ -104,6 +110,7 @@
     <record id="contact_search_inherit" model="ir.ui.view">
         <field name="name">res.partner.search.inherit</field>
         <field name="model">res.partner</field>
+        <field name="active" eval="True"/>
         <field name="inherit_id" ref="base.view_res_partner_filter"/>
         <field name="arch" type="xml">
             <xpath expr="//filter[@name='type_person']" position="after">

--- a/architects/data/website_view.xml
+++ b/architects/data/website_view.xml
@@ -4,6 +4,7 @@
         <field name="name">Contact Us</field>
         <field name="key">architects.contactus</field>
         <field name="type">qweb</field>
+        <field name="active" eval="True"/>
         <field name="website_id" ref="website.default_website"/>
         <field name="arch" type="xml">
             <t name="Contact Us" t-name="website.contactus">

--- a/art_craft/data/ir_ui_view.xml
+++ b/art_craft/data/ir_ui_view.xml
@@ -5,6 +5,7 @@
         <field name="model">purchase.order</field>
         <field name="type">tree</field>
         <field name="mode">extension</field>
+        <field name="active" eval="True"/>
         <field name="inherit_id" ref="purchase.purchase_order_kpis_tree"/>
         <field name="priority">99</field>
         <field name="arch" type="xml">
@@ -20,6 +21,7 @@
         <field name="model">purchase.order</field>
         <field name="type">form</field>
         <field name="mode">extension</field>
+        <field name="active" eval="True"/>
         <field name="inherit_id" ref="purchase.purchase_order_form"/>
         <field name="priority">160</field>
         <field name="arch" type="xml">
@@ -34,6 +36,7 @@
         <field name="name">report_saleorder_document.inherit.art_craft</field>
         <field name="type">qweb</field>
         <field name="mode">extension</field>
+        <field name="active" eval="True"/>
         <field name="inherit_id" ref="sale.report_saleorder_document"/>
         <field name="priority">160</field>
         <field name="arch" type="xml">

--- a/art_craft/data/website_view.xml
+++ b/art_craft/data/website_view.xml
@@ -4,6 +4,7 @@
         <field name="name">Contact Us</field>
         <field name="key">art_craft.contactus</field>
         <field name="type">qweb</field>
+        <field name="active" eval="True"/>
         <field name="website_id" ref="website.default_website"/>
         <field name="arch" type="xml">
             <t name="Contact Us" t-name="website.contactus">

--- a/automobile/data/ir_ui_view.xml
+++ b/automobile/data/ir_ui_view.xml
@@ -3,6 +3,7 @@
     <record id="view_x_brands_form" model="ir.ui.view">
         <field name="name">x_brands.form</field>
         <field name="model">x_brands</field>
+        <field name="active" eval="True"/>
         <field name="type">form</field>
         <field name="arch" type="xml">
             <form>
@@ -22,6 +23,7 @@
     <record id="view_x_brands_tree" model="ir.ui.view">
         <field name="name">x_brands.tree</field>
         <field name="model">x_brands</field>
+        <field name="active" eval="True"/>
         <field name="type">tree</field>
         <field name="arch" type="xml">
             <tree>
@@ -33,6 +35,7 @@
     <record id="view_x_brands_search" model="ir.ui.view">
         <field name="name">x_brands.search</field>
         <field name="model">x_brands</field>
+        <field name="active" eval="True"/>
         <field name="type">search</field>
         <field name="arch" type="xml">
             <search>
@@ -46,6 +49,7 @@
     <record id="product_template_only_form_view_inherit_automobile" model="ir.ui.view">
         <field name="name">product.template.product.form.inherit.automobile</field>
         <field name="model">product.template</field>
+        <field name="active" eval="True"/>
         <field name="priority">160</field>
         <field name="inherit_id" ref="product.product_template_only_form_view"/>
         <field name="arch" type="xml">
@@ -68,6 +72,7 @@
     <record id="product_search_form_view_stock_report_inherit_automobile" model="ir.ui.view">
         <field name="name">product.product.search.stock.form.stock.report.inherit.automobile</field>
         <field name="model">product.product</field>
+        <field name="active" eval="True"/>
         <field name="priority">99</field>
         <field name="inherit_id" ref="stock.product_search_form_view_stock_report"/>
         <field name="arch" type="xml">
@@ -84,6 +89,7 @@
         <field name="model">stock.move.line</field>
         <field name="type">tree</field>
         <field name="mode">extension</field>
+        <field name="active" eval="True"/>
         <field name="priority">99</field>
         <field name="inherit_id" ref="stock.view_move_line_tree"/>
         <field name="arch" type="xml">
@@ -99,6 +105,7 @@
         <field name="model">stock.move</field>
         <field name="type">tree</field>
         <field name="mode">extension</field>
+        <field name="active" eval="True"/>
         <field name="inherit_id" ref="stock.view_move_tree"/>
         <field name="priority">99</field>
         <field name="arch" type="xml">

--- a/bar_and_lounge/data/ir_ui_view.xml
+++ b/bar_and_lounge/data/ir_ui_view.xml
@@ -4,6 +4,7 @@
         <field name="name">sale.order.form.inherit.bar_and_lounge</field>
         <field name="model">sale.order</field>
         <field name="type">form</field>
+        <field name="active" eval="True"/>
         <field name="inherit_id" ref="sale.view_order_form" />
         <field name="mode">extension</field>
         <field name="priority">160</field>

--- a/bar_and_lounge/data/x_airline_master_view.xml
+++ b/bar_and_lounge/data/x_airline_master_view.xml
@@ -3,6 +3,7 @@
     <record id="view_x_airline_master_tree" model="ir.ui.view">
         <field name="name">x_airline_master.tree</field>
         <field name="model">x_airline_master</field>
+        <field name="active" eval="True"/>
         <field name="type">tree</field>
         <field name="arch" type="xml">
             <tree>
@@ -16,6 +17,7 @@
     <record id="view_x_airline_master_search" model="ir.ui.view">
         <field name="name">x_airline_master.search</field>
         <field name="model">x_airline_master</field>
+        <field name="active" eval="True"/>
         <field name="type">search</field>
         <field name="arch" type="xml">
             <search>
@@ -29,6 +31,7 @@
     <record id="view_x_airline_master_form" model="ir.ui.view">
         <field name="name">x_airline_master.form</field>
         <field name="model">x_airline_master</field>
+        <field name="active" eval="True"/>
         <field name="type">form</field>
         <field name="arch" type="xml">
             <form>

--- a/bar_and_lounge/data/x_airport_master_view.xml
+++ b/bar_and_lounge/data/x_airport_master_view.xml
@@ -3,6 +3,7 @@
     <record id="view_x_airport_master_tree" model="ir.ui.view">
         <field name="name">x_airport_master.tree</field>
         <field name="model">x_airport_master</field>
+        <field name="active" eval="True"/>
         <field name="type">tree</field>
         <field name="arch" type="xml">
             <tree>
@@ -18,6 +19,7 @@
     <record id="view_x_airport_master_search" model="ir.ui.view">
         <field name="name">x_airport_master.search</field>
         <field name="model">x_airport_master</field>
+        <field name="active" eval="True"/>
         <field name="type">search</field>
         <field name="arch" type="xml">
             <search>
@@ -31,6 +33,7 @@
     <record id="view_x_airport_master_form" model="ir.ui.view">
         <field name="name">x_airport_master.form</field>
         <field name="model">x_airport_master</field>
+        <field name="active" eval="True"/>
         <field name="type">form</field>
         <field name="arch" type="xml">
             <form>

--- a/bar_and_lounge/data/x_flitght_master_view.xml
+++ b/bar_and_lounge/data/x_flitght_master_view.xml
@@ -3,6 +3,7 @@
     <record id="view_x_flight_master_tree" model="ir.ui.view">
         <field name="name">x_flight_master.tree</field>
         <field name="model">x_flight_master</field>
+        <field name="active" eval="True"/>
         <field name="type">tree</field>
         <field name="arch" type="xml">
             <tree>
@@ -15,6 +16,7 @@
     <record id="view_x_flight_master_search" model="ir.ui.view">
         <field name="name">x_flight_master.search</field>
         <field name="model">x_flight_master</field>
+        <field name="active" eval="True"/>
         <field name="type">search</field>
         <field name="arch" type="xml">
             <search>
@@ -28,6 +30,7 @@
     <record id="view_x_flight_master_form" model="ir.ui.view">
         <field name="name">x_flight_master.form</field>
         <field name="model">x_flight_master</field>
+        <field name="active" eval="True"/>
         <field name="type">form</field>
         <field name="arch" type="xml">
             <form>

--- a/bar_and_lounge/data/x_guest_detail_view.xml
+++ b/bar_and_lounge/data/x_guest_detail_view.xml
@@ -3,6 +3,7 @@
     <record id="view_x_guest_detail_tree" model="ir.ui.view">
         <field name="name">x_guest_detail.tree</field>
         <field name="model">x_guest_detail</field>
+        <field name="active" eval="True"/>
         <field name="type">tree</field>
         <field name="arch" type="xml">
             <tree editable="top" multi_edit="1">
@@ -18,6 +19,7 @@
     <record id="view_x_guest_detail_search" model="ir.ui.view">
         <field name="name">x_guest_detail.search</field>
         <field name="model">x_guest_detail</field>
+        <field name="active" eval="True"/>
         <field name="type">search</field>
         <field name="arch" type="xml">
             <search>

--- a/bar_and_lounge/data/x_services_view.xml
+++ b/bar_and_lounge/data/x_services_view.xml
@@ -3,6 +3,7 @@
     <record id="view_x_services_tree" model="ir.ui.view">
         <field name="name">x_services.tree</field>
         <field name="model">x_services</field>
+        <field name="active" eval="True"/>
         <field name="type">tree</field>
         <field name="arch" type="xml">
             <tree>
@@ -14,6 +15,7 @@
     <record id="view_x_services_search" model="ir.ui.view">
         <field name="name">x_services.search</field>
         <field name="model">x_services</field>
+        <field name="active" eval="True"/>
         <field name="type">search</field>
         <field name="arch" type="xml">
             <search>
@@ -27,6 +29,7 @@
     <record id="view_x_services_form" model="ir.ui.view">
         <field name="name">x_services.form</field>
         <field name="model">x_services</field>
+        <field name="active" eval="True"/>
         <field name="type">form</field>
         <field name="arch" type="xml">
             <form>

--- a/bar_and_lounge/data/x_type_of_airport_view.xml
+++ b/bar_and_lounge/data/x_type_of_airport_view.xml
@@ -3,6 +3,7 @@
     <record id="view_x_type_of_airport_tree" model="ir.ui.view">
         <field name="name">x_type_of_airport.tree</field>
         <field name="model">x_type_of_airport</field>
+        <field name="active" eval="True"/>
         <field name="type">tree</field>
         <field name="arch" type="xml">
             <tree>
@@ -14,6 +15,7 @@
     <record id="view_x_type_of_airport_search" model="ir.ui.view">
         <field name="name">x_type_of_airport.search</field>
         <field name="model">x_type_of_airport</field>
+        <field name="active" eval="True"/>
         <field name="type">search</field>
         <field name="arch" type="xml">
             <search>
@@ -27,6 +29,7 @@
     <record id="view_x_type_of_airport_form" model="ir.ui.view">
         <field name="name">x_type_of_airport.form</field>
         <field name="model">x_type_of_airport</field>
+        <field name="active" eval="True"/>
         <field name="type">form</field>
         <field name="arch" type="xml">
             <form>
@@ -48,6 +51,7 @@
     <record id="view_x_type_of_airport_kanban" model="ir.ui.view">
         <field name="name">x_type_of_airport.kanban</field>
         <field name="model">x_type_of_airport</field>
+        <field name="active" eval="True"/>
         <field name="type">kanban</field>
         <field name="arch" type="xml">
             <kanban string="Type of Airport">

--- a/certification_organism/data/ir_ui_view.xml
+++ b/certification_organism/data/ir_ui_view.xml
@@ -3,6 +3,7 @@
     <record id="report_custom_x_control_charging_station" model="ir.ui.view">
         <field name="name">x_control_charging_station</field>
         <field name="type">qweb</field>
+        <field name="active" eval="True"/>
         <field name="arch" type="xml">
             <t t-name="x_control_charging_station">
                 <div>
@@ -225,6 +226,7 @@
         <field name="name">template_view_Installation_Control</field>
         <field name="type">form</field>
         <field name="model">x_control_charging_station</field>
+        <field name="active" eval="True"/>
         <field name="arch" type="xml">
             <form create="false" duplicate="false">
                 <sheet>
@@ -283,6 +285,7 @@
         <field name="name">tree_view_Installation_Control</field>
         <field name="type">tree</field>
         <field name="model">x_control_charging_station</field>
+        <field name="active" eval="True"/>
         <field name="arch" type="xml">
             <tree>
                 <field name="create_date"/>
@@ -294,6 +297,7 @@
         <field name="name">search_view_Installation_Control</field>
         <field name="type">search</field>
         <field name="model">x_control_charging_station</field>
+        <field name="active" eval="True"/>
         <field name="arch" type="xml">
             <search>
                 <field name="x_name"/>

--- a/certification_organism/data/website_view.xml
+++ b/certification_organism/data/website_view.xml
@@ -4,6 +4,7 @@
         <field name="name">Contact Us</field>
         <field name="key">website.contactus</field>
         <field name="type">qweb</field>
+        <field name="active" eval="True"/>
         <field name="website_id" ref="website.default_website" />
         <field name="arch" type="xml">
             <t name="Contact Us" t-name="website.contactus">

--- a/coal_petroleum/data/ir_ui_view.xml
+++ b/coal_petroleum/data/ir_ui_view.xml
@@ -3,6 +3,7 @@
     <record id="report_custom_x_quality_check_worksheet_template_1" model="ir.ui.view">
         <field name="name">x_quality_check_worksheet_template_1_studio</field>
         <field name="type">qweb</field>
+        <field name="active" eval="True"/>
         <field name="arch" type="xml">
             <t t-name="x_quality_check_worksheet_template_1">
                 <div>
@@ -75,6 +76,7 @@
     <record id="report_custom_x_quality_check_worksheet_template_2" model="ir.ui.view">
         <field name="name">x_quality_check_worksheet_template_2_studio</field>
         <field name="type">qweb</field>
+        <field name="active" eval="True"/>
         <field name="arch" type="xml">
             <t t-name="x_quality_check_worksheet_template_2">
                 <div>
@@ -133,6 +135,7 @@
     <record id="x_quality_check_worksheet_template_1_ir_ui_view_1" model="ir.ui.view">
         <field name="name">template_view_Coal_Quality_Analysis</field>
         <field name="model">x_quality_check_worksheet_template_1_studio</field>
+        <field name="active" eval="True"/>
         <field name="type">form</field>
         <field name="arch" type="xml">
             <form create="false" js_class="worksheet_validation">
@@ -164,6 +167,7 @@
         <field name="model">purchase.order</field>
         <field name="type">form</field>
         <field name="mode">extension</field>
+        <field name="active" eval="True"/>
         <field name="inherit_id" ref="purchase.purchase_order_form"/>
         <field name="priority">160</field>
         <field name="arch" type="xml">
@@ -180,6 +184,7 @@
         <field name="model">stock.picking</field>
         <field name="type">form</field>
         <field name="mode">extension</field>
+        <field name="active" eval="True"/>
         <field name="inherit_id" ref="stock.view_picking_form"/>
         <field name="priority">160</field>
         <field name="arch" type="xml">
@@ -198,6 +203,7 @@
     <record id="x_quality_check_worksheet_template_2_ir_ui_view_1" model="ir.ui.view">
         <field name="name">template_view_Gas_Quality_Analysis</field>
         <field name="model">x_quality_check_worksheet_template_2_studio</field>
+        <field name="active" eval="True"/>
         <field name="type">form</field>
         <field name="arch" type="xml">
             <form create="false" js_class="worksheet_validation">
@@ -225,6 +231,7 @@
     <record id="x_quality_check_worksheet_template_1_ir_ui_view_2" model="ir.ui.view">
         <field name="name">tree_view_Coal_Quality_Analysis</field>
         <field name="model">x_quality_check_worksheet_template_1_studio</field>
+        <field name="active" eval="True"/>
         <field name="type">tree</field>
         <field name="arch" type="xml">
             <tree>
@@ -237,6 +244,7 @@
     <record id="x_quality_check_worksheet_template_1_ir_ui_view_3" model="ir.ui.view">
         <field name="name">search_view_Coal_Quality_Analysis</field>
         <field name="model">x_quality_check_worksheet_template_1_studio</field>
+        <field name="active" eval="True"/>
         <field name="type">search</field>
         <field name="arch" type="xml">
             <search>
@@ -250,6 +258,7 @@
     <record id="x_quality_check_worksheet_template_2_ir_ui_view_2" model="ir.ui.view">
         <field name="name">tree_view_Gas_Quality_Analysis</field>
         <field name="model">x_quality_check_worksheet_template_2_studio</field>
+        <field name="active" eval="True"/>
         <field name="type">tree</field>
         <field name="arch" type="xml">
             <tree>
@@ -262,6 +271,7 @@
     <record id="x_quality_check_worksheet_template_2_ir_ui_view_3" model="ir.ui.view">
         <field name="name">search_view_Gas_Quality_Analysis</field>
         <field name="model">x_quality_check_worksheet_template_2_studio</field>
+        <field name="active" eval="True"/>
         <field name="type">search</field>
         <field name="arch" type="xml">
             <search>

--- a/condominium/data/ir_ui_view.xml
+++ b/condominium/data/ir_ui_view.xml
@@ -3,6 +3,7 @@
     <record id="form_view_x_units_tag" model="ir.ui.view">
         <field name="name">Form view for the units tag</field>
         <field name="model">x_units_tag</field>
+        <field name="active" eval="True"/>
         <field name="type">form</field>
         <field name="arch" type="xml">
             <form>
@@ -20,6 +21,7 @@
     <record id="form_view_x_units" model="ir.ui.view">
         <field name="name">Form view for units</field>
         <field name="model">x_units</field>
+        <field name="active" eval="True"/>
         <field name="type">form</field>
         <field name="arch" type="xml">
             <form>
@@ -56,6 +58,7 @@
     <record id="list_view_units" model="ir.ui.view">
         <field name="name">List view for the units</field>
         <field name="model">x_units</field>
+        <field name="active" eval="True"/>
         <field name="type">tree</field>
         <field name="arch" type="xml">
             <tree>
@@ -73,6 +76,7 @@
     <record id="list_view_x_units_tag" model="ir.ui.view">
         <field name="name">List view for the units tag</field>
         <field name="model">x_units_tag</field>
+        <field name="active" eval="True"/>
         <field name="type">tree</field>
         <field name="arch" type="xml">
             <tree editable="bottom">
@@ -84,6 +88,7 @@
     <record id="map_view_x_units" model="ir.ui.view">
         <field name="name">Map view for the units</field>
         <field name="model">x_units</field>
+        <field name="active" eval="True"/>
         <field name="type">map</field>
         <field name="arch" type="xml">
             <map res_partner="x_partner_id">
@@ -94,6 +99,7 @@
     <record id="search_view_x_units" model="ir.ui.view">
         <field name="name">Search view for the units</field>
         <field name="model">x_units</field>
+        <field name="active" eval="True"/>
         <field name="type">search</field>
         <field name="arch" type="xml">
             <search>
@@ -113,6 +119,7 @@
     <record id="search_view_x_unit_tag" model="ir.ui.view">
         <field name="name">Search view for the units tags</field>
         <field name="model">x_units_tag</field>
+        <field name="active" eval="True"/>
         <field name="type">search</field>
         <field name="arch" type="xml">
             <search>
@@ -123,6 +130,7 @@
     <record id='kanban_view_ir_model_custom' model='ir.ui.view'>
         <field name="name">Custom kanban view</field>
         <field name="model">x_units</field>
+        <field name="active" eval="True"/>
         <field name="type">kanban</field>
         <field name="arch" type="xml">
             <kanban string="Units" quick_create="false">
@@ -145,6 +153,7 @@
         <field name="inherit_id" ref="base.view_partner_form"/>
         <field name="mode">extension</field>
         <field name="model">res.partner</field>
+        <field name="active" eval="True"/>
         <field name="priority">160</field>
         <field name="type">form</field>
         <field name="arch" type="xml">
@@ -188,6 +197,7 @@
         <field name="inherit_id" ref="base.res_partner_kanban_view"/>
         <field name="mode">extension</field>
         <field name="model">res.partner</field>
+        <field name="active" eval="True"/>
         <field name="priority">200</field>
         <field name="type">kanban</field>
         <field name="arch" type="xml">
@@ -201,6 +211,7 @@
         <field name="inherit_id" ref="base.view_partner_tree"/>
         <field name="mode">extension</field>
         <field name="model">res.partner</field>
+        <field name="active" eval="True"/>
         <field name="priority">160</field>
         <field name="type">tree</field>
         <field name="arch" type="xml">
@@ -215,6 +226,7 @@
         <field name="inherit_id" ref="base.view_res_partner_filter"/>
         <field name="mode">extension</field>
         <field name="model">res.partner</field>
+        <field name="active" eval="True"/>
         <field name="priority">160</field>
         <field name="type">search</field>
         <field name="arch" type="xml">
@@ -232,6 +244,7 @@
         <field name="model">sale.order</field>
         <field name="inherit_id" ref="sale.view_order_form"/>
         <field name="mode">extension</field>
+        <field name="active" eval="True"/>
         <field name="priority">160</field>
         <field name="type">form</field>
         <field name="arch" type="xml">
@@ -258,6 +271,7 @@
         <field name="inherit_id" ref="sale.view_order_tree"/>
         <field name="mode">extension</field>
         <field name="model">sale.order</field>
+        <field name="active" eval="True"/>
         <field name="priority">160</field>
         <field name="type">tree</field>
         <field name="arch" type="xml">
@@ -271,6 +285,7 @@
         <field name="inherit_id" ref="sale.view_quotation_tree_with_onboarding"/>
         <field name="mode">extension</field>
         <field name="model">sale.order</field>
+        <field name="active" eval="True"/>
         <field name="priority">99</field>
         <field name="type">tree</field>
         <field name="arch" type="xml">

--- a/corporate_gifts/data/website_view.xml
+++ b/corporate_gifts/data/website_view.xml
@@ -4,6 +4,7 @@
         <field name="name">Contact Us</field>
         <field name="key">corporate_gifts.contactus</field>
         <field name="type">qweb</field>
+        <field name="active" eval="True"/>
         <field name="website_id" ref="website.default_website"/>
         <field name="arch" type="xml">
             <t name="Contact Us" t-name="website.contactus">

--- a/eyewear_shop/data/ir_ui_view.xml
+++ b/eyewear_shop/data/ir_ui_view.xml
@@ -5,6 +5,7 @@
         <field name="inherit_id" ref="crm.crm_lead_view_form"/>
         <field name="mode">extension</field>
         <field name="model">crm.lead</field>
+        <field name="active" eval="True"/>
         <field name="priority">160</field>
         <field name="type">form</field>
         <field name="arch" type="xml">
@@ -51,6 +52,7 @@
         <field name="inherit_id" ref="base.view_partner_form"/>
         <field name="mode">extension</field>
         <field name="model">res.partner</field>
+        <field name="active" eval="True"/>
         <field name="priority">360</field>
         <field name="type">form</field>
         <field name="arch" type="xml">
@@ -96,6 +98,7 @@
         <field name="name">eyewear_shop.report_eye_test_document</field>
         <field name="key">eyewear_shop.report_eye_test_document</field>
         <field name="type">qweb</field>
+        <field name="active" eval="True"/>
         <field name="arch" type="xml">
             <t t-name="report_document">
                 <t t-call="web.external_layout">
@@ -216,6 +219,7 @@
         <field name="name">eyewear.shop.eye.test.report</field>
         <field name="key">eyewear_shop.eye_test_report</field>
         <field name="type">qweb</field>
+        <field name="active" eval="True"/>
         <field name="arch" type="xml">
             <t t-name="main_report">
                 <t t-call="web.html_container">

--- a/eyewear_shop/data/website_view.xml
+++ b/eyewear_shop/data/website_view.xml
@@ -5,6 +5,7 @@
         <field name="website_id" ref="website.default_website"/>
         <field name="key">eyewear_shop.contactus</field>
         <field name="type">qweb</field>
+        <field name="active" eval="True"/>
         <field name="arch" type="xml">
             <t name="Contact Us" t-name="website.contactus">
                 <t t-call="website.layout">

--- a/fmcg_store/data/ir_ui_view.xml
+++ b/fmcg_store/data/ir_ui_view.xml
@@ -5,6 +5,7 @@
         <field name="model">pos.order</field>
         <field name="inherit_id" ref="point_of_sale.view_pos_pos_form"/>
         <field name="mode">extension</field>
+        <field name="active" eval="True"/>
         <field name="priority">160</field>
         <field name="type">form</field>
         <field name="arch" type="xml">
@@ -20,6 +21,7 @@
         <field name="model">product.product</field>
         <field name="inherit_id" ref="product.product_normal_form_view"/>
         <field name="mode">extension</field>
+        <field name="active" eval="True"/>
         <field name="priority">160</field>
         <field name="type">form</field>
         <field name="arch" type="xml">
@@ -33,6 +35,7 @@
     <record id="product_packaging_tree_view_inherited" model="ir.ui.view">
         <field name="name">product.packaging.tree.view</field>
         <field name="model">product.packaging</field>
+        <field name="active" eval="True"/>
         <field name="inherit_id" ref="product.product_packaging_tree_view"/>
         <field name="arch" type="xml">
             <xpath expr="//field[@name='barcode']" position="attributes">

--- a/hardware_shop/data/ir_ui_view.xml
+++ b/hardware_shop/data/ir_ui_view.xml
@@ -4,6 +4,7 @@
         <field name="name">pos.order.tree.inherit.hardware_shop</field>
         <field name="model">pos.order</field>
         <field name="mode">extension</field>
+        <field name="active" eval="True"/>
         <field name="priority">1001</field>
         <field name="inherit_id" ref="point_of_sale.view_pos_order_tree" />
         <field name="arch" type="xml">

--- a/headhunter/data/ir_ui_view.xml
+++ b/headhunter/data/ir_ui_view.xml
@@ -6,6 +6,7 @@
         <field name="type">tree</field>
         <field name="inherit_id" ref="hr_recruitment.crm_case_tree_view_job" />
         <field name="mode">extension</field>
+        <field name="active" eval="True"/>
         <field name="priority">160</field>
         <field name="arch" type="xml">
             <data>
@@ -21,6 +22,7 @@
         <field name="type">form</field>
         <field name="inherit_id" ref="crm.crm_lead_view_form" />
         <field name="mode">extension</field>
+        <field name="active" eval="True"/>
         <field name="priority">160</field>
         <field name="arch" type="xml">
             <data>
@@ -38,6 +40,7 @@
         <field name="type">form</field>
         <field name="inherit_id" ref="hr_recruitment.hr_applicant_view_form" />
         <field name="mode">extension</field>
+        <field name="active" eval="True"/>
         <field name="priority">500</field>
         <field name="arch" type="xml">
             <data>
@@ -53,6 +56,7 @@
         <field name="type">search</field>
         <field name="inherit_id" ref="hr_recruitment.hr_applicant_view_search_bis" />
         <field name="mode">extension</field>
+        <field name="active" eval="True"/>
         <field name="priority">160</field>
         <field name="arch" type="xml">
             <data>

--- a/headhunter/data/website_view.xml
+++ b/headhunter/data/website_view.xml
@@ -5,6 +5,7 @@
         <field name="type">qweb</field>
         <field name="key">headhunter.contact_us</field>
         <field name="website_id" ref="website.default_website"/>
+        <field name="active" eval="True"/>
         <field name="arch" type="xml">
             <t name="Contact Us" t-name="website.contactus">
                 <t t-call="website.layout">

--- a/industry_real_estate/data/ir_ui_views.xml
+++ b/industry_real_estate/data/ir_ui_views.xml
@@ -3,6 +3,7 @@
     <record id="property_form_view" model="ir.ui.view">
         <field name="model">account.analytic.account</field>
         <field name="mode">primary</field>
+        <field name="active" eval="True"/>
         <field name="priority">100</field>
         <field name="arch" type="xml">
             <form string="Property">
@@ -79,6 +80,7 @@
     <record id="property_kanban_view" model="ir.ui.view">
         <field name="model">account.analytic.account</field>
         <field name="mode">primary</field>
+        <field name="active" eval="True"/>
         <field name="priority">100</field>
         <field name="arch" type="xml">
             <kanban>
@@ -108,6 +110,7 @@
     <record id="view_crm_lead_form_inherit" model="ir.ui.view">
         <field name="name">crm.leam.form.inherit.industry_real_estate</field>
         <field name="model">crm.lead</field>
+        <field name="active" eval="True"/>
         <field name="inherit_id" ref="crm.crm_lead_view_form"/>
         <field name="priority">160</field>
         <field name="type">form</field>
@@ -122,6 +125,7 @@
     <record id="view_crm_lead_kanban_inherit" model="ir.ui.view">
         <field name="name">crm.lead.kanban.inherit.industry_real_estate</field>
         <field name="model">crm.lead</field>
+        <field name="active" eval="True"/>
         <field name="inherit_id" ref="crm.crm_case_kanban_view_leads"/>
         <field name="priority">320</field>
         <field name="type">kanban</field>
@@ -138,6 +142,7 @@
     <record id="view_crm_lead_form_quick_create_inherit" model="ir.ui.view">
         <field name="name">crm.lead.form.quick_create</field>
         <field name="model">crm.lead</field>
+        <field name="active" eval="True"/>
         <field name="inherit_id" ref="crm.quick_create_opportunity_form"/>
         <field name="arch" type="xml">
             <xpath expr="//label[@for='expected_revenue']" position="replace">
@@ -152,6 +157,7 @@
     <record id="rental_gantt_view" model="ir.ui.view">
         <field name="model">sale.order</field>
         <field name="mode">primary</field>
+        <field name="active" eval="True"/>
         <field name="priority">100</field>
         <field name="arch" type="xml">
             <gantt date_start="x_rental_start_date" date_stop="end_date" color="partner_id" default_scale="year" display_unavailability="true" string="Availability" />
@@ -161,6 +167,7 @@
     <record id="rental_form_view" model="ir.ui.view">
         <field name="model">sale.order</field>
         <field name="mode">primary</field>
+        <field name="active" eval="True"/>
         <field name="priority">100</field>
         <field name="inherit_id" ref="sale_subscription.sale_subscription_order_view_form"/>
         <field name="arch" type="xml">
@@ -179,6 +186,7 @@
     <record id="meters_list_view" model="ir.ui.view">
         <field name="name">meter.tree.view</field>
         <field name="model">x_meters</field>
+        <field name="active" eval="True"/>
         <field name="type">tree</field>
         <field name="arch" type="xml">
             <tree editable="bottom">

--- a/industry_real_estate/data/website_view.xml
+++ b/industry_real_estate/data/website_view.xml
@@ -5,6 +5,7 @@
         <field name="key">industry_real_estate.contactus</field>
         <field name="website_id" ref="website.default_website" />
         <field name="type">qweb</field>
+        <field name="active" eval="True"/>
         <field name="arch" type="xml">
             <t name="Contact Us" t-name="website.contactus">
                 <t t-call="website.layout">

--- a/micro_brewery/data/ir_ui_view.xml
+++ b/micro_brewery/data/ir_ui_view.xml
@@ -5,6 +5,7 @@
         <field name="model">product.template</field>
         <field name="type">tree</field>
         <field name="mode">extension</field>
+        <field name="active" eval="True"/>
         <field name="inherit_id" ref="product.product_template_tree_view"/>
         <field name="priority">160</field>
         <field name="arch" type="xml">
@@ -23,6 +24,7 @@
         <field name="model">product.template</field>
         <field name="type">form</field>
         <field name="mode">extension</field>
+        <field name="active" eval="True"/>
         <field name="inherit_id" ref="product.product_template_only_form_view"/>
         <field name="priority">160</field>
         <field name="arch" type="xml">

--- a/micro_brewery/data/website_view.xml
+++ b/micro_brewery/data/website_view.xml
@@ -4,6 +4,7 @@
         <field name="name">Contact Us</field>
         <field name="key">micro_brewery.contactus</field>
         <field name="type">qweb</field>
+        <field name="active" eval="True"/>
         <field name="website_id" ref="website.default_website"/>
         <field name="arch" type="xml">
             <t name="Contact Us" t-name="website.contactus">

--- a/solar_installation/data/ir_ui_view.xml
+++ b/solar_installation/data/ir_ui_view.xml
@@ -3,6 +3,7 @@
     <record id="report_custom_x_project_task_worksheet_template_1" model="ir.ui.view">
         <field name="name">x_project_task_worksheet_template_1_studio</field>
         <field name="type">qweb</field>
+        <field name="active" eval="True"/>
         <field name="arch" type="xml">
             <t t-name="x_project_task_worksheet_template_1">
                 <div>
@@ -45,6 +46,7 @@
         <field name="model">helpdesk.ticket</field>
         <field name="inherit_id" ref="helpdesk.helpdesk_ticket_view_form"/>
         <field name="mode">extension</field>
+        <field name="active" eval="True"/>
         <field name="priority">800</field>
         <field name="type">form</field>
         <field name="arch" type="xml">
@@ -60,6 +62,7 @@
         <field name="model">stock.lot</field>
         <field name="inherit_id" ref="stock.view_production_lot_form"/>
         <field name="mode">extension</field>
+        <field name="active" eval="True"/>
         <field name="priority">160</field>
         <field name="type">form</field>
         <field name="arch" type="xml">
@@ -73,6 +76,7 @@
     <record id="x_project_task_worksheet_template_1_ir_ui_view_1" model="ir.ui.view">
         <field name="name">template_view_Default_Worksheet</field>
         <field name="model">x_project_task_worksheet_template_1_studio</field>
+        <field name="active" eval="True"/>
         <field name="type">form</field>
         <field name="arch" type="xml">
             <form create="false" duplicate="false">
@@ -120,6 +124,7 @@
     <record id="x_project_task_worksheet_template_1_ir_ui_view_2" model="ir.ui.view">
         <field name="name">tree_view_Default_Worksheet</field>
         <field name="model">x_project_task_worksheet_template_1_studio</field>
+        <field name="active" eval="True"/>
         <field name="type">tree</field>
         <field name="arch" type="xml">
             <tree>
@@ -131,6 +136,7 @@
     <record id="x_project_task_worksheet_template_1_ir_ui_view_3" model="ir.ui.view">
         <field name="name">search_view_Default_Worksheet</field>
         <field name="model">x_project_task_worksheet_template_1_studio</field>
+        <field name="active" eval="True"/>
         <field name="type">search</field>
         <field name="arch" type="xml">
             <search>

--- a/solar_installation/data/website_view.xml
+++ b/solar_installation/data/website_view.xml
@@ -4,6 +4,7 @@
         <field name="name">Get a Quote</field>
         <field name="key">solar_installation.get-a-quote</field>
         <field name="type">qweb</field>
+        <field name="active" eval="True"/>
         <field name="website_id" ref="website.default_website"/>
         <field name="arch" type="xml">
             <t t-name="website.get-a-quote">

--- a/surveyor/data/website_view.xml
+++ b/surveyor/data/website_view.xml
@@ -4,6 +4,7 @@
         <field name="key">surveyor.contactus</field>
         <field name="name">Contact Us</field>
         <field name="type">qweb</field>
+        <field name="active" eval="True"/>
         <field name="website_id" ref="website.default_website"/>
         <field name="arch" type="xml">
             <t name="Contact Us" t-name="website.contactus">

--- a/tests/test_generic/tests/test_xml.py
+++ b/tests/test_generic/tests/test_xml.py
@@ -61,6 +61,7 @@ class TestEnv(IndustryCase):
                 self._check_website_published_false(module, file_name)
                 self._check_static_files_usage_in_xml(content, in_use_files)
                 if root.split('/')[-1] == 'data':
+                    self._check_view_active(content, file_name)
                     self._check_is_published_false(module, file_name)
                     if not is_studio_required:
                         is_studio_required = self._check_studio(content, file_name)
@@ -516,3 +517,14 @@ class TestEnv(IndustryCase):
                 records[record_key] |= fields
         except etree.XMLSyntaxError as e:
             _logger.error("XML syntax error in file %s: %s", file_name, e)
+
+    def _check_view_active(self, xml_content, file_name):
+        root = etree.fromstring(xml_content.encode('utf-8'))
+        for record in root.xpath("//record[@model='ir.ui.view']"):
+            active_field = record.xpath(".//field[@name='active']/@eval")
+            if not active_field or active_field[0] != "True":
+                _logger.warning(
+                    "You forgot to enforce active=True on ir.ui.view record (id=%s in data/%s).",
+                    record.get('id'),
+                    file_name,
+                )


### PR DESCRIPTION
Before this commit, an `ir.ui.view` that is broken by an upgrade will be archived. Upgrading the module will update the view, but will not activate it back.

This commit fixes the issue by enforcing `active` field to True on all `ir.ui.view` records in data.

task-4087229