### PR TITLE
[FIX] it_hardware: fails to install on odoo/18.0 and enterprise/18.0

### DIFF
--- a/it_hardware/__manifest__.py
+++ b/it_hardware/__manifest__.py
@@ -16,6 +16,7 @@
         'website_helpdesk',
         'website_sale_comparison',
         'website_sale_stock',
+        'helpdesk_repair',
     ],
     'data': [
         'data/res_config_settings.xml',


### PR DESCRIPTION
PR against 18.0 branch as this is where it was found, but probably present in 19.0 as well.

Description in #1136 