### PR TITLE
[FIX] non_profit_organization: fix ref to event product

### DIFF
--- a/non_profit_organization/data/product_pricelist_item.xml
+++ b/non_profit_organization/data/product_pricelist_item.xml
@@ -4,6 +4,11 @@
         <field name="applied_on">1_product</field>
         <field name="fixed_price">10.0</field>
         <field name="pricelist_id" ref="product_pricelist_1"/>
-        <field name="product_tmpl_id" eval="ref('event_product.product_product_event_product_template')"/>
+        <field name="product_tmpl_id" model="product.product" eval="(obj().env.ref('event_product.product_product_event', raise_if_not_found=False) or obj().env['product.product'].create({
+                'name': 'Generic Registration Product',
+                'list_price': 0,
+                'standard_price': 0,
+                'type': 'service',
+            })).product_tmpl_id.id"/>
     </record>
 </odoo>


### PR DESCRIPTION
This problem fixes the issue of a non-existing standard product, generating a raise. Also, since the pricelist item requires a product template, this commit also adds the creation of a product as a fallback.

opw-4791551