### PR TITLE
[FIX] gallery, guided tours: fix xpath on h2 to h1

### DIFF
--- a/gallery/demo/website_view.xml
+++ b/gallery/demo/website_view.xml
@@ -373,8 +373,8 @@
   <record id="ir_ui_view_4086" model="ir.ui.view">
     <field name="arch" type="xml">
       <data inherit_id="website_event.index_topbar">
-        <xpath expr="//h2[contains(text(), 'Events')]" position="replace">
-          <h2 class="h4 my-0 me-auto pe-sm-4">Upcoming Events</h2>
+        <xpath expr="//h1[contains(text(), 'Events')]" position="replace">
+          <h1 class="h4 my-0 me-auto pe-sm-4">Upcoming Events</h1>
         </xpath>
       </data>
     </field>

--- a/guided_tours/demo/website_view.xml
+++ b/guided_tours/demo/website_view.xml
@@ -276,8 +276,8 @@
   </record>
   <record id="ir_ui_view_3720" model="ir.ui.view">
     <field name="arch" type="xml">
-        <xpath expr="//h2[contains(text(),'Events')]" position="replace">
-          <h2 class="me-auto mb-0 h4">Guided Tours</h2>
+        <xpath expr="//h1[contains(text(),'Events')]" position="replace">
+          <h1 class="me-auto mb-0 h4">Guided Tours</h1>
         </xpath>
     </field>
     <field name="name">Topbar</field>
@@ -288,8 +288,8 @@
   <record id="ir_ui_view_3844" model="ir.ui.view">
     <field name="arch" type="xml">
       <data name="Topbar" inherit_id="website_appointment.website_calendar_index_topbar">
-         <xpath expr="//h2[contains(text(),'Choose your appointment')]" position="replace">
-            <h2 class="me-auto mb-0 h4">Choose your destination</h2>
+         <xpath expr="//h1[contains(text(),'Choose your appointment')]" position="replace">
+            <h1 class="me-auto mb-0 h4">Choose your destination</h1>
           </xpath>
       </data>
     </field>


### PR DESCRIPTION
`Changes Made:`

Events Page (website_event.index_topbar)
- Updated xpath to target header h1 instead of h2
- Replaced Events header with h2 to h1

Appointment Page (website_appointment.website_calendar_index_topbar)
- Updated xpath to target header h1 instead of h2
- Replaced Events header with h2 to h1

Task ID: 5095343