### PR TITLE
[FIX] industry_lawyer: fix wrong title in app description

### DIFF
--- a/industry_lawyer/static/description/index.html
+++ b/industry_lawyer/static/description/index.html
@@ -1,4 +1,4 @@
-<h2><strong>Odoo for Handyman Services</strong></h2>
+<h2><strong>Odoo for Law Firm</strong></h2>
 <p>This industry provides a comprehensive suite of tools designed specifically for law firms, enabling efficient management of time, appointments, deadlines, cases, and client relationships.</p>
 <p>Lawyers represent their clients and protect their interests during legal proceedings.</p>
 <p>


### PR DESCRIPTION
The title was referencing the wrong app (Handyman Services), it now shows Law Firm instead.

task-4848479