### PR TITLE
[FIX] *: fix server actions to apply on updated records only

### DIFF
--- a/electronic_store/data/ir_actions_server.xml
+++ b/electronic_store/data/ir_actions_server.xml
@@ -6,7 +6,7 @@
         <field name="state">code</field>
         <field name="base_automation_id" ref="base_automation_1"/>
         <field name="code"><![CDATA[
-move_lines = env["stock.move.line"].search([("state", "=", "done"), ("picking_code", "=", "outgoing"), ("lot_id.x_warranty_date", "=", False), ("product_id.x_warranty_months", ">", 0)])
+move_lines = records.filtered(lambda sml: not sml.lot_id.x_warranty_date and sml.product_id.x_warranty_months > 0)
 for line in move_lines:
     line.lot_id.write({'x_warranty_date': datetime.datetime.today() + dateutil.relativedelta.relativedelta(months=line.product_id.x_warranty_months)})
         ]]></field>

--- a/it_hardware/data/ir_actions_server.xml
+++ b/it_hardware/data/ir_actions_server.xml
@@ -6,7 +6,7 @@
         <field name="state">code</field>
         <field name="base_automation_id" ref="base_automation_1"/>
         <field name="code"><![CDATA[
-move_lines = env["stock.move.line"].search([("state", "=", "done"), ("picking_code", "=", "outgoing"), ("lot_id.x_warranty_date", "=", False), ("product_id.x_warranty_months", ">", 0)])
+move_lines = records.filtered(lambda sml: not sml.lot_id.x_warranty_date and sml.product_id.x_warranty_months > 0)
 for line in move_lines:
     line.lot_id.write({'x_warranty_date': datetime.datetime.today() + dateutil.relativedelta.relativedelta(months=line.product_id.x_warranty_months)})
         ]]></field>

--- a/solar_installation/data/ir_actions_server.xml
+++ b/solar_installation/data/ir_actions_server.xml
@@ -6,7 +6,7 @@
         <field name="state">code</field>
         <field name="base_automation_id" ref="base_automation_4"/>
         <field name="code"><![CDATA[
-move_lines = env["stock.move.line"].search([("state", "=", "done"), ("picking_code", "=", "outgoing"), ("lot_id.x_warranty_date", "!=", False)])
+move_lines = records.filtered(lambda sml: not sml.lot_id.x_warranty_date and sml.product_id.expiration_time)
 for line in move_lines:
     line.lot_id.write({'x_warranty_date': datetime.datetime.today() + datetime.timedelta(line.product_id.expiration_time)})
         ]]></field>


### PR DESCRIPTION
Before this commit, the server action was searching for all records instead of filtering the records updated from the automation. This commit fixes this issue by filtering the records instead.