### PR TITLE
[FIX] architects: fix expense validation mode

### DIFF
--- a/architects/demo/hr_expense.xml
+++ b/architects/demo/hr_expense.xml
@@ -13,6 +13,7 @@
         <field name="employee_id" ref="hr.employee_admin"/>
         <field name="sale_order_id" ref="sale_order_6"/>
         <field name="product_id" ref="hr_expense.product_product_no_cost"/>
+        <field name="payment_mode">company_account</field>
         <field name="total_amount">121.0</field>
     </record>
 </odoo>


### PR DESCRIPTION
Since this commit*, there is a check on the bank account of the employee if the payment method is the default (own). This commit changes the payment mode to the 'company' one.

https://github.com/odoo/odoo/commit/2dc6b6c27176c51d879b149204b642a0324ea1cb