### PR TITLE
[FIX] automobile: remove search from warranty rule to avoid loop

### DIFF
--- a/automobile/data/ir_actions_server.xml
+++ b/automobile/data/ir_actions_server.xml
@@ -6,9 +6,8 @@
         <field name="state">code</field>
         <field name="base_automation_id" ref="update_the_warranty"/>
         <field name="code"><![CDATA[
-move_lines = records.search([("state", "=", "done"), ("picking_code", "=", "outgoing")])
-for line in move_lines:
-    line.write({'x_warranty_date': datetime.datetime.today().date() + datetime.timedelta(line.product_id.expiration_time)})
+for r in records:
+    r.write({'x_warranty_date': datetime.datetime.today().date() + datetime.timedelta(r.product_id.expiration_time)})
 ]]></field>
     </record>
 </odoo>


### PR DESCRIPTION
### Issue:
The `automobile` industry module contains an Automation Rule to set the `x_warranty_date` value, a stored field on `stock.move.line` related to `stock.lot.expiration_date`. The rule has a filter to ensure that the update is only performed if the record meets those criteria. However, we then `search` for all other records that meet the criteria, and update each found record based on the current time. This causes 2 issues.

1) Each record is getting its `x_warranty_date` updated based on the time that one specific record is saved.
2) More pressing, the `search` followed by a `write` creates a loop that causes the Automation Rule to trigger itself infinitely, never allowing the save to complete.

### Solution:
We can remove the `search` and apply the rule to the specific record that was updated, solving both problems simultaneously.

opw-4672112