### PR TITLE
[UPG] *: remove customer_display_type on pos.config

### DIFF
--- a/electronic_store/data/pos_config.xml
+++ b/electronic_store/data/pos_config.xml
@@ -3,7 +3,6 @@
     <record id="pos_config_electronic_store" model="pos.config">
         <field name="name">Electronic Store</field>
         <field name="iface_tipproduct" eval="True"/>
-        <field name="customer_display_type">local</field>
         <field name="iface_print_auto" eval="True"/>
         <field name="ship_later" eval="True"/>
         <field name="down_payment_product_id" ref="pos_sale.default_downpayment_product"/>

--- a/eyewear_shop/data/pos_config.xml
+++ b/eyewear_shop/data/pos_config.xml
@@ -3,7 +3,6 @@
     <record id="pos_config_eyewear_shop" model="pos.config">
         <field name="name">Eyewear Shop</field>
         <field name="iface_tipproduct" eval="True"/>
-        <field name="customer_display_type">local</field>
         <field name="iface_print_auto" eval="True"/>
         <field name="ship_later" eval="True"/>
         <field name="limit_categories">True</field>

--- a/fitness/data/pos_config.xml
+++ b/fitness/data/pos_config.xml
@@ -5,7 +5,6 @@
         <field name="iface_tipproduct" eval="True"/>
         <field name="iface_print_auto" eval="True"/>
         <field name="ship_later" eval="True"/>
-        <field name="customer_display_type">local</field>
         <field name="down_payment_product_id" ref="pos_sale.default_downpayment_product"/>
     </record>
     <record model="pos.config" id="pos_config_fitness_center">

--- a/hardware_shop/data/pos_config.xml
+++ b/hardware_shop/data/pos_config.xml
@@ -4,7 +4,6 @@
         <field name="name">Hardware Shop</field>
         <field name="iface_tipproduct" eval="True"/>
         <field name="pricelist_id" ref="product_pricelist_2"/>
-        <field name="customer_display_type">local</field>
         <field name="iface_print_auto" eval="True"/>
         <field name="available_pricelist_ids" eval="[(6, 0, [ref('product_pricelist_2'), ref('product_pricelist_1')])]"/>
         <field name="ship_later" eval="True"/>


### PR DESCRIPTION
A commit* enables customer display without configuration, so this commit removes the use of the field to enable it, as it was removed.

https://github.com/odoo/odoo/commit/fa882c6c4d50dedb75a0b40f8824d5492b8901af