### PR TITLE
[IMP] construction, pharmacy_retail: remove blocking warnings

### DIFF
--- a/construction/data/res_config_settings.xml
+++ b/construction/data/res_config_settings.xml
@@ -11,7 +11,6 @@
         <field name="invoiced_timesheet" eval="'approved'"/> 
         <field name="group_warning_stock" eval="1"/> 
         <field name="group_stock_reception_report" eval="1"/> 
-        <field name="group_warning_account" eval="1"/> 
         <field name="group_sale_delivery_address" eval="1"/>
         <field name="documents_product_settings" eval="1"/>
         <field name="documents_hr_settings" eval="1"/>

--- a/pharmacy_retail/data/product_product.xml
+++ b/pharmacy_retail/data/product_product.xml
@@ -45,7 +45,6 @@
         <field name="x_manufacturer" ref="res_partner_16"/>
         <field name="image_1920" type="base64" file="pharmacy_retail/static/src/binary/product_template/19-image_1920"/>
         <field name="sale_line_warn_msg">If you Buy 2 Qty then 1 Qty will be free. (Buy 2 Get 1 Free Offer)</field>
-        <field name="sale_line_warn">warning</field>
         <field name="product_tag_ids" eval="[(6, 0, [ref('product_tag_1'), ref('product_tag_2')])]"/>
         <field name="pos_categ_ids" eval="[(6, 0, [ref('pos_category_5')])]"/>
         <field name="standard_price">30.0</field>


### PR DESCRIPTION
Warnings set by the user are no longer blocking in sale, purchase and stock. Additionally, internal warnings were completely removed from accounting.

See odoo/odoo#192211