### PR TITLE
[FIX] *: don't delete standard attributes

### DIFF
--- a/beverage_distributor/data/product_attribute.xml
+++ b/beverage_distributor/data/product_attribute.xml
@@ -4,39 +4,37 @@
         <field name="display_type">color</field>
         <field name="create_variant">no_variant</field>
         <field name="name">Beer type</field>
+        <field name="sequence" eval="-7"/>
     </record>
     <record id="product_attribute_11" model="product.attribute">
         <field name="create_variant">no_variant</field>
         <field name="name">Soda type</field>
+        <field name="sequence" eval="-1"/>
     </record>
     <record id="product_attribute_12" model="product.attribute">
         <field name="display_type">color</field>
         <field name="create_variant">no_variant</field>
         <field name="name">Wine type</field>
+        <field name="sequence" eval="-2"/>
     </record>
     <record id="product_attribute_13" model="product.attribute">
         <field name="create_variant">no_variant</field>
         <field name="name">Local Brand</field>
+        <field name="sequence" eval="-3"/>
     </record>
     <record id="product_attribute_14" model="product.attribute">
         <field name="create_variant">no_variant</field>
         <field name="name">IPA</field>
+        <field name="sequence" eval="-4"/>
     </record>
     <record id="product_attribute_15" model="product.attribute">
         <field name="name">Age Limit</field>
         <field name="create_variant">no_variant</field>
+        <field name="sequence" eval="-5"/>
     </record>
     <record id="product_attribute_16" model="product.attribute">
         <field name="create_variant">no_variant</field>
         <field name="name">Brand</field>
+        <field name="sequence" eval="-6"/>
     </record>
-    <delete model="product.attribute" id="product_barcodelookup.product_attribute_lookup_1"/>
-    <delete model="product.attribute" id="product_barcodelookup.product_attribute_lookup_2"/>
-    <delete model="product.attribute" id="product_barcodelookup.product_attribute_lookup_3"/>
-    <delete model="product.attribute" id="product_barcodelookup.product_attribute_lookup_4"/>
-    <delete model="product.attribute" id="product_barcodelookup.product_attribute_lookup_5"/>
-    <delete model="product.attribute" id="product_barcodelookup.product_attribute_lookup_6"/>
-    <delete model="product.attribute" id="product_barcodelookup.product_attribute_lookup_7"/>
-    <delete model="product.attribute" id="product_barcodelookup.product_attribute_lookup_8"/>    
-    <delete model="product.attribute" id="website_sale.product_attribute_brand"/>    
 </odoo>

--- a/micro_brewery/data/product_attribute.xml
+++ b/micro_brewery/data/product_attribute.xml
@@ -4,40 +4,38 @@
         <field name="name">Color</field>
         <field name="display_type">color</field>
         <field name="visibility">hidden</field>
+        <field name="sequence" eval="-7"/>
     </record>
     <record id="product_attribute_4" model="product.attribute">
         <field name="name">Size</field>
         <field name="display_type">pills</field>
         <field name="visibility">hidden</field>
+        <field name="sequence" eval="-1"/>
     </record>
     <record id="beverage_product_attribute_10" model="product.attribute">
         <field name="display_type">color</field>
         <field name="create_variant">no_variant</field>
         <field name="name">Beer type</field>
+        <field name="sequence" eval="-2"/>
     </record>
     <record id="beverage_product_attribute_13" model="product.attribute">
         <field name="create_variant">no_variant</field>
         <field name="name">Local Brand</field>
+        <field name="sequence" eval="-3"/>
     </record>
     <record id="beverage_product_attribute_14" model="product.attribute">
         <field name="create_variant">no_variant</field>
         <field name="name">IPA</field>
+        <field name="sequence" eval="-4"/>
     </record>
     <record id="beverage_product_attribute_15" model="product.attribute">
         <field name="name">Age Limit</field>
         <field name="create_variant">no_variant</field>
+        <field name="sequence" eval="-5"/>
     </record>
     <record id="beverage_product_attribute_16" model="product.attribute">
         <field name="create_variant">no_variant</field>
         <field name="name">Brand</field>
+        <field name="sequence" eval="-6"/>
     </record>
-    <delete model="product.attribute" id="product_barcodelookup.product_attribute_lookup_1"/>
-    <delete model="product.attribute" id="product_barcodelookup.product_attribute_lookup_2"/>
-    <delete model="product.attribute" id="product_barcodelookup.product_attribute_lookup_3"/>
-    <delete model="product.attribute" id="product_barcodelookup.product_attribute_lookup_4"/>
-    <delete model="product.attribute" id="product_barcodelookup.product_attribute_lookup_5"/>
-    <delete model="product.attribute" id="product_barcodelookup.product_attribute_lookup_6"/>
-    <delete model="product.attribute" id="product_barcodelookup.product_attribute_lookup_7"/>
-    <delete model="product.attribute" id="product_barcodelookup.product_attribute_lookup_8"/>    
-    <delete model="product.attribute" id="website_sale.product_attribute_brand"/>    
 </odoo>

--- a/toy_store/data/product_attribute.xml
+++ b/toy_store/data/product_attribute.xml
@@ -2,33 +2,24 @@
 <odoo noupdate="1">
     <record id="product_attribute_1" model="product.attribute">
         <field name="name">Brand</field>
-        <field name="sequence">1</field>
+        <field name="sequence">-4</field>
         <field name="create_variant">no_variant</field>
         <field name="visibility">hidden</field>
     </record>
     <record id="product_attribute_2" model="product.attribute">
         <field name="name">Minimum recommended age</field>
-        <field name="sequence">2</field>
+        <field name="sequence">-3</field>
         <field name="create_variant">no_variant</field>
         <field name="visibility">hidden</field>
     </record>
     <record id="product_attribute_3" model="product.attribute">
         <field name="name">Number of players</field>
-        <field name="sequence">3</field>
+        <field name="sequence">-2</field>
         <field name="create_variant">no_variant</field>
     </record>
     <record id="product_attribute_4" model="product.attribute">
         <field name="name">Color</field>
-        <field name="sequence">4</field>
+        <field name="sequence">-1</field>
         <field name="display_type">color</field>
     </record>
-    <delete model="product.attribute" id="website_sale.product_attribute_brand"/>
-    <delete model="product.attribute" id="product_barcodelookup.product_attribute_lookup_1"/>
-    <delete model="product.attribute" id="product_barcodelookup.product_attribute_lookup_2"/>
-    <delete model="product.attribute" id="product_barcodelookup.product_attribute_lookup_3"/>
-    <delete model="product.attribute" id="product_barcodelookup.product_attribute_lookup_4"/>
-    <delete model="product.attribute" id="product_barcodelookup.product_attribute_lookup_5"/>
-    <delete model="product.attribute" id="product_barcodelookup.product_attribute_lookup_6"/>
-    <delete model="product.attribute" id="product_barcodelookup.product_attribute_lookup_7"/>
-    <delete model="product.attribute" id="product_barcodelookup.product_attribute_lookup_8"/>
 </odoo>


### PR DESCRIPTION
Before this commit, the standard product attributes were deleted at the installation of the industry module. The problem is that deletion can easily be forbidden, as soon as there is a product created with this
attribute.
This commit therefore removes the deletion of standard attributes. It also reorders attributes such that industry-specific ones are at the top.

*toy_store, micro_brewery, beverage_distributor

task-4393043