### PR TITLE
[IMP] condominium: menu item open company's partner

### DIFF
--- a/condominium/data/ir_actions_act_window.xml
+++ b/condominium/data/ir_actions_act_window.xml
@@ -54,13 +54,10 @@
         <field name="view_mode">kanban,list,form,map,activity</field>
     </record>
     <record id="condo_act_window" model="ir.actions.act_window">
-        <field name="domain">[('ref_company_ids', 'in', allowed_company_ids)]</field>
-        <field name="help"><![CDATA[
-<p class="o_view_nocontent_smiling_face">&nbsp;Manage the condominium: buildings, properties, owners and much more!<br></p>
-]]></field>
         <field name="name">Condominium</field>
         <field name="res_model">res.partner</field>
-        <field name="view_mode">kanban,list,form,map,activity</field>
+        <field name="view_mode">form</field>
+        <field name="context">{'create': False}</field>
     </record>
     <record id="properties_act_window_view" model="ir.actions.act_window">
         <field name="context">{'search_default_x_condominium': active_id,'default_x_condominium': active_id}</field>

--- a/condominium/data/ir_actions_server.xml
+++ b/condominium/data/ir_actions_server.xml
@@ -108,4 +108,13 @@ for mr in mrs:
 ]]>
         </field>
     </record>
+    <record id="action_view_company_partner" model="ir.actions.server">
+        <field name="name">Open company partner form view</field>
+        <field name="model_id" ref="base.model_res_partner"/>
+        <field name="state">code</field>
+        <field name="code"><![CDATA[
+action = env['ir.actions.act_window']._for_xml_id('condominium.condo_act_window')
+action['res_id'] = env.company.partner_id.id]]>
+        </field>
+    </record>
 </odoo>

--- a/condominium/data/ir_ui_menu.xml
+++ b/condominium/data/ir_ui_menu.xml
@@ -40,7 +40,7 @@
         <field name="sequence">1</field>
     </record>
     <record id="infra_condo_menu" model="ir.ui.menu">
-        <field name="action" ref="condo_act_window"/>
+        <field name="action" ref="action_view_company_partner"/>
         <field name="name">Condominium</field>
         <field name="parent_id" ref="infra_menu"/>
         <field name="sequence">3</field>

--- a/condominium/data/ir_ui_view.xml
+++ b/condominium/data/ir_ui_view.xml
@@ -396,6 +396,11 @@
         <field name="priority">160</field>
         <field name="type">form</field>
         <field name="arch" type="xml">
+            <xpath expr="//sheet" position="before">
+                <div role="alert" class="alert alert-info mb-0 p-3 text-center" groups="base.group_system" invisible="not ref_company_ids">
+                    New condominiums should be created as companies from the settings <button name="%(base.action_res_company_form)d" icon="oi-arrow-right" type="action" string="Manage Companies" class="btn-link"/>
+                </div>
+            </xpath>
             <xpath expr="//button[@name='action_open_employees']" position="after">
                 <button class="oe_stat_button" icon="fa-home" type="action" name="condominium.properties_act_window_view">
                     <field widget="statinfo" name="x_condominium_account_analytic_account_count" string="Properties" />

--- a/condominium/i18n/condominium.pot
+++ b/condominium/i18n/condominium.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 18.0+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-12-11 10:12+0000\n"
-"PO-Revision-Date: 2024-12-11 10:12+0000\n"
+"POT-Creation-Date: 2024-12-23 11:55+0000\n"
+"PO-Revision-Date: 2024-12-23 11:55+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -1018,9 +1018,8 @@ msgid "Make sure that the products added are recurring."
 msgstr ""
 
 #. module: condominium
-#: model_terms:ir.actions.act_window,help:condominium.condo_act_window
-msgid ""
-"Manage the condominium: buildings, properties, owners and much more!<br>"
+#: model_terms:ir.ui.view,arch_db:condominium.res_partner_form_view
+msgid "Manage Companies"
 msgstr ""
 
 #. module: condominium
@@ -1120,6 +1119,11 @@ msgid "New"
 msgstr ""
 
 #. module: condominium
+#: model_terms:ir.ui.view,arch_db:condominium.res_partner_form_view
+msgid "New condominiums should be created as companies from the settings"
+msgstr ""
+
+#. module: condominium
 #: model:product.template,name:condominium.product_product_682_product_template
 msgid "Non-professional trustee liability"
 msgstr ""
@@ -1174,6 +1178,11 @@ msgstr ""
 #. module: condominium
 #: model:sale.order.template.line,name:condominium.sale_order_template_line_4
 msgid "One-Time Fees"
+msgstr ""
+
+#. module: condominium
+#: model:ir.actions.server,name:condominium.action_view_company_partner
+msgid "Open company partner form view"
 msgstr ""
 
 #. module: condominium


### PR DESCRIPTION
Currently, the "Condominium" is quite confusing because it allows to create a new condominium and there is no impact. The right way to create a new condominium is creating a new res.company, not a res.partner.
This commit changes the action to open the partner form linked to current company and adds a message to the admin to handle new companies with a link to the list view.

task-4418155