### PR TITLE
[FIX] sports_club: fix appointment link on the website

### DIFF
--- a/sports_club/demo/website_view.xml
+++ b/sports_club/demo/website_view.xml
@@ -21,7 +21,7 @@
                                             <b>Ready to play?</b>
                                         </h1>
                                         <p class="lead">Time to show who's best! Book a court and get working.</p>
-                                        <a class="mb-2 btn btn-primary" t-att-href="'/appointment/' + str(env.ref('sports_club.appointment_type_1').id)" data-bs-original-title="" title="">
+                                        <a class="mb-2 btn btn-primary" href="/book/court" data-bs-original-title="" title="">
                                             <font class="text-white">Book a court</font>
                                         </a>
                                     </div>
@@ -177,7 +177,7 @@
         <xpath expr="//section[hasclass('s_text_block')]/div[hasclass('container')]" position="replace">
             <section class="oe_unremovable oe_unmovable s_text_block" data-snippet="s_text_block" data-name="Text">
                 <div class="container">
-                    <a href="book/court" class="oe_unremovable btn btn-primary btn_cta">Book a Court</a>
+                    <a href="/book/court" class="oe_unremovable btn btn-primary btn_cta">Book a Court</a>
                 </div>
             </section>
         </xpath>


### PR DESCRIPTION
Before this commit, clicking the Book a Court button on the website directs to a Page not found error because the appointments are not public but accessible only through an invite code, as used by other menus. This commit adapts the link behind the button.

Task-4950786