### PR TITLE
[FIX] fitness: disabled restrict categories in pos configuration

### DIFF
--- a/fitness/data/pos_config.xml
+++ b/fitness/data/pos_config.xml
@@ -6,7 +6,6 @@
         <field name="iface_print_auto" eval="True"/>
         <field name="ship_later" eval="True"/>
         <field name="customer_display_type">local</field>
-        <field name="limit_categories">True</field>
         <field name="down_payment_product_id" ref="pos_sale.default_downpayment_product"/>
     </record>
     <record model="pos.config" id="pos_config_fitness_center">


### PR DESCRIPTION
In this PR, we have disabled the Restrict Categories setting.

Task-4700036