### PR TITLE
[FIX] beverage_distributor: fix unit product issues

### DIFF
--- a/beverage_distributor/data/ir_actions_server.xml
+++ b/beverage_distributor/data/ir_actions_server.xml
@@ -5,8 +5,8 @@
 if record.x_quantity_by_deposit_product == 1 and record.x_unit_sale_product.id:
     raise UserError("Unit sale product should be undefined if this product can not be sold in a smaller unit.")
 if record.x_unit_sale_product:
-    existing_bom = env['mrp.bom'].search([('product_tmpl_id', '=',record.x_unit_sale_product.product_tmpl_id.id)], limit=1)
-    reordering_rule = env['stock.warehouse.orderpoint'].search_count([('product_id', '=', record.x_unit_sale_product.id)], limit=1)
+    existing_bom = env['mrp.bom'].search([('product_tmpl_id', '=',record.x_unit_sale_product.id)], limit=1)
+    reordering_rule = env['stock.warehouse.orderpoint'].search_count([('product_id', '=', record.x_unit_sale_product.product_variant_id.id)], limit=1)
     bom_vals = {
         'product_qty': record.x_quantity_by_deposit_product,
         'type': 'normal',
@@ -25,11 +25,11 @@ if record.x_unit_sale_product:
     if existing_bom:
         existing_bom.write(bom_vals)
     else:
-        bom_vals['product_tmpl_id'] = record.x_unit_sale_product.product_tmpl_id.id
+        bom_vals['product_tmpl_id'] = record.x_unit_sale_product.id
         env['mrp.bom'].create(bom_vals)
     if not reordering_rule:
         env['stock.warehouse.orderpoint'].create({
-            'product_id': record.x_unit_sale_product.id,
+            'product_id': record.x_unit_sale_product.product_variant_id.id,
             'x_parent_product': record.id,
             'product_min_qty': 0,
             'product_max_qty': 0,

--- a/beverage_distributor/data/ir_model_fields.xml
+++ b/beverage_distributor/data/ir_model_fields.xml
@@ -52,6 +52,7 @@ for product in self:
         <field name="ttype">many2one</field>
         <field name="model_id" ref="product.model_product_template"/>
         <field name="relation">product.product</field>
+        <field name="copied" eval="False"/>
     </record>
     <record id="field_deposit_product_1" model="ir.model.fields">
         <field name="name">x_deposit_product_1</field>

--- a/beverage_distributor/data/ir_model_fields.xml
+++ b/beverage_distributor/data/ir_model_fields.xml
@@ -51,7 +51,7 @@ for product in self:
         <field name="field_description">Unit sale product</field>
         <field name="ttype">many2one</field>
         <field name="model_id" ref="product.model_product_template"/>
-        <field name="relation">product.product</field>
+        <field name="relation">product.template</field>
         <field name="copied" eval="False"/>
     </record>
     <record id="field_deposit_product_1" model="ir.model.fields">

--- a/beverage_distributor/data/product_template_package.xml
+++ b/beverage_distributor/data/product_template_package.xml
@@ -48,7 +48,7 @@
     <record id="product_template_54" model="product.template" context="{'create_product_product': False}">
         <field name="x_quantity_by_deposit_product">24</field>
         <field name="x_deposit_product" ref="product_template_56"/>
-        <field name="x_unit_sale_product" ref="product_product_35"/>
+        <field name="x_unit_sale_product" ref="product_template_57"/>
     </record>
     <record id="product_template_59" model="product.template" context="{'create_product_product': False}">
         <field name="name">Mobius IPA 24x33cl </field>
@@ -107,7 +107,7 @@
     </record>
     <record id="product_template_59" model="product.template" context="{'create_product_product': False}">
         <field name="x_deposit_product" ref="product_template_56"/>
-        <field name="x_unit_sale_product" ref="product_product_37"/>
+        <field name="x_unit_sale_product" ref="product_template_60"/>
         <field name="x_quantity_by_deposit_product">24</field>
     </record>
     <record id="product_template_6" model="product.template" context="{'create_product_product': False}">
@@ -167,7 +167,7 @@
     <record id="product_template_6" model="product.template" context="{'create_product_product': False}">
         <field name="x_quantity_by_deposit_product">24</field>
         <field name="x_deposit_product" ref="product_template_56"/>
-        <field name="x_unit_sale_product" ref="product_product_7"/>
+        <field name="x_unit_sale_product" ref="product_template_7"/>
     </record>
     <record id="product_template_61" model="product.template" context="{'create_product_product': False}">
         <field name="name">Mobius Triple 24x33cl</field>
@@ -226,7 +226,7 @@
     <record id="product_template_61" model="product.template" context="{'create_product_product': False}">
         <field name="x_quantity_by_deposit_product">24</field>
         <field name="x_deposit_product" ref="product_template_56"/>
-        <field name="x_unit_sale_product" ref="product_product_39"/>
+        <field name="x_unit_sale_product" ref="product_template_62"/>
     </record>
     <record id="product_template_63" model="product.template" context="{'create_product_product': False}">
         <field name="name">Lou Daro - Château de Gragnos 6x75cl</field>
@@ -274,7 +274,7 @@
     </record>
     <record id="product_template_63" model="product.template" context="{'create_product_product': False}">
         <field name="x_quantity_by_deposit_product">6</field>
-        <field name="x_unit_sale_product" ref="product_product_41"/>
+        <field name="x_unit_sale_product" ref="product_template_64"/>
     </record>
     <record id="product_template_65" model="product.template" context="{'create_product_product': False}">
         <field name="name">Rosé Cosmos - Château de Gragnos 6x75cl</field>
@@ -322,7 +322,7 @@
     </record>
     <record id="product_template_65" model="product.template" context="{'create_product_product': False}">
         <field name="x_quantity_by_deposit_product">6</field>
-        <field name="x_unit_sale_product" ref="product_product_43"/>
+        <field name="x_unit_sale_product" ref="product_template_66"/>
     </record>
     <record id="product_template_67" model="product.template" context="{'create_product_product': False}">
         <field name="name">Cava Brut Il Lusio - Josep Masachs 6x75cl</field>
@@ -370,7 +370,7 @@
     </record>
     <record id="product_template_67" model="product.template" context="{'create_product_product': False}">
         <field name="x_quantity_by_deposit_product">6</field>
-        <field name="x_unit_sale_product" ref="product_product_45"/>
+        <field name="x_unit_sale_product" ref="product_template_68"/>
     </record>
     <record id="product_template_69" model="product.template" context="{'create_product_product': False}">
         <field name="name">Cuvée Grillo - Villa Carumé 6x75cl</field>
@@ -418,6 +418,6 @@
     </record>
     <record id="product_template_69" model="product.template" context="{'create_product_product': False}">
         <field name="x_quantity_by_deposit_product">6</field>
-        <field name="x_unit_sale_product" ref="product_product_47"/>
+        <field name="x_unit_sale_product" ref="product_template_70"/>
     </record>
 </odoo>


### PR DESCRIPTION
[FIX] beverage_distributor: do not copy unit product

When duplicating a product, the linked BoM line is edited with the new product. This is due to the unit product, triggering the server action. This commit fixes the issues by not copying the unit product along with the product.

[FIX] beverage_distributor: unit sale product is a template

Before this commit, the field `x_unit_sale_product` was a `product.product`. This was misleading, mostly when clicking on the Unit sale product from another (packed) product. This commit fixes the issue by changing the relation to a `product.template`, adapting the server action accordingly

task-4360843