### PR TITLE
[FIX] corporate_gifts: fix tags issue when submit the contact us form

### DIFF
--- a/corporate_gifts/data/website_view.xml
+++ b/corporate_gifts/data/website_view.xml
@@ -227,4 +227,8 @@
             </t>
         </field>
     </record>
+    <function model="ir.model.fields" name="formbuilder_whitelist">
+        <value eval="'crm.lead'"/>
+        <value eval="['tag_ids']"/>
+      </function>
 </odoo>


### PR DESCRIPTION
In this PR we have fixed the tags issue when we submit the contact us form it should display as tags but it is showing id in the lead.

Task-4720204