### PR TITLE
[ADD] utils: Util to launch an industry easily

### DIFF
--- a/run_industry.sh
+++ b/run_industry.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Usage function
+usage() {
+  echo "Usage: ./industry/run_industry.sh -i <industry-name> [-d] [-t] [-r]"
+  echo "  -i <industry-name>   (re)Install this industry"
+  echo "  -d                   Enable demo data when installing"
+  echo "  -t                   Run tests for the installed industry"
+  echo "  -r                   Reset the database before running"
+  exit 1
+}
+
+# Default values
+INDUSTRY_NAME=""
+INSTALL=false
+TEST=false  
+RESET_DB=false
+DEMO=False
+
+# Parse arguments
+while getopts ":i:dtr" opt; do
+  case $opt in
+    i) INDUSTRY_NAME="$OPTARG"; INSTALL=true ;;
+    d) DEMO=True ;;
+    t) TEST=true ;;
+    r) RESET_DB=true ;;
+    *) usage ;;
+  esac
+done
+
+
+echo "Industry: $INDUSTRY_NAME"
+echo "Install: $INSTALL"
+echo "Demo: $DEMO"
+echo "Test: $TEST"
+echo "Reset DB: $RESET_DB"
+
+PYTHON_BIN="python3"
+ODOO_BIN="odoo/odoo-bin"
+ADDONS_PATH="industry/tests,enterprise,odoo/addons,odoo/odoo/addons,design-themes"
+TEST_TAGS="/test_generic,/test_$INDUSTRY_NAME"
+DB="test"
+
+if $RESET_DB; then
+  echo "Resetting database '$DB'..."
+  dropdb --if-exists "$DB"
+  $PYTHON_BIN $ODOO_BIN --addons-path="$ADDONS_PATH" -i base_import_module,test_generic,test_$INDUSTRY_NAME -d $DB --without-demo=1 --stop-after-init
+fi
+
+if $INSTALL; then
+  echo "Initializing modules..."
+
+  TMP_INSTALL_PY=$(mktemp)
+  cat <<EOF > "$TMP_INSTALL_PY"
+import sys
+sys.path.append('industry/')
+from utils import get_zip
+def main():
+    zip = get_zip('$INDUSTRY_NAME', env)
+    res = env['ir.module.module'].sudo()._import_zipfile(zip, force=False, with_demo=$DEMO)
+    print(res[0])
+main()
+env.cr.commit()
+exit()
+EOF
+  cat "$TMP_INSTALL_PY" | $PYTHON_BIN $ODOO_BIN shell --addons-path="$ADDONS_PATH" -d $DB
+  rm -f "$TMP_INSTALL_PY"
+fi
+
+if $TEST; then
+  echo "Running tests..."
+  $PYTHON_BIN $ODOO_BIN --addons-path="$ADDONS_PATH" -d $DB --test-tags $TEST_TAGS
+else
+  echo "Starting Odoo server..."
+  $PYTHON_BIN $ODOO_BIN --addons-path="$ADDONS_PATH" -d $DB
+fi

--- a/utils.py
+++ b/utils.py
@@ -1,0 +1,31 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+import ast
+import os
+from io import BytesIO
+from zipfile import ZipFile, ZIP_DEFLATED
+
+
+def get_zip(module_name, env):
+    output = BytesIO()
+    zf = ZipFile(output, "w", ZIP_DEFLATED)
+    external_modules = get_external_dependencies('industry/' + module_name, env)
+    dirs = ['industry/' + module_name] + ['industry/' + module for module in external_modules]
+    for dir in dirs:
+        for dirname, subdirs, files in os.walk(dir):
+            zip_dirname = os.sep.join(dirname.split(os.sep)[1:])
+            zf.write(dirname, zip_dirname)
+            for filename in files:
+                zf.write(os.path.join(dirname, filename), os.path.join(zip_dirname, filename))
+    zf.close()
+    return output
+
+
+def get_external_dependencies(dir, env):
+    manifest_file = dir + '/__manifest__.py'
+    if not os.path.exists(manifest_file):
+        raise FileNotFoundError(f"Manifest file not found: {manifest_file}")
+    with open(manifest_file, encoding="utf-8") as f:
+        manifest = ast.literal_eval(f.read())
+    dependencies = set(manifest.get('depends', ['base']))
+    known_modules = env['ir.module.module'].search([]).mapped('name')
+    return dependencies.difference(known_modules)


### PR DESCRIPTION
```
Usage: ./industry/run_industry.sh -i <industry-name> [-d] [-t] [-r]
  -i <industry-name>   (re)Install this industry
  -d                   Enable demo data when installing
  -t                   Run tests for the installed industry
  -r                   Reset the database before running
```