### PR TITLE
[FIX] automobile: fix automation / action perpetual loop

### DIFF
--- a/automobile/data/base_automation.xml
+++ b/automobile/data/base_automation.xml
@@ -3,7 +3,8 @@
     <record id="update_the_warranty" model="base.automation">
         <field name="name">Update the Warranty Date</field>
         <field name="model_id" ref="stock.model_stock_move_line"/>
-        <field name="filter_domain">["&amp;", ("state", "=", "done"), ("picking_code", "=", "outgoing")]</field>
+        <field name="filter_domain">[("state", "=", "done"), ("picking_code", "=", "outgoing")]</field>
+        <field name="filter_pre_domain">["|", ("state", "!=", "done"), ("picking_code", "!=", "outgoing")]</field>
         <field name="trigger">on_create_or_write</field>
     </record>
 </odoo>


### PR DESCRIPTION
Before this commit, the automation would be triggered on every stock.move.line outgoing and done that is edited. The problem is that the linked server action writes on the stock.move.line, leading to an unlimited loop.

To get rid of this wrong behaviour, this commits adds a pre-domain on the base.automation such that it is only triggered on new stock.move.line meeting the filter domain. The edition done by the server action no more triggers the automation.