### PR TITLE
[FIX] concert_halls: fix use of relativedelta in events

### DIFF
--- a/concert_halls/demo/event_event.xml
+++ b/concert_halls/demo/event_event.xml
@@ -29,12 +29,12 @@
         <field name="date_tz" model="res.users" eval="obj().env.ref('base.user_admin').tz or 'Europe/Brussels'"/>
         <field name="date_begin" model="res.users" eval="
             pytz.timezone(obj().env.user.tz or 'UTC').localize(
-                DateTime.now().replace(hour=22, minute=30) + relativedelta(weekday=3)
+                DateTime.now().replace(hour=22, minute=30) + relativedelta(days=1, weekday=3)
             ).astimezone(pytz.UTC).replace(tzinfo=None)
         "/>
         <field name="date_end" model="res.users" eval="
             pytz.timezone(obj().env.user.tz or 'UTC').localize(
-                DateTime.now().replace(hour=1, minute=30) + relativedelta(weekday=4)
+                DateTime.now().replace(hour=1, minute=30) + relativedelta(days=1, weekday=4)
             ).astimezone(pytz.UTC).replace(tzinfo=None)
         "/>
         <field name="country_id" ref="base.be"/>


### PR DESCRIPTION
relativedelta with a wrong use of the weekday paramter was causing end dates to be before start dates in some cases.

task-5047820