### PR TITLE
[FIX] booking_engine,campsite: small UI fixes

### DIFF
--- a/booking_engine/data/ir_ui_view.xml
+++ b/booking_engine/data/ir_ui_view.xml
@@ -354,6 +354,7 @@
         <xpath expr="/gantt" position="attributes">
           <attribute name="form_view_id">%(booking_engine_schedule_form)d</attribute>
           <attribute name="multi_create_view"/>
+          <attribute name="color">partner_id</attribute>
         </xpath>
     </field>
     <field name="inherit_id" ref="planning.planning_view_gantt"/>

--- a/booking_engine/data/product_attribute_value.xml
+++ b/booking_engine/data/product_attribute_value.xml
@@ -53,11 +53,11 @@
     <field name="attribute_id" ref="product_attribute_20"/>
   </record>
   <record id="product_attribute_value_14" model="product.attribute.value">
-    <field name="name">Breakfast Included</field>
+    <field name="name">Included</field>
     <field name="attribute_id" ref="product_attribute_21"/>
   </record>
   <record id="product_attribute_value_15" model="product.attribute.value">
-    <field name="name">Breakfast Not Included</field>
+    <field name="name">Not Included</field>
     <field name="attribute_id" ref="product_attribute_21"/>
   </record>
   <record id="product_attribute_guest1" model="product.attribute.value">

--- a/booking_engine/data/res_config_settings.xml
+++ b/booking_engine/data/res_config_settings.xml
@@ -9,6 +9,7 @@
         <field name="show_line_subtotals_tax_selection">tax_included</field>
         <field name="add_to_cart_action">go_to_cart</field>
         <field name="automatic_invoice" eval="1"/>
+        <field name="group_uom" eval="1"/>
         <field name="tz" model="res.config.settings" eval="obj().env.context.get('tz') or 'Europe/Brussels'"/>
     </record>
 

--- a/campsite/data/product_product.xml
+++ b/campsite/data/product_product.xml
@@ -8,8 +8,6 @@
   </record>
   <record id="product_product_12" model="product.product">
     <field name="product_tmpl_id" ref="product_template_7"/>
-    <field name="product_template_attribute_value_ids" eval="[(6, 0, [ref('product_template_attribute_value_2')])]"/>
-    <field name="product_template_variant_value_ids" eval="[(6, 0, [ref('product_template_attribute_value_2')])]"/>
     <field name="is_favorite" eval="True"/>
   </record>
   <record id="product_product_15" model="product.product">
@@ -59,8 +57,6 @@
   </record>
   <record id="product_product_14" model="product.product">
     <field name="product_tmpl_id" ref="product_template_6"/>
-    <field name="product_template_attribute_value_ids" eval="[(6, 0, [ref('product_template_attribute_value_4')])]"/>
-    <field name="product_template_variant_value_ids" eval="[(6, 0, [ref('product_template_attribute_value_4')])]"/>
     <field name="is_favorite" eval="True"/>
   </record>
   <record id="product_product_22" model="product.product">


### PR DESCRIPTION
- campsite: ensured bungalows are available to rent (no attribute if only 'no_variant' type).
- booking_engine: 
    - renamed breakfast attribute values to "Included" / "Not included".
    - colored schedule by partner_id (<attribute name="color">partner_id</attribute>).
    - Settings: added units option.
    - Set all room/stay offer products uom_id to "per unit".

Task ID: 5075526