### PR TITLE
[IMP] metal_fabricator: confirm demo purchase orders

### DIFF
--- a/metal_fabricator/demo/purchase_order_post.xml
+++ b/metal_fabricator/demo/purchase_order_post.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-    <!-- <function name="button_confirm" model="purchase.order">
+    <function name="button_confirm" model="purchase.order">
         <value model="purchase.order" eval="obj().search([('product_id', '=', ref('product_product_9'))], limit=1).id"/>
     </function>
     <function name="button_confirm" model="purchase.order">
@@ -11,5 +11,5 @@
     </function>
     <function name="button_confirm" model="purchase.order">
         <value model="purchase.order" eval="obj().search([('product_id', '=', ref('product_product_6'))], limit=1).id"/>
-    </function> -->
+    </function>
 </odoo>


### PR DESCRIPTION
With the fix in standard odoo[1], purchase orders with 2 finished products made from the same component can now be confirmed.

[1]: https://github.com/odoo/odoo/commit/2fd144a64ca553dd67d30e05e17d4cc34be59749