### PR TITLE
[FIX] beverage_distributor,micro_brewery: remove useless filter_domain

### DIFF
--- a/beverage_distributor/data/base_automation.xml
+++ b/beverage_distributor/data/base_automation.xml
@@ -30,7 +30,6 @@
         <field name="model_id" ref="product.model_product_template"/>
         <field name="trigger_field_ids" eval="[(6, 0, [ref('product.field_product_template__categ_id')])]"/>
         <field name="on_change_field_ids" eval="[(6, 0, [ref('product.field_product_template__categ_id')])]"/>
-        <field name="filter_domain">[('x_is_a_deposit', '=', False)]</field>
         <field name="trigger">on_change</field>
     </record>
 </odoo>

--- a/micro_brewery/data/base_automation.xml
+++ b/micro_brewery/data/base_automation.xml
@@ -30,7 +30,6 @@
         <field name="model_id" ref="product.model_product_template"/>
         <field name="trigger_field_ids" eval="[(6, 0, [ref('product.field_product_template__categ_id')])]"/>
         <field name="on_change_field_ids" eval="[(6, 0, [ref('product.field_product_template__categ_id')])]"/>
-        <field name="filter_domain">[('x_is_a_deposit', '=', False)]</field>
         <field name="trigger">on_change</field>
     </record>
 </odoo>


### PR DESCRIPTION
`filter_domain` has no effect on `on_change` triggered automation rules. This behaviour will change in saas-18.3.`