### PR TITLE
[FIX] industry_real_estate: Keep properties domain on refresh.

### DIFF
--- a/industry_real_estate/data/ir_actions_act_window.xml
+++ b/industry_real_estate/data/ir_actions_act_window.xml
@@ -31,6 +31,7 @@
         <field name="name">Properties</field>
         <field name="res_model">account.analytic.account</field>
         <field name="view_mode">kanban,list,form</field>
+        <field name="domain">[('x_is_property', '=', True)]</field>
         <field name="view_ids" eval="[
             (5, 0, 0),
             (0, 0, {'view_mode': 'kanban', 'view_id': ref('property_kanban_view')}),

--- a/industry_real_estate/data/ir_actions_server.xml
+++ b/industry_real_estate/data/ir_actions_server.xml
@@ -6,10 +6,8 @@
         <field name="state">code</field>
         <field name="code">
 <![CDATA[
-plan_id = env.ref('industry_real_estate.analytic_plan_properties').id
 action = env['ir.actions.actions']._for_xml_id('industry_real_estate.action_properties')
-action['domain'] = [('plan_id', '=', plan_id)]
-action['context'] = {'default_plan_id': plan_id}
+action['context'] = {'default_plan_id': env.ref('industry_real_estate.analytic_plan_properties').id}
 ]]>
         </field>
     </record>


### PR DESCRIPTION
The properties domain was lost when refreshing the page, causing the view to display incorrect records.

This commit explicitly adds a `domain` field to ensure that properties are correctly filtered based on `plan_id`, maintaining consistency when the page is refreshed.

[opw-4417368](https://www.odoo.com/odoo/my-tasks/4417368)
Related commit: https://github.com/odoo/industry/commit/1718eaab37690cae2c1e9fc73f5065e20c562b7e