### PR TITLE
[FIX] headhunter: remove duplicate Jobs in website menu

### DIFF
--- a/headhunter/demo/website_menu.xml
+++ b/headhunter/demo/website_menu.xml
@@ -13,16 +13,4 @@
         />
         <field name="website_id" ref="website.default_website"/>
     </record>
-    <record id="website_menu_10" model="website.menu">
-        <field name="name">Jobs</field>
-        <field name="url">/jobs</field>
-        <field name="sequence">11</field>
-        <field name="parent_id" model="website.menu"
-            eval="obj().search([
-                ('website_id', '=', ref('website.default_website')),
-                ('url', '=', '/default-main-menu'),
-            ]).id"
-        />
-        <field name="website_id" ref="website.default_website"/>
-    </record>
 </odoo>

--- a/headhunter/i18n/headhunter.pot
+++ b/headhunter/i18n/headhunter.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 18.0+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-02-14 08:29+0000\n"
-"PO-Revision-Date: 2025-02-14 08:29+0000\n"
+"POT-Creation-Date: 2025-09-15 10:09+0000\n"
+"PO-Revision-Date: 2025-09-15 10:09+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -870,11 +870,6 @@ msgstr ""
 #. module: headhunter
 #: model:product.template,name:headhunter.product_product_1_product_template
 msgid "Job Onboarding"
-msgstr ""
-
-#. module: headhunter
-#: model:website.menu,name:headhunter.website_menu_10
-msgid "Jobs"
 msgstr ""
 
 #. module: headhunter


### PR DESCRIPTION
Removed duplicate `Jobs` Menu from website as suggested in PR [1]

[1]:https://github.com/odoo/industry/pull/1102