### PR TITLE
[FIX] agriculture_shop: add dependency sale_purchase_stock for picking_ids support

### DIFF
--- a/agriculture_shop/__manifest__.py
+++ b/agriculture_shop/__manifest__.py
@@ -8,7 +8,7 @@
         'pos_sale',
         'product_expiry',
         'purchase_requisition',
-        'sale_purchase',
+        'sale_purchase_stock',
         'survey',
         'web_studio',
         'website_sale_loyalty',


### PR DESCRIPTION
-Error while installing module 'agriculture_shop'.
-The demo data accesses `picking_ids` on both `sale.order` and `purchase.order`,
 which are fields provided through modules like `sale_stock` and `purchase_stock`. 
-Since the `sale_purchase_stock` module already includes these as dependencies, 
 replacing `sale_purchase` with `sale_purchase_stock` ensures full coverage.
