### PR TITLE
[FIX] *: forcecreate for standard records

### DIFF
--- a/bike_leasing/data/delivery_carrier.xml
+++ b/bike_leasing/data/delivery_carrier.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-    <record id="delivery.free_delivery_carrier" model="delivery.carrier">
+    <record id="delivery.free_delivery_carrier" model="delivery.carrier" forcecreate="True">
         <field name="name">After quote validation</field>
     </record>
 </odoo>

--- a/bike_leasing/data/product_attribute.xml
+++ b/bike_leasing/data/product_attribute.xml
@@ -11,7 +11,7 @@
         <field name="name">Accessories</field>
         <field name="create_variant">no_variant</field>
     </record>
-    <record id="website_sale.product_attribute_brand" model="product.attribute">
+    <record id="website_sale.product_attribute_brand" model="product.attribute" forcecreate="True">
         <field name="name">Brand</field>
     </record>
 </odoo>

--- a/bookstore/data/product_category.xml
+++ b/bookstore/data/product_category.xml
@@ -190,16 +190,4 @@
         <field name="property_cost_method">average</field>
         <field name="parent_id" ref="product_category_6"/>
     </record>
-    <record id="product.product_category_1" model="product.category">
-        <field name="name">Saleable</field>
-        <field name="parent_id" ref="product.product_category_all"/>
-    </record>
-    <record id="point_of_sale.product_category_pos" model="product.category">
-        <field name="name">PoS</field>
-        <field name="parent_id" ref="product.product_category_1"/>
-    </record>
-    <record id="product.cat_expense" model="product.category">
-        <field name="name">Expenses</field>
-        <field name="parent_id" ref="product.product_category_all"/>
-    </record>
 </odoo>

--- a/condominium/demo/helpdesk_team.xml
+++ b/condominium/demo/helpdesk_team.xml
@@ -7,7 +7,7 @@
         <field name="to_stage_id" ref="helpdesk.stage_solved"/>
         <field name="project_id" ref="project_project_6"/>
     </record>
-    <record id="helpdesk.helpdesk_team1" model="helpdesk.team">
+    <record id="helpdesk.helpdesk_team1" model="helpdesk.team" forcecreate="True">
         <field name="name">Green Island Property</field>
         <field name="resource_calendar_id" ref="resource.resource_calendar_std"/>
         <field name="stage_ids" eval="[(6, 0, [ref('helpdesk.stage_new'), ref('helpdesk.stage_in_progress'), ref('helpdesk.stage_on_hold'), ref('helpdesk.stage_solved'), ref('helpdesk.stage_cancelled')])]"/>

--- a/construction/__manifest__.py
+++ b/construction/__manifest__.py
@@ -43,7 +43,6 @@ focusing on accurate quoting, efficient planning, seamless execution, and excell
         'demo/res_partner.xml',
         'demo/account_analytic_account.xml',
         'demo/project_project.xml',
-        'demo/product_product.xml',
         'demo/documents_document.xml',
         'demo/helpdesk_ticket.xml',
         'demo/hr_employee.xml',

--- a/construction/data/product_product.xml
+++ b/construction/data/product_product.xml
@@ -44,7 +44,7 @@
         <field name="project_template_id" ref="project_project_3"/>
         <field name="image_1920" type="base64" file="construction/static/src/binary/product_template/8-image_1920"/>
     </record>
-    <record id="sale_timesheet.time_product" model="product.product">
+    <record id="sale_timesheet.time_product" model="product.product" forcecreate="True">
         <field name="name">Labor hour</field>
         <field name="list_price">60.0</field>
         <field name="service_tracking">task_in_project</field>
@@ -52,7 +52,7 @@
         <field name="standard_price">35.0</field>
         <field name="image_1920" type="base64" file="construction/static/src/binary/product_template/2-image_1920"/>
     </record>
-    <record id="industry_fsm_sale.field_service_product" model="product.product">
+    <record id="industry_fsm_sale.field_service_product" model="product.product" forcecreate="True">
         <field name="name">Repair</field>
         <field name="purchase_ok" eval="False"/>
         <field name="list_price">60.0</field>

--- a/construction/demo/product_product.xml
+++ b/construction/demo/product_product.xml
@@ -1,6 +1,0 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
-    <record id="industry_fsm_sale.field_service_product" model="product.product">
-        <field name="project_id" ref="industry_fsm.fsm_project"/>
-    </record>
-</odoo>

--- a/construction/demo/project_project.xml
+++ b/construction/demo/project_project.xml
@@ -27,7 +27,7 @@
         <field name="user_id" ref="base.user_admin"/>
         <field name="favorite_user_ids" eval="[Command.link(ref('base.user_admin'))]"/>
     </record>
-    <record id="industry_fsm.fsm_project" model="project.project">
+    <record id="industry_fsm.fsm_project" model="project.project" forcecreate="True">
         <field name="stage_id" ref="project.project_project_stage_1"/>
         <field name="account_id" ref="account_analytic_account_2"/>
         <field name="allow_material" eval="True"/>

--- a/electronic_store/data/helpdesk_config.xml
+++ b/electronic_store/data/helpdesk_config.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-    <record id="helpdesk.helpdesk_team1" model="helpdesk.team">
+    <record id="helpdesk.helpdesk_team1" model="helpdesk.team" forcecreate="True">
         <field name="use_credit_notes" eval="True"/>
         <field name="use_product_returns" eval="True"/>
         <field name="use_product_repairs" eval="True"/>

--- a/electronic_store/demo/stock_warehouse.xml
+++ b/electronic_store/demo/stock_warehouse.xml
@@ -1,9 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-    <record id="stock.warehouse0" model="stock.warehouse">
+    <record id="stock.warehouse0" model="stock.warehouse" forcecreate="True">
         <field name="name">Electronic store</field>
-    </record>
-    <record id="stock.picking_type_out" model="stock.picking.type">
-        <field name="show_operations" eval="True"/>
     </record>
 </odoo>

--- a/headhunter/data/crm_stage.xml
+++ b/headhunter/data/crm_stage.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-    <record id="crm.stage_lead4" model="crm.stage">
+    <record id="crm.stage_lead4" model="crm.stage" forcecreate="True">
         <field name="name">Done</field>
     </record>
     <record id="crm_stage_6" model="crm.stage">

--- a/headhunter/data/hr_recruitment_stage.xml
+++ b/headhunter/data/hr_recruitment_stage.xml
@@ -4,7 +4,7 @@
         <field name="name">Reserve</field>
         <field name="sequence">3</field>
     </record>
-    <record id="hr_recruitment.stage_job2" model="hr.recruitment.stage">
+    <record id="hr_recruitment.stage_job2" model="hr.recruitment.stage" forcecreate="True">
         <field name="template_id" ref="hr_recruitment.email_template_data_applicant_interest"/>
     </record>
 </odoo>

--- a/headhunter/data/mail_template.xml
+++ b/headhunter/data/mail_template.xml
@@ -27,7 +27,7 @@
         </field>
     </record>
 
-    <record id="hr_recruitment.email_template_data_applicant_interest" model="mail.template">
+    <record id="hr_recruitment.email_template_data_applicant_interest" model="mail.template" forcecreate="True">
         <field name="name">Recruitment: Interview</field>
         <field name="body_html">
             <![CDATA[

--- a/industry_real_estate/data/crm_stages.xml
+++ b/industry_real_estate/data/crm_stages.xml
@@ -1,10 +1,10 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-    <record id="crm.stage_lead2" model="crm.stage">
+    <record id="crm.stage_lead2" model="crm.stage" forcecreate="True">
         <field name="name">Visit</field>
         <field name="sequence">2</field>
     </record>
-    <record id="crm.stage_lead3" model="crm.stage">
+    <record id="crm.stage_lead3" model="crm.stage" forcecreate="True">
         <field name="name">Application</field>
         <field name="sequence">3</field>
     </record>

--- a/personal_trainer/data/crm_stage.xml
+++ b/personal_trainer/data/crm_stage.xml
@@ -1,18 +1,18 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-    <record id="crm.stage_lead1" model="crm.stage">
+    <record id="crm.stage_lead1" model="crm.stage" forcecreate="True">
         <field name="name">Initial Contact</field>
         <field name="sequence">1</field>
     </record>
-    <record id="crm.stage_lead2" model="crm.stage">
+    <record id="crm.stage_lead2" model="crm.stage" forcecreate="True">
         <field name="sequence">2</field>
         <field name="name">Assessment</field>
     </record>
-    <record id="crm.stage_lead3" model="crm.stage">
+    <record id="crm.stage_lead3" model="crm.stage" forcecreate="True">
         <field name="name">Proposal</field>
         <field name="sequence">3</field>
     </record>
-    <record id="crm.stage_lead4" model="crm.stage">
+    <record id="crm.stage_lead4" model="crm.stage" forcecreate="True">
         <field name="name">Won</field>
         <field name="sequence">5</field>
         <field name="is_won" eval="True" />

--- a/solar_installation/data/crm_stage.xml
+++ b/solar_installation/data/crm_stage.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-    <record id="crm.stage_lead3" model="crm.stage">
+    <record id="crm.stage_lead3" model="crm.stage" forcecreate="True">
         <field name="name">Site Survey</field>
     </record>
 </odoo>

--- a/solar_installation/data/crm_team.xml
+++ b/solar_installation/data/crm_team.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-    <record id="sales_team.team_sales_department" model="crm.team">
+    <record id="sales_team.team_sales_department" model="crm.team" forcecreate="True">
         <field name="name">Solar Sales Team</field>
         <field name="invoiced_target">60000.0</field>
     </record>

--- a/solar_installation/data/helpdesk_config.xml
+++ b/solar_installation/data/helpdesk_config.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-    <record id="helpdesk.helpdesk_team1" model="helpdesk.team">
+    <record id="helpdesk.helpdesk_team1" model="helpdesk.team" forcecreate="True">
         <field name="use_credit_notes" eval="True"/>
         <field name="use_product_returns" eval="True"/>
         <field name="use_product_repairs" eval="True"/>

--- a/wellness_practitioner/data/crm_stage.xml
+++ b/wellness_practitioner/data/crm_stage.xml
@@ -1,10 +1,10 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-  <record id="crm.stage_lead3" model="crm.stage">
+  <record id="crm.stage_lead3" model="crm.stage" forcecreate="True">
     <field name="name">Consultation</field>
     <field name="sequence">3</field>
   </record>
-  <record id="crm.stage_lead4" model="crm.stage">
+  <record id="crm.stage_lead4" model="crm.stage" forcecreate="True">
     <field name="name">Active Client</field>
     <field name="sequence">4</field>
     <field name="is_won" eval="True"/>


### PR DESCRIPTION
Some standard records may have already been deleted before the installation of an industry module that relies on it. This commit turns on the `forcecreate` attribute on those records to avoid installation from failing.

opw-4277227