### PR TITLE
[FIX] architects: fix the expense payment_mode

### DIFF
--- a/architects/demo/hr_expense.xml
+++ b/architects/demo/hr_expense.xml
@@ -13,6 +13,7 @@
         <field name="employee_id" ref="hr.employee_admin"/>
         <field name="sale_order_id" ref="sale_order_6"/>
         <field name="product_id" ref="hr_expense.product_product_no_cost"/>
+        <field name="payment_mode">company_account</field>
         <field name="total_amount">121.0</field>
     </record>
 </odoo>

--- a/architects/demo/hr_expense_action.xml
+++ b/architects/demo/hr_expense_action.xml
@@ -10,11 +10,4 @@
             obj().env.ref('architects.hr_expense_2')).sheet_id.ids
         "/>
     </function>
-
-    <function model="hr.expense.sheet" name="action_approve_expense_sheets">
-        <value model="hr.expense.sheet" eval="(
-            obj().env.ref('architects.hr_expense_1') +
-            obj().env.ref('architects.hr_expense_2')).sheet_id.ids
-        "/>
-    </function>
 </odoo>


### PR DESCRIPTION
The error was linked to the payment_mode not defined on the hr_expense records. However this field is required.
Another issue is the outstanding account must be defined to approve it, so this part is removed from the demo data.