### PR TITLE
[FIX] concert_halls: fix end after begin with relativedelta

### DIFF
--- a/concert_halls/demo/event_event.xml
+++ b/concert_halls/demo/event_event.xml
@@ -29,12 +29,12 @@
         <field name="date_tz" model="res.users" eval="obj().env.ref('base.user_admin').tz or 'Europe/Brussels'"/>
         <field name="date_begin" model="res.users" eval="
             pytz.timezone(obj().env.user.tz or 'UTC').localize(
-                DateTime.now().replace(hour=22, minute=30) + relativedelta(days=1, weekday=3)
+                DateTime.now().replace(hour=22, minute=30) + relativedelta(weekday=0) + relativedelta(weekday=3)
             ).astimezone(pytz.UTC).replace(tzinfo=None)
         "/>
         <field name="date_end" model="res.users" eval="
             pytz.timezone(obj().env.user.tz or 'UTC').localize(
-                DateTime.now().replace(hour=1, minute=30) + relativedelta(days=1, weekday=4)
+                DateTime.now().replace(hour=1, minute=30) + relativedelta(weekday=0) + relativedelta(weekday=4)
             ).astimezone(pytz.UTC).replace(tzinfo=None)
         "/>
         <field name="country_id" ref="base.be"/>


### PR DESCRIPTION
Before this commit, the use of relativedelta makes it possible to have a start date after the end date (if new was the end of the week). This commit makes it more robust.