### PR TITLE
[FIX] guest_house: fix confirming a sale order that caused an error

### DIFF
--- a/guest_house/demo/sale_order_post.xml
+++ b/guest_house/demo/sale_order_post.xml
@@ -5,9 +5,6 @@
             ref('sale_order_1'),
             ref('sale_order_2'),
             ref('sale_order_3'),
-            ref('sale_order_4'),
-            ref('sale_order_5'),
-            ref('sale_order_6'),
         ]"/>
     </function>
     <record id="pickup_wizard_1" model="rental.order.wizard">
@@ -36,6 +33,13 @@
             ref('return_wizard_1'),
             ref('pickup_wizard_2'),
             ref('pickup_wizard_3'),
+        ]"/>
+    </function>
+    <function name="action_confirm" model="sale.order">
+        <value eval="[
+            ref('sale_order_4'),
+            ref('sale_order_5'),
+            ref('sale_order_6'),
         ]"/>
     </function>
 </odoo>


### PR DESCRIPTION
Confirming all the SO at once was causing a shift conflict in planning and prevented the module from installing.
This started to happen after a fix in Rental.

Now we split the confirmation of the SOs to treat first the ones getting picked-up/returned, this compute the potential conflicts before we confirms the other SOs, and solves the problem