### PR TITLE
[FIX] industry_restaurant: Table number instead of name

### DIFF
--- a/industry_restaurant/data/pos_config.xml
+++ b/industry_restaurant/data/pos_config.xml
@@ -14,7 +14,7 @@
         <field name="is_header_or_footer" eval="1"/>
         <field name="receipt_footer">Thank You! Visit Again.</field>
         <field name="module_pos_restaurant_appointment" eval="1"/>
-        <field name="appointment_type_ids" eval="[(6, 0, [ref('appointment_type_1'), ref('appointment_type_2')])]"/>
+        <field name="appointment_type_id" eval="ref('appointment_type_1')"/>
         <field name="floor_ids" eval="[(6, 0, [ref('restaurant_floor_1'), ref('restaurant_floor_2')])]"/>
         <field name="payment_method_ids" eval="[(6, 0, [ref('pos_payment_method_1')])]"/>
     </record>

--- a/industry_restaurant/data/restaurant_table.xml
+++ b/industry_restaurant/data/restaurant_table.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
     <record id="restaurant_table_1" model="restaurant.table">
-        <field name="name">Master Table</field>
+        <field name="table_number">1</field>
         <field name="floor_id" ref="restaurant_floor_1"/>
         <field name="seats">10</field>
         <field name="width">144.77</field>
@@ -10,7 +10,7 @@
         <field name="position_v">31.0</field>
     </record>
     <record id="restaurant_table_2" model="restaurant.table">
-        <field name="name">Table 1</field>
+        <field name="table_number">2</field>
         <field name="floor_id" ref="restaurant_floor_1"/>
         <field name="seats">4</field>
         <field name="width">115.77</field>
@@ -19,7 +19,7 @@
         <field name="position_v">58.0</field>
     </record>
     <record id="restaurant_table_3" model="restaurant.table">
-        <field name="name">Table 2</field>
+        <field name="table_number">3</field>
         <field name="floor_id" ref="restaurant_floor_1"/>
         <field name="seats">4</field>
         <field name="width">115.77</field>
@@ -28,7 +28,7 @@
         <field name="position_v">279.0</field>
     </record>
     <record id="restaurant_table_4" model="restaurant.table">
-        <field name="name">Table 3</field>
+        <field name="table_number">4</field>
         <field name="floor_id" ref="restaurant_floor_1"/>
         <field name="seats">4</field>
         <field name="width">115.77</field>
@@ -37,7 +37,7 @@
         <field name="position_v">48.0</field>
     </record>
     <record id="restaurant_table_5" model="restaurant.table">
-        <field name="name">Table 4</field>
+        <field name="table_number">5</field>
         <field name="floor_id" ref="restaurant_floor_1"/>
         <field name="seats">4</field>
         <field name="width">115.77</field>
@@ -46,7 +46,7 @@
         <field name="position_v">260.0</field>
     </record>
     <record id="restaurant_table_6" model="restaurant.table">
-        <field name="name">Master Table A</field>
+        <field name="table_number">6</field>
         <field name="floor_id" ref="restaurant_floor_2"/>
         <field name="seats">10</field>
         <field name="width">158.77</field>
@@ -55,7 +55,7 @@
         <field name="position_v">76.0</field>
     </record>
     <record id="restaurant_table_7" model="restaurant.table">
-        <field name="name">Master Table B</field>
+        <field name="table_number">7</field>
         <field name="floor_id" ref="restaurant_floor_2"/>
         <field name="seats">12</field>
         <field name="width">143.77</field>
@@ -64,7 +64,7 @@
         <field name="position_v">72.0</field>
     </record>
     <record id="restaurant_table_8" model="restaurant.table">
-        <field name="name">Table 5</field>
+        <field name="table_number">8</field>
         <field name="floor_id" ref="restaurant_floor_2"/>
         <field name="seats">4</field>
         <field name="width">115.77</field>
@@ -73,7 +73,7 @@
         <field name="position_v">67.0</field>
     </record>
     <record id="restaurant_table_9" model="restaurant.table">
-        <field name="name">Table 6</field>
+        <field name="table_number">9</field>
         <field name="floor_id" ref="restaurant_floor_2"/>
         <field name="seats">4</field>
         <field name="width">115.77</field>
@@ -82,7 +82,7 @@
         <field name="position_v">243.0</field>
     </record>
     <record id="restaurant_table_10" model="restaurant.table">
-        <field name="name">Table 7</field>
+        <field name="table_number">10</field>
         <field name="floor_id" ref="restaurant_floor_2"/>
         <field name="seats">6</field>
         <field name="shape">round</field>


### PR DESCRIPTION
In restaurant table, the 'name' field become an integer field called table_number. The change made in this commit aims at conserving previous name that were integer. For the name that were not, the field is set to a unique integer higher than the previous maximum table number in the database.

Error seen in https://github.com/odoo/industry/pull/194
Caused by https://github.com/odoo/odoo/pull/173108