### PR TITLE
[FIX] pharmacy_retail: fix partner form view

### DIFF
--- a/pharmacy_retail/data/ir_ui_view.xml
+++ b/pharmacy_retail/data/ir_ui_view.xml
@@ -82,7 +82,7 @@
         <field name="active" eval="True"/>
         <field name="priority">360</field>
         <field name="arch" type="xml">
-            <xpath expr="//field[@name='vat']" position="after">
+            <xpath expr="//group/group" position="inside">  <!-- vat field is unstable -->
                 <field name="x_drug_license_number" invisible="not x_is_a_manufacturer"/>
                 <field name="x_drug_license_date" invisible="not x_is_a_manufacturer"  options='{"warn_future":false}'/>
                 <field name="x_registration_number" invisible="not x_is_a_doctor"/>


### PR DESCRIPTION
Since `vat` field is affected by a lot of modules, the xpath on it is unstable. This commit fixes the inherited view by inserting new fields in the first group, not relying on a specific field anymore.

Fixes #420