### PR TITLE
[IMP] condominium: add button for condominium creation

### DIFF
--- a/condominium/data/ir_actions_server.xml
+++ b/condominium/data/ir_actions_server.xml
@@ -100,10 +100,7 @@ mrs = env['x_meter_reading'].search([
     ('x_meter_id', '=', record.x_meter_id.id)], order='x_date')
 previous_mr = False
 for mr in mrs:
-    if previous_mr:
-        mr['x_usage'] = mr['x_quantity'] - previous_mr['x_quantity']
-    else :
-        mr['x_usage'] = 0
+    mr['x_usage'] = mr['x_quantity'] - previous_mr['x_quantity'] if previous_mr else 0
     previous_mr = mr
 ]]>
         </field>
@@ -117,4 +114,26 @@ action = env['ir.actions.act_window']._for_xml_id('condominium.condo_act_window'
 action['res_id'] = env.company.partner_id.id]]>
         </field>
     </record>
+    <record id="ir_action_create_condominium" model="ir.actions.server">
+        <field name="code"><![CDATA[env['res.company'].create({
+    'partner_id': record.id,
+    'name': record.name,
+    'street': record.street,
+    'street2': record.street2,
+    'zip': record.zip,
+    'city': record.city,
+    'state_id': record.state_id.id,
+    'country_id': record.country_id.id,
+    'vat': record.vat,
+    'phone': record.phone,
+    'mobile': record.mobile,
+    'email': record.email,
+    'website': record.website,
+    'logo': record.image_1920,
+})
+action = {'type': 'ir.actions.client', 'tag': 'reload'}]]></field>
+        <field name="model_id" ref="base.model_res_partner"/>
+        <field name="state">code</field>
+        <field name="name">Create Condominium</field>
+  </record>
 </odoo>

--- a/condominium/data/ir_ui_view.xml
+++ b/condominium/data/ir_ui_view.xml
@@ -400,6 +400,9 @@
                 <div role="alert" class="alert alert-info" groups="base.group_system" invisible="not ref_company_ids">
                     New condominiums should be created as companies from the settings <button name="%(base.action_res_company_form)d" icon="oi-arrow-right" type="action" string="Manage Companies" class="btn-link"/>
                 </div>
+                <header>
+                    <button string="Create Condominium" name="%(ir_action_create_condominium)d" type="action" invisible="company_type == 'person' or ref_company_ids"/>
+                </header>
             </xpath>
             <xpath expr="//button[@name='action_open_employees']" position="after">
                 <button class="oe_stat_button" icon="fa-home" type="action" name="condominium.properties_act_window_view">

--- a/condominium/i18n/condominium.pot
+++ b/condominium/i18n/condominium.pot
@@ -490,6 +490,12 @@ msgid "Country"
 msgstr ""
 
 #. module: condominium
+#: model:ir.actions.server,name:condominium.ir_action_create_condominium
+#: model_terms:ir.ui.view,arch_db:condominium.res_partner_form_view
+msgid "Create Condominium"
+msgstr ""
+
+#. module: condominium
 #: model_terms:ir.actions.act_window,help:condominium.buildings_act_window
 msgid "Create and manage the buildings that compose this condominium<br>"
 msgstr ""


### PR DESCRIPTION
This commit simplifies the condominium creation process by:

* Adding a "Create Condominium" button to the `res.partner` form.
* Added server action for the button to create a new condominium record.
* Setting visibility conditions for the button domain.
* Triggering a form refresh after creation to ensure visibility.

This improves the workflow for users by allowing them to create condominiums directly from the partner form.

task-4482863