### PR TITLE
[FIX] base_industry_data: disable digest emails for admin in SaaS trials

### DIFF
--- a/base_industry_data/__manifest__.py
+++ b/base_industry_data/__manifest__.py
@@ -13,7 +13,7 @@
         'data/res_partner_category.xml',
     ],
     'demo': [
-        'demo/res_config_settings.xml',
+        'demo/ir_cron.xml',
         'demo/res_users.xml',
         'demo/res_partner.xml',
         'demo/res_partner_category.xml',

--- a/base_industry_data/demo/ir_cron.xml
+++ b/base_industry_data/demo/ir_cron.xml
@@ -1,0 +1,6 @@
+<?xml version='1.0' encoding='utf-8'?>
+<odoo noupdate="1">
+    <record id="digest.ir_cron_digest_scheduler_action" model="ir.cron" forcecreate="0">
+        <field name="active" eval="False" />
+    </record>
+</odoo>

--- a/base_industry_data/demo/res_config_settings.xml
+++ b/base_industry_data/demo/res_config_settings.xml
@@ -1,7 +1,0 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
-    <record id="res_config_account_setting_marketing" model="res.config.settings">
-        <field name="digest_emails" eval="0"/>
-    </record>
-    <function name="execute" model="res.config.settings" eval="[ref('res_config_account_setting_marketing')]"/>
-</odoo>


### PR DESCRIPTION
Despite the setting being unchecked, digest emails were still sent to admin in SaaS trials. 
Explicitly deactivate the digest cron via XML.

Task ID: 4903336