### PR TITLE
[FIX] *: upgrade is_favorite and display_in_project + auto_sequence

### DIFF
--- a/bar_industry/demo/project_task.xml
+++ b/bar_industry/demo/project_task.xml
@@ -14,28 +14,24 @@
             ]]></field>
         <field name="project_id" ref="project_project_1"/>
         <field name="stage_id" ref="project_task_type_1"/>
-        <field name="display_in_project" eval="True"/>
         <field name="recurring_task" eval="True"/>
     </record>
     <record id="project_task_2" model="project.task">
         <field name="name">Kitchen Cleaning</field>
         <field name="project_id" ref="project_project_2"/>
         <field name="stage_id" ref="project_task_type_1"/>
-        <field name="display_in_project" eval="True"/>
         <field name="recurring_task" eval="True"/>
     </record>
     <record id="project_task_3" model="project.task">
         <field name="name">Oven Cleaning</field>
         <field name="project_id" ref="project_project_2"/>
         <field name="stage_id" ref="project_task_type_1"/>
-        <field name="display_in_project" eval="True"/>
         <field name="recurring_task" eval="True"/>
     </record>
     <record id="project_task_4" model="project.task">
         <field name="name">Coffee Machine Cleaning</field>
         <field name="project_id" ref="project_project_2"/>
         <field name="stage_id" ref="project_task_type_1"/>
-        <field name="display_in_project" eval="True"/>
         <field name="recurring_task" eval="True"/>
     </record>
 </odoo>

--- a/custom_furniture/data/project_task.xml
+++ b/custom_furniture/data/project_task.xml
@@ -2,7 +2,6 @@
 <odoo noupdate="1">
     <record id="project_task_16" model="project.task">
         <field name="name">Manufacture Orders Creation</field>
-        <field name="display_in_project" eval="True"/>
         <field name="project_id" ref="project_project_6"/>
         <field name="stage_id" ref="project_task_type_17"/>
         <field name="state">04_waiting_normal</field>
@@ -13,7 +12,6 @@
         <field name="project_id" ref="project_project_6"/>
         <field name="stage_id" ref="project_task_type_18"/>
         <field name="state">02_changes_requested</field>
-        <field name="display_in_project" eval="True"/>
         <field name="dependent_ids" eval="[(6, 0, [ref('project_task_16')])]"/>
     </record>
     <record id="project_task_11" model="project.task">
@@ -21,13 +19,11 @@
         <field name="project_id" ref="project_project_6"/>
         <field name="stage_id" ref="project_task_type_17"/>
         <field name="state">04_waiting_normal</field>
-        <field name="display_in_project" eval="True"/>
     </record>
     <record id="project_task_13" model="project.task">
         <field name="name">Installation Follow up</field>
         <field name="project_id" ref="project_project_6"/>
         <field name="stage_id" ref="project_task_type_17"/>
-        <field name="display_in_project" eval="True"/>
         <field name="dependent_ids" eval="[(6, 0, [ref('project_task_11')])]"/>
     </record>
     <record id="project_task_6" model="project.task">
@@ -36,25 +32,21 @@
         <field name="stage_id" ref="project_task_type_17"/>
         <field name="depend_on_ids" eval="[(6, 0, [ref('project_task_11')])]"/>
         <field name="state">04_waiting_normal</field>
-        <field name="display_in_project" eval="True"/>
     </record>
     <record id="project_task_12" model="project.task">
         <field name="name">Bill of Material Preparation</field>
         <field name="project_id" ref="project_project_6"/>
         <field name="stage_id" ref="project_task_type_19"/>
-        <field name="display_in_project" eval="True"/>
     </record>
     <record id="project_task_14" model="project.task">
         <field name="name">Production Follow up</field>
         <field name="project_id" ref="project_project_6"/>
         <field name="stage_id" ref="project_task_type_17"/>
-        <field name="display_in_project" eval="True"/>
     </record>
     <record id="project_task_15" model="project.task">
         <field name="name">Purchases non-manufactured goods</field>
         <field name="project_id" ref="project_project_6"/>
         <field name="stage_id" ref="project_task_type_17"/>
-        <field name="display_in_project" eval="True"/>
         <field name="priority">1</field>
     </record>
     <record id="project_task_3" model="project.task">
@@ -62,35 +54,30 @@
         <field name="project_id" ref="project_project_6"/>
         <field name="stage_id" ref="project_task_type_21"/>
         <field name="state">03_approved</field>
-        <field name="display_in_project" eval="True"/>
     </record>
     <record id="project_task_4" model="project.task">
         <field name="name">Project Configuration</field>
         <field name="project_id" ref="project_project_6"/>
         <field name="stage_id" ref="project_task_type_21"/>
         <field name="state">03_approved</field>
-        <field name="display_in_project" eval="True"/>
     </record>
     <record id="project_task_5" model="project.task">
         <field name="name">Down Payment</field>
         <field name="project_id" ref="project_project_6"/>
         <field name="stage_id" ref="project_task_type_21"/>
         <field name="state">1_done</field>
-        <field name="display_in_project" eval="True"/>
     </record>
     <record id="project_task_7" model="project.task">
         <field name="name">Design Validation Down Payment</field>
         <field name="project_id" ref="project_project_6"/>
         <field name="stage_id" ref="project_task_type_17"/>
         <field name="state">04_waiting_normal</field>
-        <field name="display_in_project" eval="True"/>
     </record>
     <record id="project_task_9" model="project.task">
         <field name="name">Design Validation</field>
         <field name="project_id" ref="project_project_6"/>
         <field name="stage_id" ref="project_task_type_19"/>
         <field name="state">02_changes_requested</field>
-        <field name="display_in_project" eval="True"/>
         <field name="dependent_ids" eval="[(6, 0, [ref('project_task_7')])]"/>
     </record>
     <record id="project_task_8" model="project.task">
@@ -98,6 +85,5 @@
         <field name="project_id" ref="project_project_6"/>
         <field name="stage_id" ref="project_task_type_21"/>
         <field name="state">03_approved</field>
-        <field name="display_in_project" eval="True"/>
     </record>
 </odoo>

--- a/hair_salon/data/product_product.xml
+++ b/hair_salon/data/product_product.xml
@@ -27,34 +27,27 @@
         <field name="purchase_method">purchase</field>
         <field name="available_in_pos" eval="True"/>
         <field name="name">Men's Haircut</field>
-        <field name="is_favorite" eval="True"/>
         <field name="purchase_ok" eval="False"/>
         <field name="list_price">30.0</field>
         <field name="type">service</field>
         <field name="pos_categ_ids" eval="[(6, 0, [ref('pos_category_4')])]"/>
         <field name="image_1920" type="base64" file="hair_salon/static/src/binary/product_template/Men's Haircut.png"/>
     </record>
+    <record id="product_product_30_product_template" model="product.template">
+        <field name="is_favorite" eval="True"/>
+    </record>
     <record id="product_product_27" model="product.product">
         <field name="purchase_method">purchase</field>
         <field name="available_in_pos" eval="True"/>
         <field name="name">Brushing</field>
-        <field name="is_favorite" eval="True"/>
         <field name="purchase_ok" eval="False"/>
         <field name="list_price">40.0</field>
         <field name="type">service</field>
         <field name="pos_categ_ids" eval="[(6, 0, [ref('pos_category_4')])]"/>
         <field name="image_1920" type="base64" file="hair_salon/static/src/binary/product_template/Brushing.png"/>
     </record>
-    <record id="product_product_28" model="product.product">
-        <field name="purchase_method">purchase</field>
-        <field name="available_in_pos" eval="True"/>
-        <field name="name">Women's Haircut</field>
+    <record id="product_product_27_product_template" model="product.template">
         <field name="is_favorite" eval="True"/>
-        <field name="purchase_ok" eval="False"/>
-        <field name="list_price">50.0</field>
-        <field name="pos_categ_ids" eval="[(6, 0, [ref('pos_category_4')])]"/>
-        <field name="image_1920" type="base64" file="hair_salon/static/src/binary/product_template/Women's Haircut.png"/>
-        <field name="type">service</field>
     </record>
     <record id="product_product_29" model="product.product">
         <field name="product_tmpl_id" ref="product_template_24"/>
@@ -76,11 +69,13 @@
         <field name="purchase_method">purchase</field>
         <field name="available_in_pos" eval="True"/>
         <field name="name">Mustache and beard shaping</field>
-        <field name="is_favorite" eval="True"/>
         <field name="purchase_ok" eval="False"/>
         <field name="list_price">30.0</field>
         <field name="type">service</field>
         <field name="pos_categ_ids" eval="[(6, 0, [ref('pos_category_4')])]"/>
         <field name="image_1920" type="base64" file="hair_salon/static/src/binary/product_template/Mustache and beard shaping.png"/>
+    </record>
+    <record id="product_product_7_product_template" model="product.template">
+        <field name="is_favorite" eval="True"/>
     </record>
 </odoo>

--- a/hair_salon/data/product_template.xml
+++ b/hair_salon/data/product_template.xml
@@ -55,6 +55,17 @@
         <field name="pos_categ_ids" eval="[(6, 0, [ref('pos_category_3')])]"/>
         <field name="image_1920" type="base64" file="hair_salon/static/src/binary/product_template/Conditioner - 500ml.webp"/>
     </record>
+    <record id="product_template_28" model="product.template">
+        <field name="purchase_method">purchase</field>
+        <field name="available_in_pos" eval="True"/>
+        <field name="name">Women's Haircut</field>
+        <field name="is_favorite" eval="True"/>
+        <field name="purchase_ok" eval="False"/>
+        <field name="list_price">50.0</field>
+        <field name="pos_categ_ids" eval="[(6, 0, [ref('pos_category_4')])]"/>
+        <field name="image_1920" type="base64" file="hair_salon/static/src/binary/product_template/Women's Haircut.png"/>
+        <field name="type">service</field>
+    </record>
     <record id="product_template_5" model="product.template" context="{'create_product_product': False}">
         <field name="purchase_method">purchase</field>
         <field name="available_in_pos" eval="True"/>

--- a/hair_salon/i18n/hair_salon.pot
+++ b/hair_salon/i18n/hair_salon.pot
@@ -662,7 +662,7 @@ msgid "Welcome! Happy exploring."
 msgstr ""
 
 #. module: hair_salon
-#: model:product.template,name:hair_salon.product_product_28_product_template
+#: model:product.template,name:hair_salon.product_template_28
 msgid "Women's Haircut"
 msgstr ""
 

--- a/industry_restaurant/demo/project_task.xml
+++ b/industry_restaurant/demo/project_task.xml
@@ -4,35 +4,30 @@
         <field name="name">Order Ecodys</field>
         <field name="project_id" ref="project_project_1"/>
         <field name="stage_id" ref="project_task_type_1"/>
-        <field name="display_in_project" eval="True"/>
         <field name="recurring_task" eval="True"/>
     </record>
     <record id="project_task_1" model="project.task">
         <field name="name">Order VDS</field>
         <field name="project_id" ref="project_project_1"/>
         <field name="stage_id" ref="project_task_type_1"/>
-        <field name="display_in_project" eval="True"/>
         <field name="recurring_task" eval="True"/>
     </record>
     <record id="project_task_2" model="project.task">
         <field name="name">Floors</field>
         <field name="project_id" ref="project_project_2"/>
         <field name="stage_id" ref="project_task_type_1"/>
-        <field name="display_in_project" eval="True"/>
         <field name="recurring_task" eval="True"/>
     </record>
     <record id="project_task_3" model="project.task">
         <field name="name">Oven</field>
         <field name="project_id" ref="project_project_2"/>
         <field name="stage_id" ref="project_task_type_1"/>
-        <field name="display_in_project" eval="True"/>
         <field name="recurring_task" eval="True"/>
     </record>
     <record id="project_task_4" model="project.task">
         <field name="name">Dishwasher</field>
         <field name="project_id" ref="project_project_2"/>
         <field name="stage_id" ref="project_task_type_1"/>
-        <field name="display_in_project" eval="True"/>
         <field name="recurring_task" eval="True"/>
     </record>
 </odoo>

--- a/odoo_partner/data/project_task.xml
+++ b/odoo_partner/data/project_task.xml
@@ -4,90 +4,77 @@
         <field name="name">ROI Kick Off Call</field>
         <field name="project_id" ref="project_project_6"/>
         <field name="stage_id" ref="project_task_type_26"/>
-        <field name="display_in_project" eval="True"/>
     </record>
     <record id="project_task_8" model="project.task">
         <field name="name">Preparation Documentation</field>
         <field name="sequence">1</field>
         <field name="project_id" ref="project_project_6"/>
         <field name="stage_id" ref="project_task_type_26"/>
-        <field name="display_in_project" eval="True"/>
     </record>
     <record id="project_task_9" model="project.task">
         <field name="name">Preparation of workshops</field>
         <field name="sequence">2</field>
         <field name="project_id" ref="project_project_6"/>
         <field name="stage_id" ref="project_task_type_26"/>
-        <field name="display_in_project" eval="True"/>
     </record>
     <record id="project_task_13" model="project.task">
         <field name="name">WS2 -  Management of agreements</field>
         <field name="sequence">4</field>
         <field name="project_id" ref="project_project_6"/>
         <field name="stage_id" ref="project_task_type_26"/>
-        <field name="display_in_project" eval="True"/>
     </record>
     <record id="project_task_14" model="project.task">
         <field name="name">WS3 -  Sales process</field>
         <field name="sequence">5</field>
         <field name="project_id" ref="project_project_6"/>
         <field name="stage_id" ref="project_task_type_26"/>
-        <field name="display_in_project" eval="True"/>
     </record>
     <record id="project_task_15" model="project.task">
         <field name="name">WS4 -  Inventory management</field>
         <field name="sequence">6</field>
         <field name="project_id" ref="project_project_6"/>
         <field name="stage_id" ref="project_task_type_26"/>
-        <field name="display_in_project" eval="True"/>
     </record>
     <record id="project_task_16" model="project.task">
         <field name="name">WS5 -  Purchasing and reception management</field>
         <field name="sequence">7</field>
         <field name="project_id" ref="project_project_6"/>
         <field name="stage_id" ref="project_task_type_26"/>
-        <field name="display_in_project" eval="True"/>
     </record>
     <record id="project_task_17" model="project.task">
         <field name="name">WS6 - Operational management</field>
         <field name="sequence">8</field>
         <field name="project_id" ref="project_project_6"/>
         <field name="stage_id" ref="project_task_type_26"/>
-        <field name="display_in_project" eval="True"/>
     </record>
     <record id="project_task_18" model="project.task">
         <field name="name">WS7 - Accounting</field>
         <field name="sequence">9</field>
         <field name="project_id" ref="project_project_6"/>
         <field name="stage_id" ref="project_task_type_26"/>
-        <field name="display_in_project" eval="True"/>
     </record>
     <record id="project_task_19" model="project.task">
         <field name="name">WS8 - Others</field>
         <field name="project_id" ref="project_project_6"/>
         <field name="stage_id" ref="project_task_type_26"/>
-        <field name="display_in_project" eval="True"/>
     </record>
     <record id="project_task_20" model="project.task">
         <field name="name">WS9 - Marketing</field>
         <field name="sequence">11</field>
         <field name="project_id" ref="project_project_6"/>
         <field name="stage_id" ref="project_task_type_26"/>
-        <field name="display_in_project" eval="True"/>
     </record>
     <record id="project_task_21" model="project.task">
         <field name="name">WS10 - Buffer</field>
         <field name="sequence">12</field>
         <field name="project_id" ref="project_project_6"/>
         <field name="stage_id" ref="project_task_type_26"/>
-        <field name="display_in_project" eval="True"/>
     </record>
     <record id="project_task_12" model="project.task">
         <field name="name">WS1 -  Master Data &amp; Repositories</field>
         <field name="sequence">3</field>
         <field name="project_id" ref="project_project_6"/>
         <field name="stage_id" ref="project_task_type_26"/>
-        <field name="display_in_project" eval="True"/>
     </record>
     <record id="project_task_11" model="project.task">
         <field name="name">Presentation of results</field>
@@ -95,13 +82,11 @@
         <field name="project_id" ref="project_project_6"/>
         <field name="stage_id" ref="project_task_type_26"/>
         <field name="depend_on_ids" eval="[(6, 0, [ref('project_task_12'), ref('project_task_13'), ref('project_task_14'), ref('project_task_15'), ref('project_task_16'), ref('project_task_17'), ref('project_task_18'), ref('project_task_19'), ref('project_task_20'), ref('project_task_21')])]"/>
-        <field name="display_in_project" eval="True"/>
     </record>
     <record id="project_task_10" model="project.task">
         <field name="name">Analysis, estimation &amp; report preparation</field>
         <field name="sequence">13</field>
         <field name="project_id" ref="project_project_6"/>
         <field name="stage_id" ref="project_task_type_26"/>
-        <field name="display_in_project" eval="True"/>
     </record>
 </odoo>

--- a/odoo_partner/data/project_task.xml
+++ b/odoo_partner/data/project_task.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" auto_sequence="1">
     <record id="project_task_7" model="project.task">
         <field name="name">ROI Kick Off Call</field>
         <field name="project_id" ref="project_project_6"/>
@@ -7,49 +7,46 @@
     </record>
     <record id="project_task_8" model="project.task">
         <field name="name">Preparation Documentation</field>
-        <field name="sequence">1</field>
         <field name="project_id" ref="project_project_6"/>
         <field name="stage_id" ref="project_task_type_26"/>
     </record>
     <record id="project_task_9" model="project.task">
         <field name="name">Preparation of workshops</field>
-        <field name="sequence">2</field>
+        <field name="project_id" ref="project_project_6"/>
+        <field name="stage_id" ref="project_task_type_26"/>
+    </record>
+    <record id="project_task_12" model="project.task">
+        <field name="name">WS1 -  Master Data &amp; Repositories</field>
         <field name="project_id" ref="project_project_6"/>
         <field name="stage_id" ref="project_task_type_26"/>
     </record>
     <record id="project_task_13" model="project.task">
         <field name="name">WS2 -  Management of agreements</field>
-        <field name="sequence">4</field>
         <field name="project_id" ref="project_project_6"/>
         <field name="stage_id" ref="project_task_type_26"/>
     </record>
     <record id="project_task_14" model="project.task">
         <field name="name">WS3 -  Sales process</field>
-        <field name="sequence">5</field>
         <field name="project_id" ref="project_project_6"/>
         <field name="stage_id" ref="project_task_type_26"/>
     </record>
     <record id="project_task_15" model="project.task">
         <field name="name">WS4 -  Inventory management</field>
-        <field name="sequence">6</field>
         <field name="project_id" ref="project_project_6"/>
         <field name="stage_id" ref="project_task_type_26"/>
     </record>
     <record id="project_task_16" model="project.task">
         <field name="name">WS5 -  Purchasing and reception management</field>
-        <field name="sequence">7</field>
         <field name="project_id" ref="project_project_6"/>
         <field name="stage_id" ref="project_task_type_26"/>
     </record>
     <record id="project_task_17" model="project.task">
         <field name="name">WS6 - Operational management</field>
-        <field name="sequence">8</field>
         <field name="project_id" ref="project_project_6"/>
         <field name="stage_id" ref="project_task_type_26"/>
     </record>
     <record id="project_task_18" model="project.task">
         <field name="name">WS7 - Accounting</field>
-        <field name="sequence">9</field>
         <field name="project_id" ref="project_project_6"/>
         <field name="stage_id" ref="project_task_type_26"/>
     </record>
@@ -60,33 +57,23 @@
     </record>
     <record id="project_task_20" model="project.task">
         <field name="name">WS9 - Marketing</field>
-        <field name="sequence">11</field>
         <field name="project_id" ref="project_project_6"/>
         <field name="stage_id" ref="project_task_type_26"/>
     </record>
     <record id="project_task_21" model="project.task">
         <field name="name">WS10 - Buffer</field>
-        <field name="sequence">12</field>
         <field name="project_id" ref="project_project_6"/>
         <field name="stage_id" ref="project_task_type_26"/>
     </record>
-    <record id="project_task_12" model="project.task">
-        <field name="name">WS1 -  Master Data &amp; Repositories</field>
-        <field name="sequence">3</field>
+    <record id="project_task_10" model="project.task">
+        <field name="name">Analysis, estimation &amp; report preparation</field>
         <field name="project_id" ref="project_project_6"/>
         <field name="stage_id" ref="project_task_type_26"/>
     </record>
     <record id="project_task_11" model="project.task">
         <field name="name">Presentation of results</field>
-        <field name="sequence">14</field>
         <field name="project_id" ref="project_project_6"/>
         <field name="stage_id" ref="project_task_type_26"/>
         <field name="depend_on_ids" eval="[(6, 0, [ref('project_task_12'), ref('project_task_13'), ref('project_task_14'), ref('project_task_15'), ref('project_task_16'), ref('project_task_17'), ref('project_task_18'), ref('project_task_19'), ref('project_task_20'), ref('project_task_21')])]"/>
-    </record>
-    <record id="project_task_10" model="project.task">
-        <field name="name">Analysis, estimation &amp; report preparation</field>
-        <field name="sequence">13</field>
-        <field name="project_id" ref="project_project_6"/>
-        <field name="stage_id" ref="project_task_type_26"/>
     </record>
 </odoo>


### PR DESCRIPTION
**[FIX]** *: **remove display_in_project on project.task**

The field `display_in_project` is now a readonly field, and should not be used to display some subtasks and not others. There is now a filter in the view to display sub-tasks.

Ref: odoo/odoo@46adf76

**[IMP] odoo_partner: auto_sequence tasks in project**

**[FIX] hair_salon: declare is_favorite on product.template**

The field `is_favorite` is now defined on product.template only, and cannot be changed on product.product

Ref: https://github.com/odoo/odoo/commit/41d8fa352a7baec