### PR TITLE
[FIX] theater: Impossible to log in

### DIFF
--- a/theater/demo/website_theme_apply.xml
+++ b/theater/demo/website_theme_apply.xml
@@ -3,7 +3,7 @@
   
   <function name="button_choose_theme" model="ir.module.module" eval="[ref('base.module_theme_loftspace', raise_if_not_found=False) or ref('base.module_theme_default')]"/>
 
-  <function model="theme.utils" name="enable_view" eval="['website.template_header_sales_one']"/>
+  <!-- <function model="theme.utils" name="enable_view" eval="['website.template_header_sales_one']"/> -->
 
   <function model="ir.ui.view" name="write">
     <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('website.default_website').id).viewref('website.homepage').id"/>

--- a/theater/i18n/theater.pot
+++ b/theater/i18n/theater.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server saas~18.4+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-07-17 11:40+0000\n"
-"PO-Revision-Date: 2025-07-17 11:40+0000\n"
+"POT-Creation-Date: 2025-08-28 04:51+0000\n"
+"PO-Revision-Date: 2025-08-28 04:51+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -504,13 +504,6 @@ msgstr ""
 msgid ""
 "Generation<br/>Performing\n"
 "                      Arts Theater."
-msgstr ""
-
-#. module: theater
-#: model_terms:ir.ui.view,arch_db:theater.homepage
-msgid ""
-"Get\n"
-"                              your tickets"
 msgstr ""
 
 #. module: theater


### PR DESCRIPTION
The field definition contained `eval="['website.template_header_sales_one']"/>` which is broken in standard. This caused loading errors when installing or upgrading the module.

Upstream Odoo task reference: https://www.odoo.com/odoo/project/974/tasks/5003249