### PR TITLE
[FIX] industry_real_estate: improve performance on computed x_rental_contract_id

### DIFF
--- a/industry_real_estate/data/ir_model_fields.xml
+++ b/industry_real_estate/data/ir_model_fields.xml
@@ -184,22 +184,6 @@ for property in self:
         <field name="ttype">many2many</field>
     </record>
 
-    <record id="field_property_rental_contract_id" model="ir.model.fields">
-        <field name="name">x_rental_contract_id</field>
-        <field name="field_description">Rental Contract</field>
-        <field name="model_id" ref="analytic.model_account_analytic_account"/>
-        <field name="relation">sale.order</field>
-        <field name="ttype">many2one</field>
-        <field name="readonly" eval="True"/>
-        <field name="store" eval="False"/>
-        <field name="compute">
-<![CDATA[
-for record in self:
-    sos = self.env['sale.order'].search([('x_account_analytic_account_id', '=', record.id), ('state', '=', 'sale'), ('x_rental_start_date', '<=', datetime.date.today())], order='x_rental_start_date desc')
-    record['x_rental_contract_id'] = sos[0] if sos else None
-]]></field>
-    </record>
-
     <record id="field_property_invoice_status" model="ir.model.fields">
         <field name="name">x_invoice_status</field>
         <field name="field_description">Invoice Status</field>
@@ -237,6 +221,24 @@ for record in self:
         <field name="field_description">Rental Start Date</field>
         <field name="model_id" ref="sale.model_sale_order"/>
         <field name="ttype">date</field>
+    </record>
+
+    <!-- After field_rental_start_date because field_property_rental_contract_id needs it-->
+    <record id="field_property_rental_contract_id" model="ir.model.fields">
+        <field name="name">x_rental_contract_id</field>
+        <field name="field_description">Rental Contract</field>
+        <field name="model_id" ref="analytic.model_account_analytic_account"/>
+        <field name="relation">sale.order</field>
+        <field name="ttype">many2one</field>
+        <field name="readonly" eval="True"/>
+        <field name="store" eval="False"/>
+        <field name="compute">
+<![CDATA[
+sos = self.env['sale.order']._read_group([('x_account_analytic_account_id', 'in', self.ids), ('state', '=', 'sale'), ('x_rental_start_date', '<=', datetime.date.today()), ('subscription_state', 'not in', ['5_renewed', '6_churn'])], groupby=['x_account_analytic_account_id','id'], order='x_rental_start_date:max')
+mapped_data = {account_id.id: so_id for account_id, so_id in sos}
+for record in self:
+    record['x_rental_contract_id'] = mapped_data.get(record.id, False)
+]]></field>
     </record>
 
     <record id="field_account_analytic_account_id" model="ir.model.fields">

--- a/tests/test_industry_real_estate/__init__.py
+++ b/tests/test_industry_real_estate/__init__.py
@@ -1,0 +1,1 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.

--- a/tests/test_industry_real_estate/__manifest__.py
+++ b/tests/test_industry_real_estate/__manifest__.py
@@ -1,0 +1,8 @@
+{
+    'name': 'Test Industry Real Estate',
+    'version': '1.0',
+    'category': 'Hidden/Tests',
+    'description': """A module to test code in the industry real estate.""",
+    'depends': ['base'],
+    'license': 'LGPL-3',
+}

--- a/tests/test_industry_real_estate/tests/__init__.py
+++ b/tests/test_industry_real_estate/tests/__init__.py
@@ -1,0 +1,3 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import test_computed_fields

--- a/tests/test_industry_real_estate/tests/test_computed_fields.py
+++ b/tests/test_industry_real_estate/tests/test_computed_fields.py
@@ -1,0 +1,21 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+import datetime
+from odoo.tests.common import TransactionCase
+
+
+class ComputedFieldsTestCase(TransactionCase):
+
+    def test_x_rental_contract_id_computation(self):
+        for sale_order in self.env['sale.order'].search([('x_account_analytic_account_id', '!=', False)]):
+            if sale_order.x_account_analytic_account_id:
+                aa = sale_order.x_account_analytic_account_id
+                start_date = sale_order.x_rental_start_date
+                self.assertTrue(
+                    (sale_order == aa.x_rental_contract_id) or (
+                        aa == aa.x_rental_contract_id.x_account_analytic_account_id and (
+                            (start_date < aa.x_rental_contract_id.x_rental_start_date) or
+                            (start_date > datetime.date.today())
+                        )
+                    )
+                )


### PR DESCRIPTION
Before this commit, x_rental_start_date was defined after being used in the computed field x_rental_contract_id, which led to sql_db deadlock. Furthermore, the performance of the computed method was poor due to a search on sale.order in a loop.
This commit moves the definition of x_rental_contract_id after its dependency fields definitions, and improves the performance of the computed field by using _read_group method instead.
Additionally, it adds a new test to verify that x_rental_contract_id is correctly computed.

OPW-4805375