### PR TITLE
[FIX] *: forcecreate for standard records

### DIFF
--- a/bike_leasing/data/product_attribute.xml
+++ b/bike_leasing/data/product_attribute.xml
@@ -11,7 +11,4 @@
         <field name="name">Accessories</field>
         <field name="create_variant">no_variant</field>
     </record>
-    <record id="website_sale.product_attribute_brand" model="product.attribute" forcecreate="True">
-        <field name="name">Brand</field>
-    </record>
 </odoo>

--- a/condominium/demo/helpdesk_team.xml
+++ b/condominium/demo/helpdesk_team.xml
@@ -7,7 +7,7 @@
         <field name="to_stage_id" ref="helpdesk.stage_solved"/>
         <field name="project_id" ref="project_project_6"/>
     </record>
-    <record id="helpdesk.helpdesk_team1" model="helpdesk.team" forcecreate="True">
+    <record id="helpdesk.helpdesk_team1" model="helpdesk.team" forcecreate="False">
         <field name="name">Green Island Property</field>
         <field name="resource_calendar_id" ref="resource.resource_calendar_std"/>
         <field name="stage_ids" eval="[(6, 0, [ref('helpdesk.stage_new'), ref('helpdesk.stage_in_progress'), ref('helpdesk.stage_on_hold'), ref('helpdesk.stage_solved'), ref('helpdesk.stage_cancelled')])]"/>

--- a/construction/data/product_product.xml
+++ b/construction/data/product_product.xml
@@ -44,7 +44,7 @@
         <field name="project_template_id" ref="project_project_3"/>
         <field name="image_1920" type="base64" file="construction/static/src/binary/product_template/8-image_1920"/>
     </record>
-    <record id="sale_timesheet.time_product" model="product.product" forcecreate="True">
+    <record id="sale_timesheet.time_product" model="product.product" forcecreate="False">
         <field name="name">Labor hour</field>
         <field name="list_price">60.0</field>
         <field name="service_tracking">task_in_project</field>
@@ -52,7 +52,7 @@
         <field name="standard_price">35.0</field>
         <field name="image_1920" type="base64" file="construction/static/src/binary/product_template/2-image_1920"/>
     </record>
-    <record id="industry_fsm_sale.field_service_product" model="product.product" forcecreate="True">
+    <record id="industry_fsm_sale.field_service_product" model="product.product" forcecreate="False">
         <field name="name">Repair</field>
         <field name="purchase_ok" eval="False"/>
         <field name="list_price">60.0</field>

--- a/construction/demo/project_project.xml
+++ b/construction/demo/project_project.xml
@@ -27,7 +27,7 @@
         <field name="user_id" ref="base.user_admin"/>
         <field name="favorite_user_ids" eval="[Command.link(ref('base.user_admin'))]"/>
     </record>
-    <record id="industry_fsm.fsm_project" model="project.project" forcecreate="True">
+    <record id="industry_fsm.fsm_project" model="project.project" forcecreate="False">
         <field name="stage_id" ref="project.project_project_stage_1"/>
         <field name="analytic_account_id" ref="account_analytic_account_2"/>
         <field name="allow_material" eval="True"/>

--- a/electronic_store/data/helpdesk_config.xml
+++ b/electronic_store/data/helpdesk_config.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-    <record id="helpdesk.helpdesk_team1" model="helpdesk.team" forcecreate="True">
+    <record id="helpdesk.helpdesk_team1" model="helpdesk.team" forcecreate="False">
         <field name="use_credit_notes" eval="True"/>
         <field name="use_product_returns" eval="True"/>
         <field name="use_product_repairs" eval="True"/>

--- a/electronic_store/demo/stock_warehouse.xml
+++ b/electronic_store/demo/stock_warehouse.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-    <record id="stock.warehouse0" model="stock.warehouse" forcecreate="True">
+    <record id="stock.warehouse0" model="stock.warehouse" forcecreate="False">
         <field name="name">Electronic store</field>
     </record>
 </odoo>

--- a/headhunter/data/crm_stage.xml
+++ b/headhunter/data/crm_stage.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-    <record id="crm.stage_lead4" model="crm.stage" forcecreate="True">
+    <record id="crm.stage_lead4" model="crm.stage" forcecreate="False">
         <field name="name">Done</field>
     </record>
     <record id="crm_stage_6" model="crm.stage">

--- a/headhunter/data/hr_recruitment_stage.xml
+++ b/headhunter/data/hr_recruitment_stage.xml
@@ -4,7 +4,7 @@
         <field name="name">Reserve</field>
         <field name="sequence">3</field>
     </record>
-    <record id="hr_recruitment.stage_job2" model="hr.recruitment.stage" forcecreate="True">
+    <record id="hr_recruitment.stage_job2" model="hr.recruitment.stage" forcecreate="False">
         <field name="template_id" ref="hr_recruitment.email_template_data_applicant_interest"/>
     </record>
 </odoo>

--- a/headhunter/data/mail_template.xml
+++ b/headhunter/data/mail_template.xml
@@ -27,7 +27,7 @@
         </field>
     </record>
 
-    <record id="hr_recruitment.email_template_data_applicant_interest" model="mail.template" forcecreate="True">
+    <record id="hr_recruitment.email_template_data_applicant_interest" model="mail.template" forcecreate="False">
         <field name="name">Recruitment: Interview</field>
         <field name="body_html">
             <![CDATA[

--- a/solar_installation/data/crm_stage.xml
+++ b/solar_installation/data/crm_stage.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-    <record id="crm.stage_lead3" model="crm.stage" forcecreate="True">
+    <record id="crm.stage_lead3" model="crm.stage" forcecreate="False">
         <field name="name">Site Survey</field>
     </record>
 </odoo>

--- a/solar_installation/data/crm_team.xml
+++ b/solar_installation/data/crm_team.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-    <record id="sales_team.team_sales_department" model="crm.team" forcecreate="True">
+    <record id="sales_team.team_sales_department" model="crm.team" forcecreate="False">
         <field name="name">Solar Sales Team</field>
         <field name="invoiced_target">60000.0</field>
     </record>

--- a/solar_installation/data/helpdesk_config.xml
+++ b/solar_installation/data/helpdesk_config.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-    <record id="helpdesk.helpdesk_team1" model="helpdesk.team" forcecreate="True">
+    <record id="helpdesk.helpdesk_team1" model="helpdesk.team" forcecreate="False">
         <field name="use_credit_notes" eval="True"/>
         <field name="use_product_returns" eval="True"/>
         <field name="use_product_repairs" eval="True"/>


### PR DESCRIPTION
Some standard records may have already been deleted before the installation of an industry module that relies on it.

This commit turns off the `forcecreate` attribute on those records to avoid installation from failing.

This reverts 198908503 as forcecreate="True" is not available in 17 for a record with an external id from another module.