### PR TITLE
[FIX] gallery,micro_brewery: prevent error on opening product page

### DIFF
--- a/gallery/demo/website_view.xml
+++ b/gallery/demo/website_view.xml
@@ -422,17 +422,17 @@
   </record>
   <record id="ir_ui_view_3574" model="ir.ui.view">
     <field name="arch" type="xml">
-      <data inherit_id="website_sale.product" active="True" name="Share Buttons" priority="22">
-        <xpath expr="//div[@id='o_product_terms_and_share']" position="inside">
+      <data inherit_id="website_sale.product_terms_and_conditions" active="True" name="Share Buttons" priority="22">
+        <xpath expr="//small" position="after">
           <div data-snippet="s_share" data-name="Share" class="s_share text-start o_no_link_popover">
-            <h4 class="s_share_title d-none">Shar<a href="https://www.facebook.com/sharer/sharer.php?u={url}" target="_blank" aria-label="Facebook" class="s_share_facebook">
+            <h4 class="s_share_title d-none">Share<a href="https://www.facebook.com/sharer/sharer.php?u={url}" target="_blank" aria-label="Facebook" class="s_share_facebook">
                     </a><a href="mailto:?body={url}&amp;subject={title}" aria-label="Email" class="s_share_email"><i class="fa fa-envelope rounded shadow-sm"/></a>
             </h4>
           </div>
         </xpath>
       </data>
     </field>
-    <field name="inherit_id" ref="website_sale.product"/>
+    <field name="inherit_id" ref="website_sale.product_terms_and_conditions"/>
     <field name="key">gallery.product_share_buttons</field>
     <field name="mode">extension</field>
     <field name="name">Share Buttons</field>

--- a/gallery/i18n/gallery.pot
+++ b/gallery/i18n/gallery.pot
@@ -4,10 +4,10 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server saas~18.3+e\n"
+"Project-Id-Version: Odoo Server saas~18.4+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-07-17 05:42+0000\n"
-"PO-Revision-Date: 2025-07-17 05:42+0000\n"
+"POT-Creation-Date: 2025-08-29 09:50+0000\n"
+"PO-Revision-Date: 2025-08-29 09:50+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -1220,7 +1220,7 @@ msgstr ""
 
 #. module: gallery
 #: model_terms:ir.ui.view,arch_db:gallery.ir_ui_view_3574
-msgid "Shar"
+msgid "Share"
 msgstr ""
 
 #. module: gallery

--- a/micro_brewery/demo/website_view.xml
+++ b/micro_brewery/demo/website_view.xml
@@ -238,8 +238,8 @@
   </record>
   <record id="ir_ui_view_3854" model="ir.ui.view">
     <field name="arch" type="xml">
-      <data inherit_id="website_sale.product" active="True" name="Share Buttons" priority="22">
-        <xpath expr="//div[@id='o_product_terms_and_share']" position="inside">
+      <data inherit_id="website_sale.product_terms_and_conditions" active="True" name="Share Buttons" priority="22">
+        <xpath expr="//small" position="after">
           <div data-snippet="s_share" data-name="Share" class="s_share o_no_link_popover text-start">
             <h4 class="s_share_title d-none">Share</h4>
             <a href="https://www.facebook.com/sharer/sharer.php?u={url}" target="_blank" aria-label="Facebook" class="s_share_facebook">
@@ -264,7 +264,7 @@
         </xpath>
       </data>
     </field>
-    <field name="inherit_id" ref="website_sale.product"/>
+    <field name="inherit_id" ref="website_sale.product_terms_and_conditions"/>
     <field name="key">micro_brewery.website_sale.product_share_buttons</field>
     <field name="mode">extension</field>
     <field name="name">Share Buttons</field>


### PR DESCRIPTION
Currently an error occurs when opening product page on website.

**Steps to replicate:**
* Install `micro_brewery` with demo data.
* Website > Shop > Open any product.

**Error**:
`ValueError: Element'<xpath expr='//div[@id='o_product_terms_and_share']'>' cannot be located in parent view`

**Root cause:**
After commit [1], the div at [2] was removed, but the demo data `XPath` expressions in the `gallery` and `micro_brewery` modules still reference it, causing error.

**Solution:**
* Modify the xpath template to match with the updated code.

[1]:
https://github.com/odoo/odoo/commit/bbb2d98d9ab97ce729d59b9858b63daccf5434e2#diff-635040c730ccbb8e4f6f2bf6472cf48a0cc9b8a3d488289dabdfce8096811915L2078

[2]:
https://github.com/odoo/odoo/blob/981a3f7afef6bf321b956b85e453ba85b83e43ed/addons/website_sale/views/templates.xml#L1884-L1887

sentry-6781422394