### PR TITLE
[FIX] real_estate: correctly apply 4/3 thumbnail ratio on shop page

### DIFF
--- a/real_estate/demo/website_view.xml
+++ b/real_estate/demo/website_view.xml
@@ -494,20 +494,7 @@
     <field name="type">qweb</field>
     <field name="website_id" ref="website.default_website"/>
   </record>
-  <!-- <record id="ir_ui_view_thumbnails_design" model="ir.ui.view">
-    <field name="name">Thumbnails Design</field>
-    <field name="key">website_sale.products_design_thumbs</field>
-    <field name="inherit_id" ref="website_sale.products"/>
-    <field name="mode">extension</field>
-    <field name="website_id" ref="website.default_website"/>
-    <field name="type">qweb</field>
-    <field name="arch" type="xml">
-      <xpath expr="//section[@id='o_wsale_products_grid']" position="attributes">
-        <attribute name="t-attf-class" add="o_wsale_design_thumbs" separator=" "/>
-      </xpath>
-    </field>
-  </record> -->
-  <!-- <record id="ir_ui_view_thumb_4_3" model="ir.ui.view">
+  <record id="ir_ui_view_thumb_4_3" model="ir.ui.view">
     <field name="name">thumb_4_3</field>
     <field name="key">website_sale.products_thumb_4_3</field>
     <field name="inherit_id" ref="website_sale.products"/>
@@ -515,11 +502,11 @@
     <field name="website_id" ref="website.default_website"/>
     <field name="type">qweb</field>
     <field name="arch" type="xml">
-      <xpath expr="//section[@id='o_wsale_products_grid']" position="attributes">
-        <attribute name="t-attf-class" add="o_wsale_context_thumb_2_3" separator=" "/>
+      <xpath expr="//div[@id='o_wsale_container']" position="attributes">
+        <attribute name="t-attf-class" add="o_wsale_context_thumb_4_3" separator=" "/>
       </xpath>
     </field>
-  </record> -->
+  </record>
   <record id="ir_ui_view_header_effect_fixed" model="ir.ui.view">
     <field name="name">Header Effect Fixed</field>
     <field name="key">website.header_visibility_fixed</field>


### PR DESCRIPTION
- The previous inheritance targeted section[@id='o_wsale_products_grid'], which conflicted with the default snippet logic and prevented the landscape (4/3) ratio from being applied.

- This fix adjusts the view ir_ui_view_thumb_4_3 to extend div[@id='o_wsale_container'] instead, ensuring that the class o_wsale_context_thumb_4_3 is properly added and the 4/3 thumbnail design is applied as expected.

Task ID: 4937043