### PR TITLE
[FIX] industry_real_estate: fix navigation on website

### DIFF
--- a/industry_real_estate/data/website_menu.xml
+++ b/industry_real_estate/data/website_menu.xml
@@ -8,7 +8,7 @@
         <field name="controller_page_id" ref="website_controller_page_1"/>
         <field name="parent_id" model="website.menu" eval="obj().search([
                 ('website_id', '=', ref('website.default_website')),
-                ('url', '=', '/default-main-menu'),
+                ('url', '=', '#'),
         ]).id"/>
         <field name="website_id" ref="website.default_website"/>
     </record>

--- a/industry_real_estate/demo/website_menu.xml
+++ b/industry_real_estate/demo/website_menu.xml
@@ -6,7 +6,7 @@
         <field name="page_id" ref="website_page_9"/>
         <field name="parent_id" model="website.menu" eval="obj().search([
                 ('website_id', '=', ref('website.default_website')),
-                ('url', '=', '/default-main-menu'),
+                ('url', '=', '#'),
         ]).id"/>
         <field name="website_id" ref="website.default_website"/>
     </record>


### PR DESCRIPTION
In this PR we have fixed broken navigation for the **"About Us"** and **"Properties"** menu 
items on the website.

Task-4700144