### PR TITLE
[FIX] booking_engine: get the real rental unit price in booking engine

### DIFF
--- a/booking_engine/data/ir_actions_server.xml
+++ b/booking_engine/data/ir_actions_server.xml
@@ -72,10 +72,12 @@ if record.sale_line_id:
         for slot in record.sale_line_id.planning_slot_ids:
             if slot.start_datetime and slot.end_datetime:
                 nights += ceil((slot.end_datetime - slot.start_datetime).total_seconds() / (24 * 3600))
-    record['sale_line_id']['x_nights'] = nights
-    rent_unit_price = env['product.pricing'].search([('product_template_id', '=', record.sale_line_id.product_id.product_tmpl_id.id)], limit=1).price
-    if rent_unit_price:
-        record['sale_line_id']['price_unit'] = rent_unit_price * nights
+    record.sale_line_id.update({
+        'start_date': record.start_datetime,
+        'return_date': record.end_datetime,
+        'x_nights': nights,
+    })
+    record.sale_line_id._reset_price_unit()
 ]]></field>
     </record>
     <record id="industry_set_rental_hours" model="ir.actions.server">


### PR DESCRIPTION
Versions
--------
- master

Steps
-----
1. Use the `campsite` industry;
2. go to /shop
3. book 2 nights on a large pitch for 2 people;
4. go to checkout & pay.

Issue
-----
Order couldn't be confirmed because the order amount changed post-payment.

Cause
-----
The booking engine automation action reset rental prices when a linked planning slot has its dates changed. It computes this rental price by getting the first `product.pricing` on the product template, ignoring any pricing differences for product variants.

Solution
--------
Update the rental dates to the slot dates, and use `_reset_price_unit` which gets the correct unit price.

opw-5075564