### PR TITLE
[FIX] industry_real_estate: allow installation when crm stages are missing

### DIFF
--- a/industry_real_estate/data/crm_stages.xml
+++ b/industry_real_estate/data/crm_stages.xml
@@ -1,10 +1,10 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-    <record id="crm.stage_lead2" model="crm.stage" forcecreate="True">
+    <record id="crm.stage_lead2" model="crm.stage" forcecreate="False">
         <field name="name">Visit</field>
         <field name="sequence">2</field>
     </record>
-    <record id="crm.stage_lead3" model="crm.stage" forcecreate="True">
+    <record id="crm.stage_lead3" model="crm.stage" forcecreate="False">
         <field name="name">Application</field>
         <field name="sequence">3</field>
     </record>

--- a/industry_real_estate/demo/crm_lead_action.xml
+++ b/industry_real_estate/demo/crm_lead_action.xml
@@ -2,10 +2,10 @@
 <odoo>
     <function model="crm.lead" name="write">
         <value model="crm.lead" eval="[ref('crm_lead_49'), ref('crm_lead_50')]"/>
-        <value eval="{'stage_id': ref('crm.stage_lead2')}"/>
+        <value eval="{'stage_id': ref('crm.stage_lead2', raise_if_not_found=False)}"/>
     </function>
     <function model="crm.lead" name="write">
         <value model="crm.lead" eval="[ref('crm_lead_53')]"/>
-        <value eval="{'stage_id': ref('crm.stage_lead3')}"/>
+        <value eval="{'stage_id': ref('crm.stage_lead3', raise_if_not_found=False)}"/>
     </function>
 </odoo>


### PR DESCRIPTION
Since in 17.0, `forcecreate="True"` for creating other records's models is not supported, we bypass creating them for real_estate to skip the installation error.

opw-4277227