### PR TITLE
[FIX] industry_restaurant: fix error tax not found

### DIFF
--- a/industry_restaurant/demo/pos_order_lines.xml
+++ b/industry_restaurant/demo/pos_order_lines.xml
@@ -6,7 +6,6 @@
         <field name="price_unit">13.0</field>
         <field name="price_subtotal_incl">14.95</field>
         <field name="price_subtotal">13.0</field>
-        <field name="tax_ids" eval="[ref('account.1_sale_tax_template', raise_if_not_found=False)]"/>
     </record>
     <record id="pos_order_line_2" model="pos.order.line">
         <field name="product_id" ref="pos_restaurant.pos_food_chicken"/>
@@ -14,7 +13,6 @@
         <field name="price_unit">3.0</field>
         <field name="price_subtotal_incl">3.45</field>
         <field name="price_subtotal">3.0</field>
-        <field name="tax_ids" eval="[ref('account.1_sale_tax_template', raise_if_not_found=False)]"/>
     </record>
     <record id="pos_order_line_3" model="pos.order.line">
         <field name="product_id" ref="pos_restaurant.schweppes"/>
@@ -22,7 +20,6 @@
         <field name="price_unit">2.20</field>
         <field name="price_subtotal_incl">2.53</field>
         <field name="price_subtotal">2.20</field>
-        <field name="tax_ids" eval="[ref('account.1_sale_tax_template', raise_if_not_found=False)]"/>
     </record>
     <record id="pos_order_line_4" model="pos.order.line">
         <field name="product_id" ref="pos_restaurant.ice_tea"/>
@@ -30,6 +27,5 @@
         <field name="price_unit">2.20</field>
         <field name="price_subtotal_incl">2.53</field>
         <field name="price_subtotal">2.20</field>
-        <field name="tax_ids" eval="[ref('account.1_sale_tax_template', raise_if_not_found=False)]"/>
     </record>
 </odoo>


### PR DESCRIPTION
The module can't be loaded due to the taxes on the demo pos order line being not found. This commit removes those lines as they should not be set directly.