### PR TITLE
[FIX] *: Multiple industry installation

### DIFF
--- a/agriculture_shop/data/knowledge_tour.xml
+++ b/agriculture_shop/data/knowledge_tour.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
     <record id="knowledge_tour" model="web_tour.tour">
-        <field name="name">knowledge_tour</field>
+        <field name="name">agriculture_shop_knowledge_tour</field>
         <field name="sequence">2</field>
         <field name="rainbow_man_message">Welcome! Happy exploring.</field>    
     </record>

--- a/agriculture_shop/static/src/js/my_tour.js
+++ b/agriculture_shop/static/src/js/my_tour.js
@@ -3,7 +3,7 @@
 import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
 
-registry.category("web_tour.tours").add("knowledge_tour", {
+registry.category("web_tour.tours").add("agriculture_shop_knowledge_tour", {
     url: "/odoo",
     
     steps: () => [

--- a/architects/data/knowledge_tour.xml
+++ b/architects/data/knowledge_tour.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
     <record id="knowledge_tour" model="web_tour.tour">
-        <field name="name">knowledge_tour</field>
+        <field name="name">architects_knowledge_tour</field>
         <field name="sequence">2</field>
         <field name="rainbow_man_message">Welcome! Happy exploring.</field>    
     </record>

--- a/architects/static/src/js/my_tour.js
+++ b/architects/static/src/js/my_tour.js
@@ -3,7 +3,7 @@
 import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
 
-registry.category("web_tour.tours").add("knowledge_tour", {
+registry.category("web_tour.tours").add("architects_knowledge_tour", {
     url: "/odoo",
     
     steps: () => [

--- a/art_craft/data/knowledge_tour.xml
+++ b/art_craft/data/knowledge_tour.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
     <record id="knowledge_tour" model="web_tour.tour">
-        <field name="name">knowledge_tour</field>
+        <field name="name">art_craft_knowledge_tour</field>
         <field name="sequence">2</field>
         <field name="rainbow_man_message">Welcome! Happy exploring.</field>    
     </record>

--- a/art_craft/static/src/js/my_tour.js
+++ b/art_craft/static/src/js/my_tour.js
@@ -3,7 +3,7 @@
 import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
 
-registry.category("web_tour.tours").add("knowledge_tour", {
+registry.category("web_tour.tours").add("art_craft_knowledge_tour", {
     url: "/odoo",
     
     steps: () => [

--- a/automobile/data/knowledge_tour.xml
+++ b/automobile/data/knowledge_tour.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
     <record id="knowledge_tour" model="web_tour.tour">
-        <field name="name">knowledge_tour</field>
+        <field name="name">automobile_knowledge_tour</field>
         <field name="sequence">2</field>
         <field name="rainbow_man_message">Welcome! Happy exploring.</field>    
     </record>

--- a/automobile/static/src/js/my_tour.js
+++ b/automobile/static/src/js/my_tour.js
@@ -3,7 +3,7 @@
 import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
 
-registry.category("web_tour.tours").add("knowledge_tour", {
+registry.category("web_tour.tours").add("automobile_knowledge_tour", {
     url: "/odoo",
     
     steps: () => [

--- a/bar_industry/data/knowledge_tour.xml
+++ b/bar_industry/data/knowledge_tour.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
     <record id="knowledge_tour" model="web_tour.tour">
-        <field name="name">knowledge_tour</field>
+        <field name="name">bar_industry_knowledge_tour</field>
         <field name="sequence">2</field>
         <field name="rainbow_man_message">Welcome! Happy exploring.</field>    
     </record>

--- a/bar_industry/static/src/js/my_tour.js
+++ b/bar_industry/static/src/js/my_tour.js
@@ -3,7 +3,7 @@
 import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
 
-registry.category("web_tour.tours").add("knowledge_tour", {
+registry.category("web_tour.tours").add("bar_industry_knowledge_tour", {
     url: "/odoo",
     
     steps: () => [

--- a/beverage_distributor/data/knowledge_tour.xml
+++ b/beverage_distributor/data/knowledge_tour.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
     <record id="knowledge_tour" model="web_tour.tour">
-        <field name="name">knowledge_tour</field>
+        <field name="name">beverage_distributor_knowledge_tour</field>
         <field name="sequence">2</field>
         <field name="rainbow_man_message">Welcome! Happy exploring.</field>    
     </record>

--- a/beverage_distributor/static/src/js/my_tour.js
+++ b/beverage_distributor/static/src/js/my_tour.js
@@ -3,7 +3,7 @@
 import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
 
-registry.category("web_tour.tours").add("knowledge_tour", {
+registry.category("web_tour.tours").add("beverage_distributor_knowledge_tour", {
     url: "/odoo",
     
     steps: () => [

--- a/bike_leasing/data/knowledge_tour.xml
+++ b/bike_leasing/data/knowledge_tour.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
     <record id="knowledge_tour" model="web_tour.tour">
-        <field name="name">knowledge_tour</field>
+        <field name="name">bike_leasing_knowledge_tour</field>
         <field name="sequence">2</field>
         <field name="rainbow_man_message">Welcome! Happy exploring.</field>    
     </record>

--- a/bike_leasing/static/src/js/my_tour.js
+++ b/bike_leasing/static/src/js/my_tour.js
@@ -3,7 +3,7 @@
 import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
 
-registry.category("web_tour.tours").add("knowledge_tour", {
+registry.category("web_tour.tours").add("bike_leasing_knowledge_tour", {
     url: "/odoo",
     
     steps: () => [

--- a/billboard_rental/data/knowledge_tour.xml
+++ b/billboard_rental/data/knowledge_tour.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
     <record id="knowledge_tour" model="web_tour.tour">
-        <field name="name">knowledge_tour</field>
+        <field name="name">billboard_rental_knowledge_tour</field>
         <field name="sequence">2</field>
         <field name="rainbow_man_message">Welcome! Happy exploring.</field>    
     </record>

--- a/billboard_rental/static/src/js/my_tour.js
+++ b/billboard_rental/static/src/js/my_tour.js
@@ -3,7 +3,7 @@
 import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
 
-registry.category("web_tour.tours").add("knowledge_tour", {
+registry.category("web_tour.tours").add("billboard_rental_knowledge_tour", {
     url: "/odoo",
     
     steps: () => [

--- a/bookstore/data/knowledge_tour.xml
+++ b/bookstore/data/knowledge_tour.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
     <record id="knowledge_tour" model="web_tour.tour">
-        <field name="name">knowledge_tour</field>
+        <field name="name">bookstore_knowledge_tour</field>
         <field name="sequence">2</field>
         <field name="rainbow_man_message">Welcome! Happy exploring.</field>    
     </record>

--- a/bookstore/static/src/js/my_tour.js
+++ b/bookstore/static/src/js/my_tour.js
@@ -3,7 +3,7 @@
 import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
 
-registry.category("web_tour.tours").add("knowledge_tour", {
+registry.category("web_tour.tours").add("bookstore_knowledge_tour", {
     url: "/odoo",
     
     steps: () => [

--- a/cake_shop/data/knowledge_tour.xml
+++ b/cake_shop/data/knowledge_tour.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
     <record id="knowledge_tour" model="web_tour.tour">
-        <field name="name">knowledge_tour</field>
+        <field name="name">cake_shop_knowledge_tour</field>
         <field name="sequence">2</field>
         <field name="rainbow_man_message">Welcome! Happy exploring.</field>    
     </record>

--- a/cake_shop/static/src/js/my_tour.js
+++ b/cake_shop/static/src/js/my_tour.js
@@ -3,7 +3,7 @@
 import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
 
-registry.category("web_tour.tours").add("knowledge_tour", {
+registry.category("web_tour.tours").add("cake_shop_knowledge_tour", {
     url: "/odoo",
     
     steps: () => [

--- a/certification_organism/data/knowledge_tour.xml
+++ b/certification_organism/data/knowledge_tour.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
     <record id="knowledge_tour" model="web_tour.tour">
-        <field name="name">knowledge_tour</field>
+        <field name="name">certification_organism_knowledge_tour</field>
         <field name="sequence">2</field>
         <field name="rainbow_man_message">Welcome! Happy exploring.</field>    
     </record>

--- a/certification_organism/static/src/js/my_tour.js
+++ b/certification_organism/static/src/js/my_tour.js
@@ -3,7 +3,7 @@
 import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
 
-registry.category("web_tour.tours").add("knowledge_tour", {
+registry.category("web_tour.tours").add("certification_organism_knowledge_tour", {
     url: "/odoo",
     
     steps: () => [

--- a/clothing_boutique/data/knowledge_tour.xml
+++ b/clothing_boutique/data/knowledge_tour.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
     <record id="knowledge_tour" model="web_tour.tour">
-        <field name="name">knowledge_tour</field>
+        <field name="name">clothing_boutique_knowledge_tour</field>
         <field name="sequence">2</field>
         <field name="rainbow_man_message">Welcome! Happy exploring.</field>    
     </record>

--- a/clothing_boutique/static/src/js/my_tour.js
+++ b/clothing_boutique/static/src/js/my_tour.js
@@ -3,7 +3,7 @@
 import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
 
-registry.category("web_tour.tours").add("knowledge_tour", {
+registry.category("web_tour.tours").add("clothing_boutique_knowledge_tour", {
     url: "/odoo",
     
     steps: () => [

--- a/coal_petroleum/data/knowledge_tour.xml
+++ b/coal_petroleum/data/knowledge_tour.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
     <record id="knowledge_tour" model="web_tour.tour">
-        <field name="name">knowledge_tour</field>
+        <field name="name">coal_petroleum_knowledge_tour</field>
         <field name="sequence">2</field>
         <field name="rainbow_man_message">Welcome! Happy exploring.</field>    
     </record>

--- a/coal_petroleum/static/src/js/my_tour.js
+++ b/coal_petroleum/static/src/js/my_tour.js
@@ -3,7 +3,7 @@
 import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
 
-registry.category("web_tour.tours").add("knowledge_tour", {
+registry.category("web_tour.tours").add("coal_petroleum_knowledge_tour", {
     url: "/odoo",
     
     steps: () => [

--- a/condominium/data/knowledge_tour.xml
+++ b/condominium/data/knowledge_tour.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
     <record id="knowledge_tour" model="web_tour.tour">
-        <field name="name">knowledge_tour</field>
+        <field name="name">condominium_knowledge_tour</field>
         <field name="sequence">2</field>
         <field name="rainbow_man_message">Welcome! Happy exploring.</field>    
     </record>

--- a/condominium/static/src/js/my_tour.js
+++ b/condominium/static/src/js/my_tour.js
@@ -3,7 +3,7 @@
 import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
 
-registry.category("web_tour.tours").add("knowledge_tour", {
+registry.category("web_tour.tours").add("condominium_knowledge_tour", {
     url: "/odoo",
     
     steps: () => [

--- a/construction/data/knowledge_tour.xml
+++ b/construction/data/knowledge_tour.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
     <record id="knowledge_tour" model="web_tour.tour">
-        <field name="name">knowledge_tour</field>
+        <field name="name">construction_knowledge_tour</field>
         <field name="sequence">2</field>
         <field name="rainbow_man_message">Welcome! Happy exploring.</field>    
     </record>

--- a/construction/static/src/js/my_tour.js
+++ b/construction/static/src/js/my_tour.js
@@ -3,7 +3,7 @@
 import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
 
-registry.category("web_tour.tours").add("knowledge_tour", {
+registry.category("web_tour.tours").add("construction_knowledge_tour", {
     url: "/odoo",
     steps: () => [
         {

--- a/corporate_gifts/data/knowledge_tour.xml
+++ b/corporate_gifts/data/knowledge_tour.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
     <record id="knowledge_tour" model="web_tour.tour">
-        <field name="name">knowledge_tour</field>
+        <field name="name">corporate_gifts_knowledge_tour</field>
         <field name="sequence">2</field>
         <field name="rainbow_man_message">Welcome! Happy exploring.</field>    
     </record>

--- a/corporate_gifts/static/src/js/my_tour.js
+++ b/corporate_gifts/static/src/js/my_tour.js
@@ -3,7 +3,7 @@
 import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
 
-registry.category("web_tour.tours").add("knowledge_tour", {
+registry.category("web_tour.tours").add("corporate_gifts_knowledge_tour", {
     url: "/odoo",
     
     steps: () => [

--- a/custom_furniture/data/knowledge_tour.xml
+++ b/custom_furniture/data/knowledge_tour.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
     <record id="knowledge_tour" model="web_tour.tour">
-        <field name="name">knowledge_tour</field>
+        <field name="name">custom_furniture_knowledge_tour</field>
         <field name="sequence">2</field>
         <field name="rainbow_man_message">Welcome! Happy exploring.</field>    
     </record>

--- a/custom_furniture/static/src/js/my_tour.js
+++ b/custom_furniture/static/src/js/my_tour.js
@@ -3,7 +3,7 @@
 import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
 
-registry.category("web_tour.tours").add("knowledge_tour", {
+registry.category("web_tour.tours").add("custom_furniture_knowledge_tour", {
     url: "/odoo",
     
     steps: () => [

--- a/electronic_store/data/knowledge_tour.xml
+++ b/electronic_store/data/knowledge_tour.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
     <record id="knowledge_tour" model="web_tour.tour">
-        <field name="name">knowledge_tour</field>
+        <field name="name">electronic_store_knowledge_tour</field>
         <field name="sequence">2</field>
         <field name="rainbow_man_message">Welcome! Happy exploring.</field>    
     </record>

--- a/electronic_store/static/src/js/my_tour.js
+++ b/electronic_store/static/src/js/my_tour.js
@@ -3,7 +3,7 @@
 import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
 
-registry.category("web_tour.tours").add("knowledge_tour", {
+registry.category("web_tour.tours").add("electronic_store_knowledge_tour", {
     url: "/odoo",
     
     steps: () => [

--- a/eyewear_shop/data/knowledge_tour.xml
+++ b/eyewear_shop/data/knowledge_tour.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
     <record id="knowledge_tour" model="web_tour.tour">
-        <field name="name">knowledge_tour</field>
+        <field name="name">eyewear_shop_knowledge_tour</field>
         <field name="sequence">2</field>
         <field name="rainbow_man_message">Welcome! Happy exploring.</field>    
     </record>

--- a/eyewear_shop/static/src/js/my_tour.js
+++ b/eyewear_shop/static/src/js/my_tour.js
@@ -3,7 +3,7 @@
 import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
 
-registry.category("web_tour.tours").add("knowledge_tour", {
+registry.category("web_tour.tours").add("eyewear_shop_knowledge_tour", {
     url: "/odoo",
     
     steps: () => [

--- a/fast_food/data/knowledge_tour.xml
+++ b/fast_food/data/knowledge_tour.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
     <record id="knowledge_tour" model="web_tour.tour">
-        <field name="name">knowledge_tour</field>
+        <field name="name">fast_food_knowledge_tour</field>
         <field name="sequence">2</field>
         <field name="rainbow_man_message">Welcome! Happy exploring.</field>    
     </record>

--- a/fast_food/static/src/js/my_tour.js
+++ b/fast_food/static/src/js/my_tour.js
@@ -3,7 +3,7 @@
 import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
 
-registry.category("web_tour.tours").add("knowledge_tour", {
+registry.category("web_tour.tours").add("fast_food_knowledge_tour", {
     url: "/odoo",
     
     steps: () => [

--- a/fitness/data/knowledge_tour.xml
+++ b/fitness/data/knowledge_tour.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
     <record id="knowledge_tour" model="web_tour.tour">
-        <field name="name">knowledge_tour</field>
+        <field name="name">fitness_knowledge_tour</field>
         <field name="sequence">2</field>
         <field name="rainbow_man_message">Welcome! Happy exploring.</field>    
     </record>

--- a/fitness/static/src/js/my_tour.js
+++ b/fitness/static/src/js/my_tour.js
@@ -3,7 +3,7 @@
 import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
 
-registry.category("web_tour.tours").add("knowledge_tour", {
+registry.category("web_tour.tours").add("fitness_knowledge_tour", {
     url: "/odoo",
     
     steps: () => [

--- a/fmcg_store/data/knowledge_tour.xml
+++ b/fmcg_store/data/knowledge_tour.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
     <record id="knowledge_tour" model="web_tour.tour">
-        <field name="name">knowledge_tour</field>
+        <field name="name">fmcg_store_knowledge_tour</field>
         <field name="sequence">2</field>
         <field name="rainbow_man_message">Welcome! Happy exploring.</field>    
     </record>

--- a/fmcg_store/static/src/js/my_tour.js
+++ b/fmcg_store/static/src/js/my_tour.js
@@ -3,7 +3,7 @@
 import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
 
-registry.category("web_tour.tours").add("knowledge_tour", {
+registry.category("web_tour.tours").add("fmcg_store_knowledge_tour", {
     url: "/odoo",
     
     steps: () => [

--- a/furniture_store/data/knowledge_tour.xml
+++ b/furniture_store/data/knowledge_tour.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
     <record id="knowledge_tour" model="web_tour.tour">
-        <field name="name">knowledge_tour</field>
+        <field name="name">furniture_store_knowledge_tour</field>
         <field name="sequence">2</field>
         <field name="rainbow_man_message">Welcome! Happy exploring.</field>    
     </record>

--- a/furniture_store/static/src/js/my_tour.js
+++ b/furniture_store/static/src/js/my_tour.js
@@ -3,7 +3,7 @@
 import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
 
-registry.category("web_tour.tours").add("knowledge_tour", {
+registry.category("web_tour.tours").add("furniture_store_knowledge_tour", {
     url: "/odoo",
     
     steps: () => [

--- a/gardening/data/knowledge_tour.xml
+++ b/gardening/data/knowledge_tour.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
     <record id="knowledge_tour" model="web_tour.tour">
-        <field name="name">knowledge_tour</field>
+        <field name="name">gardening_knowledge_tour</field>
         <field name="sequence">2</field>
         <field name="rainbow_man_message">Welcome! Happy exploring.</field>    
     </record>

--- a/gardening/static/src/js/my_tour.js
+++ b/gardening/static/src/js/my_tour.js
@@ -3,7 +3,7 @@
 import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
 
-registry.category("web_tour.tours").add("knowledge_tour", {
+registry.category("web_tour.tours").add("gardening_knowledge_tour", {
     url: "/odoo",
     
     steps: () => [

--- a/hair_salon/data/knowledge_tour.xml
+++ b/hair_salon/data/knowledge_tour.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
     <record id="knowledge_tour" model="web_tour.tour">
-        <field name="name">knowledge_tour</field>
+        <field name="name">hair_salon_knowledge_tour</field>
         <field name="sequence">2</field>
         <field name="rainbow_man_message">Welcome! Happy exploring.</field>    
     </record>

--- a/hair_salon/static/src/js/my_tour.js
+++ b/hair_salon/static/src/js/my_tour.js
@@ -3,7 +3,7 @@
 import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
 
-registry.category("web_tour.tours").add("knowledge_tour", {
+registry.category("web_tour.tours").add("hair_salon_knowledge_tour", {
     url: "/odoo",
     
     steps: () => [

--- a/hardware_shop/data/knowledge_tour.xml
+++ b/hardware_shop/data/knowledge_tour.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
     <record id="knowledge_tour" model="web_tour.tour">
-        <field name="name">knowledge_tour</field>
+        <field name="name">hardware_shop_knowledge_tour</field>
         <field name="sequence">2</field>
         <field name="rainbow_man_message">Welcome! Happy exploring.</field>    
     </record>

--- a/hardware_shop/static/src/js/my_tour.js
+++ b/hardware_shop/static/src/js/my_tour.js
@@ -3,7 +3,7 @@
 import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
 
-registry.category("web_tour.tours").add("knowledge_tour", {
+registry.category("web_tour.tours").add("hardware_shop_knowledge_tour", {
     url: "/odoo",
     
     steps: () => [

--- a/headhunter/data/knowledge_tour.xml
+++ b/headhunter/data/knowledge_tour.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
     <record id="knowledge_tour" model="web_tour.tour">
-        <field name="name">knowledge_tour</field>
+        <field name="name">headhunter_knowledge_tour</field>
         <field name="sequence">2</field>
         <field name="rainbow_man_message">Welcome! Happy exploring.</field>    
     </record>

--- a/headhunter/static/src/js/my_tour.js
+++ b/headhunter/static/src/js/my_tour.js
@@ -3,7 +3,7 @@
 import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
 
-registry.category("web_tour.tours").add("knowledge_tour", {
+registry.category("web_tour.tours").add("headhunter_knowledge_tour", {
     url: "/odoo",
     
     steps: () => [

--- a/industry_lawyer/data/knowledge_tour.xml
+++ b/industry_lawyer/data/knowledge_tour.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
     <record id="knowledge_tour" model="web_tour.tour">
-        <field name="name">knowledge_tour</field>
+        <field name="name">industry_lawyer_knowledge_tour</field>
         <field name="sequence">2</field>
         <field name="rainbow_man_message">Welcome! Happy exploring.</field>    
     </record>

--- a/industry_lawyer/static/src/js/my_tour.js
+++ b/industry_lawyer/static/src/js/my_tour.js
@@ -3,7 +3,7 @@
 import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
 
-registry.category("web_tour.tours").add("knowledge_tour", {
+registry.category("web_tour.tours").add("industry_lawyer_knowledge_tour", {
     url: "/odoo",
     
     steps: () => [

--- a/industry_real_estate/data/knowledge_tour.xml
+++ b/industry_real_estate/data/knowledge_tour.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
     <record id="knowledge_tour" model="web_tour.tour">
-        <field name="name">knowledge_tour</field>
+        <field name="name">inudstry_real_estate_knowledge_tour</field>
         <field name="sequence">2</field>
         <field name="rainbow_man_message">Welcome! Happy exploring.</field>    
     </record>

--- a/industry_real_estate/static/src/js/my_tour.js
+++ b/industry_real_estate/static/src/js/my_tour.js
@@ -3,7 +3,7 @@
 import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
 
-registry.category("web_tour.tours").add("knowledge_tour", {
+registry.category("web_tour.tours").add("industry_real_estate_knowledge_tour", {
     url: "/odoo",
     
     steps: () => [

--- a/industry_restaurant/data/knowledge_tour.xml
+++ b/industry_restaurant/data/knowledge_tour.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
     <record id="knowledge_tour" model="web_tour.tour">
-        <field name="name">knowledge_tour</field>
+        <field name="name">industry_restaurant_knowledge_tour</field>
         <field name="sequence">2</field>
         <field name="rainbow_man_message">Welcome! Happy exploring.</field>    
     </record>

--- a/industry_restaurant/static/src/js/my_tour.js
+++ b/industry_restaurant/static/src/js/my_tour.js
@@ -3,7 +3,7 @@
 import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
 
-registry.category("web_tour.tours").add("knowledge_tour", {
+registry.category("web_tour.tours").add("industry_restaurant_knowledge_tour", {
     url: "/odoo",
     
     steps: () => [

--- a/it_hardware/data/knowledge_tour.xml
+++ b/it_hardware/data/knowledge_tour.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
     <record id="knowledge_tour" model="web_tour.tour">
-        <field name="name">knowledge_tour</field>
+        <field name="name">it_hardware_knowledge_tour</field>
         <field name="sequence">2</field>
         <field name="rainbow_man_message">Welcome! Happy exploring.</field>    
     </record>

--- a/it_hardware/static/src/js/my_tour.js
+++ b/it_hardware/static/src/js/my_tour.js
@@ -3,7 +3,7 @@
 import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
 
-registry.category("web_tour.tours").add("knowledge_tour", {
+registry.category("web_tour.tours").add("it_hardware_knowledge_tour", {
     url: "/odoo",
     
     steps: () => [

--- a/micro_brewery/data/knowledge_tour.xml
+++ b/micro_brewery/data/knowledge_tour.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
     <record id="knowledge_tour" model="web_tour.tour">
-        <field name="name">knowledge_tour</field>
+        <field name="name">micro_brewery_knowledge_tour</field>
         <field name="sequence">2</field>
         <field name="rainbow_man_message">Welcome! Happy exploring.</field>    
     </record>

--- a/micro_brewery/static/src/js/my_tour.js
+++ b/micro_brewery/static/src/js/my_tour.js
@@ -3,7 +3,7 @@
 import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
 
-registry.category("web_tour.tours").add("knowledge_tour", {
+registry.category("web_tour.tours").add("micro_brewery_knowledge_tour", {
     url: "/odoo",
     
     steps: () => [

--- a/non_profit_organization/data/knowledge_tour.xml
+++ b/non_profit_organization/data/knowledge_tour.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
     <record id="knowledge_tour" model="web_tour.tour">
-        <field name="name">knowledge_tour</field>
+        <field name="name">non_profit_organization_knowledge_tour</field>
         <field name="sequence">2</field>
         <field name="rainbow_man_message">Welcome! Happy exploring.</field>    
     </record>

--- a/non_profit_organization/static/src/js/my_tour.js
+++ b/non_profit_organization/static/src/js/my_tour.js
@@ -3,7 +3,7 @@
 import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
 
-registry.category("web_tour.tours").add("knowledge_tour", {
+registry.category("web_tour.tours").add("non_profit_organization_knowledge_tour", {
     url: "/odoo",
     
     steps: () => [

--- a/odoo_partner/data/knowledge_tour.xml
+++ b/odoo_partner/data/knowledge_tour.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
     <record id="knowledge_tour" model="web_tour.tour">
-        <field name="name">knowledge_tour</field>
+        <field name="name">odoo_partner_knowledge_tour</field>
         <field name="sequence">2</field>
         <field name="rainbow_man_message">Welcome! Happy exploring.</field>    
     </record>

--- a/odoo_partner/static/src/js/my_tour.js
+++ b/odoo_partner/static/src/js/my_tour.js
@@ -3,7 +3,7 @@
 import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
 
-registry.category("web_tour.tours").add("knowledge_tour", {
+registry.category("web_tour.tours").add("odoo_partner_knowledge_tour", {
     url: "/odoo",
     
     steps: () => [

--- a/pharmacy_retail/data/knowledge_tour.xml
+++ b/pharmacy_retail/data/knowledge_tour.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
     <record id="knowledge_tour" model="web_tour.tour">
-        <field name="name">knowledge_tour</field>
+        <field name="name">pharmacy_retail_knowledge_tour</field>
         <field name="sequence">2</field>
         <field name="rainbow_man_message">Welcome! Happy exploring.</field>    
     </record>

--- a/pharmacy_retail/static/src/js/my_tour.js
+++ b/pharmacy_retail/static/src/js/my_tour.js
@@ -3,7 +3,7 @@
 import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
 
-registry.category("web_tour.tours").add("knowledge_tour", {
+registry.category("web_tour.tours").add("pharmacy_retail_knowledge_tour", {
     url: "/odoo",
     
     steps: () => [

--- a/photography/data/knowledge_tour.xml
+++ b/photography/data/knowledge_tour.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
     <record id="knowledge_tour" model="web_tour.tour">
-        <field name="name">knowledge_tour</field>
+        <field name="name">photography_knowledge_tour</field>
         <field name="sequence">2</field>
         <field name="rainbow_man_message">Welcome! Happy exploring.</field>    
     </record>

--- a/photography/static/src/js/my_tour.js
+++ b/photography/static/src/js/my_tour.js
@@ -3,7 +3,7 @@
 import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
 
-registry.category("web_tour.tours").add("knowledge_tour", {
+registry.category("web_tour.tours").add("photography_knowledge_tour", {
     url: "/odoo",
     
     steps: () => [

--- a/software_reseller/data/knowledge_tour.xml
+++ b/software_reseller/data/knowledge_tour.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
     <record id="knowledge_tour" model="web_tour.tour">
-        <field name="name">knowledge_tour</field>
+        <field name="name">software_reseller_knowledge_tour</field>
         <field name="sequence">2</field>
         <field name="rainbow_man_message">Welcome! Happy exploring.</field>    
     </record>

--- a/software_reseller/static/src/js/my_tour.js
+++ b/software_reseller/static/src/js/my_tour.js
@@ -3,7 +3,7 @@
 import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
 
-registry.category("web_tour.tours").add("knowledge_tour", {
+registry.category("web_tour.tours").add("software_reseller_knowledge_tour", {
     url: "/odoo",
     
     steps: () => [

--- a/solar_installation/data/knowledge_tour.xml
+++ b/solar_installation/data/knowledge_tour.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
     <record id="knowledge_tour" model="web_tour.tour">
-        <field name="name">knowledge_tour</field>
+        <field name="name">solar_installation_knowledge_tour</field>
         <field name="sequence">2</field>
         <field name="rainbow_man_message">Welcome! Happy exploring.</field>    
     </record>

--- a/solar_installation/static/src/js/my_tour.js
+++ b/solar_installation/static/src/js/my_tour.js
@@ -3,7 +3,7 @@
 import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
 
-registry.category("web_tour.tours").add("knowledge_tour", {
+registry.category("web_tour.tours").add("solar_installation_knowledge_tour", {
     url: "/odoo",
     
     steps: () => [

--- a/sports_club/data/knowledge_tour.xml
+++ b/sports_club/data/knowledge_tour.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
     <record id="knowledge_tour" model="web_tour.tour">
-        <field name="name">knowledge_tour</field>
+        <field name="name">sports_club_knowledge_tour</field>
         <field name="sequence">2</field>
         <field name="rainbow_man_message">Welcome! Happy exploring.</field>    
     </record>

--- a/sports_club/static/src/js/my_tour.js
+++ b/sports_club/static/src/js/my_tour.js
@@ -3,7 +3,7 @@
 import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
 
-registry.category("web_tour.tours").add("knowledge_tour", {
+registry.category("web_tour.tours").add("sports_club_knowledge_tour", {
     url: "/odoo",
     
     steps: () => [

--- a/surveyor/data/knowledge_tour.xml
+++ b/surveyor/data/knowledge_tour.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
     <record id="knowledge_tour" model="web_tour.tour">
-        <field name="name">knowledge_tour</field>
+        <field name="name">surveyor_knowledge_tour</field>
         <field name="sequence">2</field>
         <field name="rainbow_man_message">Welcome! Happy exploring.</field>    
     </record>

--- a/surveyor/static/src/js/my_tour.js
+++ b/surveyor/static/src/js/my_tour.js
@@ -3,7 +3,7 @@
 import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
 
-registry.category("web_tour.tours").add("knowledge_tour", {
+registry.category("web_tour.tours").add("surveyor_knowledge_tour", {
     url: "/odoo",
     
     steps: () => [

--- a/toy_store/data/knowledge_tour.xml
+++ b/toy_store/data/knowledge_tour.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
     <record id="knowledge_tour" model="web_tour.tour">
-        <field name="name">knowledge_tour</field>
+        <field name="name">toy_store_knowledge_tour</field>
         <field name="sequence">2</field>
         <field name="rainbow_man_message">Welcome! Happy exploring.</field>    
     </record>

--- a/toy_store/static/src/js/my_tour.js
+++ b/toy_store/static/src/js/my_tour.js
@@ -3,7 +3,7 @@
 import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
 
-registry.category("web_tour.tours").add("knowledge_tour", {
+registry.category("web_tour.tours").add("toy_store_knowledge_tour", {
     url: "/odoo",
     
     steps: () => [

--- a/wellness_practitioner/data/knowledge_tour.xml
+++ b/wellness_practitioner/data/knowledge_tour.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
     <record id="knowledge_tour" model="web_tour.tour">
-        <field name="name">knowledge_tour</field>
+        <field name="name">wellness_practitioner_knowledge_tour</field>
         <field name="sequence">2</field>
         <field name="rainbow_man_message">Welcome! Happy exploring.</field>    
     </record>

--- a/wellness_practitioner/static/src/js/my_tour.js
+++ b/wellness_practitioner/static/src/js/my_tour.js
@@ -3,7 +3,7 @@
 import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
 
-registry.category("web_tour.tours").add("knowledge_tour", {
+registry.category("web_tour.tours").add("wellness_practitioner_knowledge_tour", {
     url: "/odoo",
     
     steps: () => [


### PR DESCRIPTION
Steps:
- Create a DB with industry addons (SaaS)
- Install one industry (bike_leasing)
- Install a second industry (industry_real_estate)

Actual result:
- Tour name conflict
- Constraint violation: web_tour_tour_uniq_name

Expected result:
- No conflict second industry is installed

opw-4264625

Forward of: #271
Caused by: #cbeab117a90bc92ea3dfab58973c1931afc73cbd