### PR TITLE
[UPG] *: remove partner_gid and additional_info on res.partner

### DIFF
--- a/condominium/demo/res_partner.xml
+++ b/condominium/demo/res_partner.xml
@@ -72,7 +72,6 @@
         <field name="phone">+1 972-940-6000</field>
         <field name="street">5959 Las Colinas Boulevard</field>
         <field name="is_company" eval="True"/>
-        <field name="partner_gid">4504</field>
         <field name="state_id" ref="base.state_us_44"/>
         <field name="image_1920" type="base64" file="condominium/static/src/binary/res_partner/28-image_1920"/>
         <field name="zip">75039</field>
@@ -85,7 +84,6 @@
         <field name="phone">+1 212-770-7000</field>
         <field name="street">175 Water Street</field>
         <field name="is_company" eval="True"/>
-        <field name="partner_gid">225008</field>
         <field name="state_id" ref="base.state_us_27"/>
         <field name="zip">10038</field>
     </record>
@@ -198,7 +196,6 @@
         <field name="phone">+1 212-554-1234</field>
         <field name="street">1290 6th Avenue</field>
         <field name="is_company" eval="True"/>
-        <field name="partner_gid">3824</field>
         <field name="state_id" ref="base.state_us_27"/>
         <field name="email">actionnaires.web@axa.com</field>
         <field name="zip">10104</field>

--- a/handyman/demo/res_partner.xml
+++ b/handyman/demo/res_partner.xml
@@ -4,7 +4,6 @@
         <field name="name">Insurance Group</field>
         <field name="image_1920" type="base64" file="handyman/static/src/binary/res_partner/16-image_1920"/>
         <field name="is_company" eval="True"/>
-        <field name="partner_gid">26948</field>
     </record>
     <record id="res_partner_23" model="res.partner">
         <field name="name">Amanda white</field>
@@ -33,7 +32,6 @@
         <field name="website">http://kennerdentalgroup.com</field>
         <field name="phone">+1 206-248-1339</field>
         <field name="is_company" eval="True"/>
-        <field name="partner_gid">448610</field>
     </record>
     <record id="res_partner_24" model="res.partner">
         <field name="name">Chris Taylor</field>
@@ -91,7 +89,6 @@
         <field name="name">Northview Apartment REIT</field>
         <field name="image_1920" type="base64" file="handyman/static/src/binary/res_partner/15-image_1920"/>
         <field name="is_company" eval="True"/>
-        <field name="partner_gid">33795</field>
     </record>
     <record id="res_partner_26" model="res.partner">
         <field name="name">Emily Johnson</field>

--- a/pharmacy_retail/data/res_partner.xml
+++ b/pharmacy_retail/data/res_partner.xml
@@ -21,7 +21,6 @@
         <field name="zip">27703</field>
         <field name="state_id" ref="base.state_us_28"/>
         <field name="country_id" ref="base.us"/>
-        <field name="partner_gid">113460</field>
         <field name="website">http://ncgskfoundation.org</field>
         <field name="is_company" eval="True"/>
     </record>
@@ -36,7 +35,6 @@
         <field name="zip">560100</field>
         <field name="state_id" ref="base.state_in_ka"/>
         <field name="country_id" ref="base.in"/>
-        <field name="partner_gid">124115</field>
         <field name="website">http://biocon.com</field>
         <field name="is_company" eval="True"/>
     </record>
@@ -49,7 +47,6 @@
         <field name="city">Ahmedabad</field>
         <field name="state_id" ref="base.state_in_gj"/>
         <field name="country_id" ref="base.in"/>
-        <field name="partner_gid">129146</field>
         <field name="website">http://intaspharma.com</field>
         <field name="is_company" eval="True"/>
     </record>
@@ -61,7 +58,6 @@
         <field name="x_is_a_manufacturer" eval="True"/>
         <field name="city">Paris</field>
         <field name="country_id" ref="base.fr"/>
-        <field name="partner_gid">6726</field>
         <field name="website">http://medday-pharma.com</field>
         <field name="is_company" eval="True"/>
     </record>
@@ -77,7 +73,6 @@
         <field name="zip">77478</field>
         <field name="state_id" ref="base.state_us_44"/>
         <field name="country_id" ref="base.us"/>
-        <field name="partner_gid">110986</field>
         <field name="website">http://himalayausa.com</field>
         <field name="is_company" eval="True"/>
     </record>

--- a/software_reseller/demo/res_partner.xml
+++ b/software_reseller/demo/res_partner.xml
@@ -8,7 +8,6 @@
         <field name="vat">BE0477472701</field>
         <field name="country_id" ref="base.be" />
         <field name="zip">1160</field>
-        <field name="partner_gid">3</field>
         <field name="image_1920" type="base64" file="software_reseller/static/src/binary/res_partner/10-image_1920" />
     </record>
     <record id="res_partner_11" model="res.partner">
@@ -17,9 +16,7 @@
         <field name="phone">+41 21 619 10 10</field>
         <field name="website">http://camptocamp.com</field>
         <field name="country_id" ref="base.de" />
-        <field name="partner_gid">11784</field>
         <field name="image_1920" type="base64" file="software_reseller/static/src/binary/res_partner/11-image_1920" />
-        <field name="additional_info">{"name": "Camptocamp", "company_type": "private", "logo": "https://logo.clearbit.com/camptocamp.com", "sector": ["Information Technology", "Software &amp; Services", "Internet Software &amp; Services", "Internet Software &amp; Services"], "sector_primary": "Information Technology", "industry": "Internet Software &amp; Services", "industry_group": "Software &amp; Services", "sub_industry": "Internet Software &amp; Services", "founded_year": 2001, "description": "We are offering innovative Open Source solutions for the implementation of GIS, Management Software (ERP Odoo) and IT Infrastructure.", "employees": 150.0, "annual_revenue": 0.0, "estimated_annual_revenue": "$10M-$50M", "twitter": "camptocamp", "facebook": "207324185960679", "linkedin": "company/camptocamp-sa", "crunchbase": "organization/camptocamp", "tech": ["Nginx", "Google Apps", "Google Analytics", "Facebook Connect", "Twitter Button", "Google Tag Manager", "Recaptcha", "Aws Route 53", "Amazon Ses", "Digital Ocean", "Atlassian Jira", "Filemaker Pro", "Apache Http Server", "Mysql", "Apache Tomcat", "Microsoft Dynamics", "Github", "Neo4J", "Sap Crm", "Mongodb", "Sap Crystal Reports", "Postgresql", "Oracle Hyperion", "Atlassian Confluence", "Talend", "Rabbitmq", "Couchdb", "Grafana", "Servicenow"], "timezone": "Europe/Berlin", "timezone_url": "https://time.is/Berlin", "phone_numbers": ["+41 21 619 10 10", "+33 1 83 71 75 00", "+33 4 58 48 20 00", "+49 89 262089900", "+49 89 26208990", "+49 89 262089", "+41 62 544 03 70"], "email": ["info@camptocamp.com", "info@camptocamp.de", "job@camptocamp.com"], "twitter_bio": "Open Source specialist, innovative company in the software integration geospatial, business &amp; infrastructure solutions, in the provision &amp; renewal of licenses.", "twitter_followers": 2649}</field>
     </record>
     <record id="res_partner_12" model="res.partner">
         <field name="name">Stibbe</field>
@@ -31,7 +28,6 @@
         <field name="city">Amsterdam</field>
         <field name="country_id" ref="base.nl" />
         <field name="zip">1077 WM</field>
-        <field name="partner_gid">95314</field>
         <field name="image_1920" type="base64" file="software_reseller/static/src/binary/res_partner/12-image_1920" />
     </record>
     <record id="res_partner_9" model="res.partner">
@@ -44,7 +40,6 @@
         <field name="state_id" ref="base.state_us_44" />
         <field name="country_id" ref="base.us" />
         <field name="zip">78741</field>
-        <field name="partner_gid">605</field>
         <field name="supplier_rank">1</field>
         <field name="image_1920" type="base64" file="software_reseller/static/src/binary/res_partner/9-image_1920" />
     </record>


### PR DESCRIPTION
Since this commit*, these two fields are not defined on res.partner anymore. This commit removes their definition.

*https://github.com/odoo/odoo/commit/7814c1915d7c11ce9858dd5889e9871628f52096