### PR TITLE
[UPG] *: ir.filter field user_id became user_ids

### DIFF
--- a/industry_real_estate/data/ir_filters.xml
+++ b/industry_real_estate/data/ir_filters.xml
@@ -1,10 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
 
-    <record id="filter_default_property_availability" model="ir.filters" forcecreate="0">
+    <record id="filter_default_property_availability" model="ir.filters">
         <field name="name">Availability</field>
         <field name="model_id">sale.order</field>
-        <field name="user_id" eval="False"/>
         <field name="is_default" eval="True"/>
         <field name="action_id" ref="action_availability"/>
         <field name="domain">[]</field>

--- a/non_profit_organization/data/filters.xml
+++ b/non_profit_organization/data/filters.xml
@@ -1,10 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
 
-    <record id="filter_default_crm_pipeline" model="ir.filters" forcecreate="0">
+    <record id="filter_default_crm_pipeline" model="ir.filters">
         <field name="name">Pipeline</field>
         <field name="model_id">crm.lead</field>
-        <field name="user_id" eval="False"/>
         <field name="is_default" eval="True"/>
         <field name="action_id" ref="crm.crm_lead_action_pipeline"/>
         <field name="domain">[]</field>
@@ -12,17 +11,16 @@
         <field name="sort">[]</field>
     </record>
 
-    <record id="filter_domation_payments" model="ir.filters" forcecreate="0">
+    <record id="filter_domation_payments" model="ir.filters">
         <field name="name">Donations</field>
         <field name="model_id">account.payment</field>
-        <field name="user_id" eval="False"/>
         <field name="action_id" ref="account.action_account_payments"/>
         <field name="domain">[("is_donation", "=", True)]</field>
         <field name="context">{'group_by': []}</field>
         <field name="sort">[]</field>
     </record>
 
-    <record id="mailing_filter_payming_members" model="mailing.filter" forcecreate="0">
+    <record id="mailing_filter_payming_members" model="mailing.filter">
         <field name="name">Payming Members</field>
         <field name="mailing_model_id" ref="sale.model_sale_order"/>
         <field name="mailing_domain">["&amp;", "&amp;", ("state", "!=", "cancel"), "|", ("subscription_state", "=", "3_progress"), ("subscription_state", "=", "4_paused"), ("order_line.product_id.name", "ilike", "Member")]</field>


### PR DESCRIPTION
This commit* changes the user_id (m2o) field to user_ids (m2m) field. In industry occurences, the filter is shared so there is no need to define the user anyway, so the field definition is removed.

*https://github.com/odoo/odoo/commit/414e55cf7c3971a7ba0a7c96855db4c23e77a5c4