### PR TITLE
[FIX] industry_restaurant: Wrong ref used for journal 

### DIFF
--- a/industry_restaurant/demo/pos_session.xml
+++ b/industry_restaurant/demo/pos_session.xml
@@ -3,7 +3,7 @@
     <data noupdate="1">
         <record id="pos_session_1" model="pos.session">
             <field name="config_id" ref="pos_config_main_seven_star_restaurant"/>
-            <field name="cash_journal_id" ref="pos_payment_method_3"/>
+            <field name="cash_journal_id" ref="cash"/>
         </record>
     </data>
 


### PR DESCRIPTION
Steps:
- Install industry_restaurant with demo data in a clean DB
    - or in new saas with:
![image](https://github.com/user-attachments/assets/9e975276-28c9-4457-81bf-7cf72f6d5b0b)


Actual result:
- Error due to foreign key not existing

Expected result
- Module installed

Caused by #117

opw-4092336