### PR TITLE
[UPG] shoe_maker: ir_action_server requires state (no default)

### DIFF
--- a/shoe_maker/data/ir_actions_server.xml
+++ b/shoe_maker/data/ir_actions_server.xml
@@ -7,6 +7,7 @@
     </record>
     <record id="update_stage_cancel" model="ir.actions.server">
         <field name="model_id" ref="project.model_project_task"/>
+        <field name="state">object_write</field>
         <field name="update_path">stage_id</field>
         <field name="crud_model_id" ref="project.model_project_task"/>
         <field name="update_field_id" ref="project.field_project_task__stage_id"/>
@@ -15,6 +16,7 @@
     </record>
     <record id="update_state_done" model="ir.actions.server">
         <field name="model_id" ref="project.model_project_task"/>
+        <field name="state">object_write</field>
         <field name="update_path">state</field>
         <field name="crud_model_id" ref="project.model_project_task"/>
         <field name="update_field_id" ref="project.field_project_task__state"/>
@@ -23,6 +25,7 @@
     </record>
     <record id="update_state_cancel" model="ir.actions.server">
         <field name="model_id" ref="project.model_project_task"/>
+        <field name="state">object_write</field>
         <field name="update_path">state</field>
         <field name="crud_model_id" ref="project.model_project_task"/>
         <field name="update_field_id" ref="project.field_project_task__state"/>


### PR DESCRIPTION
Since this commit*, all ir.action.server records need a state (no default value anymore). This commit adds the previous default value for existing server actions.

*https://github.com/odoo/odoo/commit/46cf1dc327cbd8809b35093def8287db9e31b3cd