### PR TITLE
[FIX] marketing_agency: disable header templates in website views

### DIFF
--- a/marketing_agency/demo/website_theme_apply.xml
+++ b/marketing_agency/demo/website_theme_apply.xml
@@ -2,7 +2,7 @@
 <odoo>
     <function name="button_choose_theme" model="ir.module.module" eval="[ref('base.module_theme_buzzy', raise_if_not_found=False) or ref('base.module_theme_default')]"/>
 
-    <function model="theme.utils" name="enable_view" eval="['website.template_header_hamburger']"/>
+    <!-- <function model="theme.utils" name="enable_view" eval="['website.template_header_hamburger']"/> -->
     <function model="theme.utils" name="enable_view" eval="['website.no_autohide_menu']"/>
     <function name="make_scss_customization" model="web_editor.assets" context="{'website_id': ref('website.default_website')}">
         <value eval="'/website/static/src/scss/options/colors/user_color_palette.scss'"/>


### PR DESCRIPTION
In this PR, we comment out the website header template views to work around a standard bug that breaks industry module views and causes related issues