### PR TITLE
[FIX] billboard_rental: don't edit subscriptions from billboard

### DIFF
--- a/billboard_rental/data/ir_model_fields.xml
+++ b/billboard_rental/data/ir_model_fields.xml
@@ -13,6 +13,7 @@
         <field name="model_id" ref="analytic.model_account_analytic_account"/>
         <field name="relation">sale.order</field>
         <field name="relation_field">analytic_account_id</field>
+        <field name="readonly" eval="True"/>
     </record>
     <record id="x_state_field" model="ir.model.fields">
         <field name="name">x_is_available</field>


### PR DESCRIPTION
When adding a subscription in the sub tab of a billboard form view, a traceback appears. As the goal of the tab is to display the linked subscriptions (and not create new ones), the field is now marked as readonly. 

task-4501934