### PR TITLE
"[FIX] tests: removing price_unit from the USELESS_FIELDS"

### DIFF
--- a/tests/test_generic/tests/test_xml.py
+++ b/tests/test_generic/tests/test_xml.py
@@ -42,7 +42,7 @@ USELESS_FIELDS = {
     'planning.role': ['color'],
     'planning.slot': ['access_token', 'allocated_hours'],
     'pos.order': ['date_order', 'pos_reference', 'company_id', 'state', 'currency_id', 'last_order_preparation_change'],
-    'pos.order.line': ['price_unit', 'total_cost', 'company_id', 'full_product_name'],
+    'pos.order.line': ['total_cost', 'company_id', 'full_product_name'],
     'product.attribute.value': ['color'],
     'product.product': ['lst_price'],
     'product.template.attribute.value': ['color'],


### PR DESCRIPTION
Removing the pos.order.line field "price_unit" from the USELESS_FIELDS dictionary in the tests because it is needed to change the unit price on an order line.