### PR TITLE
[IMP] tests: allow state on sale.order

### DIFF
--- a/tests/test_generic/tests/test_xml.py
+++ b/tests/test_generic/tests/test_xml.py
@@ -50,7 +50,7 @@ USELESS_FIELDS = {
     'res.partner': ['tz'],
     'sale.order': [
         'access_token', 'date_order', 'health', 'origin', 'partner_invoice_id', 'partner_shipping_id',
-        'state', 'validity_date', 'warehouse_id',
+        'validity_date', 'warehouse_id',
     ],
     'sale.order.line': ['qty_delivered'],
     'sign.template': ['name'],


### PR DESCRIPTION
Before this commit, `state` was not provided on the `sale.order` records because the state was handled by actions (like `action_confirm`) to generate tasks / projects / ... This method requires to manually adapt generated records.
This commit allows to handle the state on the `sale.order` record directly and will allow to handle generated records directly from the exporter.