### PR TITLE
[FIX] fmcg_store: give valid module name

### DIFF
--- a/fmcg_store/__manifest__.py
+++ b/fmcg_store/__manifest__.py
@@ -62,7 +62,7 @@ This module setup a Point of Sale (POS) system for a grocery store which is esse
     'license': 'OPL-1',
     'assets': {
         'web.assets_backend': [
-            'fcmg_store/static/src/js/my_tour.js',
+            'fmcg_store/static/src/js/my_tour.js',
         ]
     },
     'author': 'Odoo S.A.',


### PR DESCRIPTION
An error occurs due to give an invalid module name of `fmcg_store` at [1].

Link [1]: https://github.com/odoo/industry/blob/bb0f691d97bbe3fdd297d034da3b54f1cb59509b/fmcg_store/__manifest__.py#L65

Sentry-5974074704