### PR TITLE
[FIX] condominium: different views for properties and analytic accounts

### DIFF
--- a/condominium/data/ir_actions_act_window.xml
+++ b/condominium/data/ir_actions_act_window.xml
@@ -61,7 +61,7 @@
     </record>
     <record id="properties_act_window_view" model="ir.actions.act_window">
         <field name="context">{'search_default_x_condominium': active_id,'default_x_condominium': active_id}</field>
-        <field name="domain">[('x_condominium', '=', active_id)]</field>
+        <field name="domain">[('x_condominium', '=', active_id), ('x_is_a_property','=', True)]</field>
         <field name="name">Properties</field>
         <field name="res_model">account.analytic.account</field>
     </record>
@@ -83,37 +83,13 @@
         <field name="name">Properties</field>
         <field name="res_model">account.analytic.account</field>
     </record>
-    <record id="properties_building_act_window" model="ir.actions.act_window">
-        <field name="context">{'search_default_x_building': active_id,'default_x_building': active_id}</field>
-        <field name="domain">[('x_building', '=', active_id)]</field>
-        <field name="name">Properties</field>
-        <field name="res_model">account.analytic.account</field>
-      </record>
     <record id="properties_tags_act_window" model="ir.actions.act_window">
         <field name="name">Properties Tags</field>
         <field name="res_model">x_properties_tag</field>
     </record>
-    <record id="props_act_window" model="ir.actions.act_window">
-        <field name="context">{'search_default_x_parent': active_id,'default_x_parent': active_id}</field>
-        <field name="domain">[('x_parent', '=', active_id)]</field>
-        <field name="name">Properties</field>
-        <field name="res_model">account.analytic.account</field>
-    </record>
     <record id="props_build_act_window" model="ir.actions.act_window">
         <field name="context">{'search_default_x_building': active_id,'default_x_building': active_id}</field>
         <field name="domain">[('x_building', '=', active_id)]</field>
-        <field name="name">Properties</field>
-        <field name="res_model">account.analytic.account</field>
-    </record>
-    <record id="prop_condo_act_window" model="ir.actions.act_window">
-        <field name="context">{'search_default_x_condominium': active_id,'default_x_condominium': active_id}</field>
-        <field name="domain">[('x_condominium', '=', active_id)]</field>
-        <field name="name">Properties</field>
-        <field name="res_model">account.analytic.account</field>
-    </record>
-    <record id="prop_own_act_window" model="ir.actions.act_window">
-        <field name="context">{'search_default_x_owner': active_id,'default_x_owner': active_id}</field>
-        <field name="domain">[('x_owner', '=', active_id)]</field>
         <field name="name">Properties</field>
         <field name="res_model">account.analytic.account</field>
     </record>
@@ -134,11 +110,5 @@
         <field name="name">Distribution Keys</field>
         <field name="res_model">product.pricelist</field>
         <field name="view_mode">list,kanban,form</field>
-    </record>
-    <record id="properties_action_window" model="ir.actions.act_window">
-        <field name="context">{'search_default_partner_id': active_id,'default_partner_id': active_id}</field>
-        <field name="domain">[('partner_id', '=', active_id)]</field>
-        <field name="name">Properties</field>
-        <field name="res_model">account.analytic.account</field>
     </record>
 </odoo>

--- a/condominium/data/ir_ui_view.xml
+++ b/condominium/data/ir_ui_view.xml
@@ -138,7 +138,7 @@
     <record id="analytic_account_custom_form_view" model="ir.ui.view">
         <field name="name">analytic.analytic.account.form customization</field>
         <field name="inherit_id" ref="analytic.view_account_analytic_account_form" />
-        <field name="mode">extension</field>
+        <field name="mode">primary</field>
         <field name="active" eval="True"/>
         <field name="model">account.analytic.account</field>
         <field name="priority">400</field>
@@ -463,7 +463,6 @@
             </xpath>
         </field>
     </record>
-
     <record id="res_partner_select_custom" model="ir.ui.view">
         <field name="name">res.partner.select customization</field>
         <field name="inherit_id" ref="base.view_res_partner_filter"/>
@@ -477,5 +476,33 @@
                 <field name="x_companies" string="Condominiums"/>
             </field>
         </field>
+    </record>
+    <record id="properties_act_window_view" model="ir.actions.act_window">
+        <field name="view_ids" eval="[
+            (5, 0, 0),
+            (0, 0, {'view_mode': 'kanban', 'view_id': ref('analytic_account_custom_kanban_view')}),
+            (0, 0, {'view_mode': 'form', 'view_id': ref('analytic_account_custom_form_view')}),
+        ]"/>
+    </record>
+    <record id="properties_parent_act_window" model="ir.actions.act_window">
+        <field name="view_ids" eval="[
+            (5, 0, 0),
+            (0, 0, {'view_mode': 'kanban', 'view_id': ref('analytic_account_custom_kanban_view')}),
+            (0, 0, {'view_mode': 'form', 'view_id': ref('analytic_account_custom_form_view')}),
+        ]"/>
+    </record>
+    <record id="props_build_act_window" model="ir.actions.act_window">
+        <field name="view_ids" eval="[
+            (5, 0, 0),
+            (0, 0, {'view_mode': 'kanban', 'view_id': ref('analytic_account_custom_kanban_view')}),
+            (0, 0, {'view_mode': 'form', 'view_id': ref('analytic_account_custom_form_view')}),
+        ]"/>
+    </record>
+    <record id="properties_act_window" model="ir.actions.act_window">
+        <field name="view_ids" eval="[
+            (5, 0, 0),
+            (0, 0, {'view_mode': 'kanban', 'view_id': ref('analytic_account_custom_kanban_view')}),
+            (0, 0, {'view_mode': 'form', 'view_id': ref('analytic_account_custom_form_view')}),
+        ]"/>
     </record>
 </odoo>

--- a/condominium/i18n/condominium.pot
+++ b/condominium/i18n/condominium.pot
@@ -1396,14 +1396,9 @@ msgstr ""
 
 #. module: condominium
 #: model:account.analytic.plan,name:condominium.account_analytic_plan_2
-#: model:ir.actions.act_window,name:condominium.prop_condo_act_window
-#: model:ir.actions.act_window,name:condominium.prop_own_act_window
 #: model:ir.actions.act_window,name:condominium.properties_act_window
 #: model:ir.actions.act_window,name:condominium.properties_act_window_view
-#: model:ir.actions.act_window,name:condominium.properties_action_window
-#: model:ir.actions.act_window,name:condominium.properties_building_act_window
 #: model:ir.actions.act_window,name:condominium.properties_parent_act_window
-#: model:ir.actions.act_window,name:condominium.props_act_window
 #: model:ir.actions.act_window,name:condominium.props_build_act_window
 #: model:ir.model.fields,field_description:condominium.x_properties_ids
 #: model:ir.ui.menu,name:condominium.conf_prop_menu


### PR DESCRIPTION
Before this commit, the view for properties (using specific analytic account) was shared with other analytic accounts. This prevents creating new analytic accounts that are not properties.
This commit solves the issue by using a new primary form view, linked to all window actions for properties.
It also removes window actions that were not used anymore.

task-4535537