### PR TITLE
[FIX] beverage_distributor,micro_brewery: adapt filter_domain

### DIFF
--- a/beverage_distributor/data/base_automation.xml
+++ b/beverage_distributor/data/base_automation.xml
@@ -30,7 +30,7 @@
         <field name="model_id" ref="product.model_product_template"/>
         <field name="trigger_field_ids" eval="[(6, 0, [ref('product.field_product_template__categ_id')])]"/>
         <field name="on_change_field_ids" eval="[(6, 0, [ref('product.field_product_template__categ_id')])]"/>
-        <field name="filter_domain">[('x_is_a_deposit', '=', False)]</field>
+        <field name="filter_domain">[('x_is_a_deposit', '=', True)]</field>
         <field name="trigger">on_change</field>
     </record>
 </odoo>

--- a/beverage_distributor/data/ir_actions_server.xml
+++ b/beverage_distributor/data/ir_actions_server.xml
@@ -72,8 +72,7 @@ record['supplier_taxes_id'] = [(6, 0, (supplier_taxe).ids)]
     </record>
     <record id="action_make_deposit_storable_delivery_invoice" model="ir.actions.server">
         <field name="code"><![CDATA[
-if record.x_is_a_deposit:
-    record.write({'invoice_policy':'delivery', 'type': 'consu', 'is_storable': True})
+record.write({'invoice_policy':'delivery', 'type': 'consu', 'is_storable': True})
 ]]></field>
         <field name="model_id" ref="product.model_product_template"/>
         <field name="state">code</field>

--- a/micro_brewery/data/base_automation.xml
+++ b/micro_brewery/data/base_automation.xml
@@ -30,7 +30,7 @@
         <field name="model_id" ref="product.model_product_template"/>
         <field name="trigger_field_ids" eval="[(6, 0, [ref('product.field_product_template__categ_id')])]"/>
         <field name="on_change_field_ids" eval="[(6, 0, [ref('product.field_product_template__categ_id')])]"/>
-        <field name="filter_domain">[('x_is_a_deposit', '=', False)]</field>
+        <field name="filter_domain">[('x_is_a_deposit', '=', True)]</field>
         <field name="trigger">on_change</field>
     </record>
 </odoo>

--- a/micro_brewery/data/ir_actions_server.xml
+++ b/micro_brewery/data/ir_actions_server.xml
@@ -72,8 +72,7 @@ record['supplier_taxes_id'] = [(6, 0, (supplier_taxe).ids)]
     </record>
     <record id="action_make_deposit_storable_delivery_invoice" model="ir.actions.server">
         <field name="code"><![CDATA[
-if record.x_is_a_deposit:
-    record.write({'invoice_policy':'delivery', 'type': 'consu', 'is_storable': True})
+record.write({'invoice_policy':'delivery', 'type': 'consu', 'is_storable': True})
 ]]></field>
         <field name="model_id" ref="product.model_product_template"/>
         <field name="state">code</field>


### PR DESCRIPTION
Before this commit*, `filter_domain` had no effect on `on_change` triggered automation rules. Afterwards, it is taken into account and this `filter_domain` needs to be adapted.

*https://github.com/odoo/odoo/commit/64d6b25aa763a27c74eb479210a1313131c654e9