### PR TITLE
[IMP] test_generic: add test to ensure 'is_locked' is set on knowledge article

### DIFF
--- a/architects/data/knowledge_article.xml
+++ b/architects/data/knowledge_article.xml
@@ -66,6 +66,7 @@
         <field name="name">Architecture Firm</field>
         <field name="sequence">2</field>
         <field name="internal_permission">write</field>
+        <field name="is_locked" eval="True"/>
         <field name="is_article_visible_by_everyone" eval="True"/>
         <field name="cover_image_id" ref="knowledge_cover_2"/>
         <field name="cover_image_position">68.59</field>

--- a/fitness/data/knowledge_article.xml
+++ b/fitness/data/knowledge_article.xml
@@ -271,6 +271,7 @@
         <field name="name">Fitness Industry</field>
         <field name="cover_image_id" ref="knowledge_cover_8"/>
         <field name="internal_permission">write</field>
+        <field name="is_locked" eval="True"/>
         <field name="icon">🏋️</field>
         <field name="sequence">15</field>
         <field name="is_article_visible_by_everyone" eval="True"/>

--- a/handyman/data/knowledge_article.xml
+++ b/handyman/data/knowledge_article.xml
@@ -160,6 +160,7 @@
         <field name="cover_image_position">55.15</field>
         <field name="cover_image_id" ref="knowledge_cover_6"/>
         <field name="internal_permission">write</field>
+        <field name="is_locked" eval="True"/>
         <field name="sequence">15</field>
         <field name="is_article_visible_by_everyone" eval="True" />
     </record>    

--- a/personal_trainer/data/knowledge_article.xml
+++ b/personal_trainer/data/knowledge_article.xml
@@ -130,6 +130,7 @@
         <field name="cover_image_id" ref="knowledge_cover_9"/>
         <field name="internal_permission">write</field>
         <field name="last_edition_uid" ref="base.user_admin"/>
+        <field name="is_locked" eval="True"/>
         <field name="is_article_visible_by_everyone" eval="True"/>
         <field name="body"><![CDATA[]]></field>
     </record>

--- a/photography/data/knowledge_article.xml
+++ b/photography/data/knowledge_article.xml
@@ -66,6 +66,7 @@
     <record id="welcome_article" model="knowledge.article">
         <field name="name">Photography - Start here!</field>
         <field name="internal_permission">write</field>
+        <field name="is_locked" eval="True"/>
         <field name="cover_image_id" ref="knowledge_cover_0" />
         <field name="cover_image_position">50.0</field>
         <field name="is_article_visible_by_everyone" eval="True"/>

--- a/surveyor/data/knowledge_article.xml
+++ b/surveyor/data/knowledge_article.xml
@@ -43,7 +43,7 @@
         <field name="cover_image_id" ref="knowledge_cover_8"/>
         <field name="parent_path">3/</field>
         <field name="internal_permission">write</field>
-        <field name="is_locked">True</field>
+        <field name="is_locked" eval="True"/>
         <field name="is_article_visible_by_everyone" eval="True"/>
         <field name="sequence">3</field>
         <field name="name">Surveying &amp; Mapping</field>

--- a/tests/test_generic/tests/test_xml.py
+++ b/tests/test_generic/tests/test_xml.py
@@ -133,6 +133,7 @@ class TestEnv(IndustryCase):
                 self._check_xml_style(decoded_content, tree, module, file_name)
                 self._check_update_status(tree, file_name)
                 self._check_knowledge_article_is_published(tree, file_name)
+                self._check_knowledge_article_is_locked(tree, file_name)
                 checked_records_with_user = self._check_user_is_set(tree, checked_records_with_user)
                 self._check_duplicate_records(tree, file_name)
                 self._check_website_published_false(tree, file_name)
@@ -291,6 +292,14 @@ class TestEnv(IndustryCase):
             if is_published_fields:
                 _logger.warning(
                     f"Knowledge article in {file_name} should not have 'is_published' set to True."
+                )
+
+    def _check_knowledge_article_is_locked(self, root, file_name):
+        for record in root.xpath("//record[@model='knowledge.article']"):
+            is_locked_fields = record.xpath(".//field[@name='is_locked']/@eval")
+            if not is_locked_fields:
+                _logger.warning(
+                    f"Knowledge article in {file_name} should have 'is_locked' set to True."
                 )
 
     def _check_is_published_false(self, root, file_name):


### PR DESCRIPTION
In all industry modules, there is a knowledge article that explains the main business flows covered by the module should be locked.