### PR TITLE
[ADD] hvac_services: add 'New device' wizard

### DIFF
--- a/hvac_services/__manifest__.py
+++ b/hvac_services/__manifest__.py
@@ -30,6 +30,7 @@
         'data/res_config_settings.xml',
         'data/sale_order_template.xml',
         'data/ir_actions_act_window.xml',
+        'data/ir_actions_server.xml',
         'data/ir_ui_view.xml',
         'data/qweb_view.xml',
         'data/ir_ui_menu.xml',
@@ -38,7 +39,6 @@
         'data/product_template.xml',
         'data/product_product.xml',
         'data/sale_order_template_line.xml',
-        'data/ir_actions_server.xml',
         'data/base_automation.xml',
     ],
     'demo': [

--- a/hvac_services/data/ir_actions_act_window.xml
+++ b/hvac_services/data/ir_actions_act_window.xml
@@ -29,4 +29,15 @@
         <field name="view_mode">list,form</field>
         <field name="domain">[('partner_ids', 'child_of', active_ids)]</field>
     </record>
+    <record id="x_new_devices_action" model="ir.actions.act_window">
+        <field name="name">New Device</field>
+        <field name="res_model">x_new_devices</field>
+        <field name="view_mode">form</field>
+        <field name="target">new</field>
+        <field name="context">{
+            'default_x_partner_id': active_id,
+        }</field>
+        <field name="binding_model_id" ref="base.model_res_partner"/>
+        <field name="binding_view_types">form</field>
+    </record>
 </odoo>

--- a/hvac_services/data/ir_actions_server.xml
+++ b/hvac_services/data/ir_actions_server.xml
@@ -41,4 +41,23 @@ for so in records:
 ]]></field>
         <field name="model_id" ref="sale.model_sale_order"/>
     </record>
+    <record id="add_new_device_to_customer" model="ir.actions.server">
+        <field name="name">Add new device to customer</field>
+        <field name="model_id" ref="x_new_devices"/>
+        <field name="state">code</field>
+        <field name="code"><![CDATA[
+if env['stock.lot'].search([('name', '=', record.x_serial_number),('product_id', '=', record.x_device_id.id)], limit=1):
+    raise UserError('This serial number already exists for this product. Make sure to introduce a unique serial number.')
+lot = env['stock.lot'].create({'name': record.x_serial_number, 'product_id': record.x_device_id.id, })
+picking = env['stock.picking'].create({'partner_id': record.x_partner_id.id,
+    'picking_type_id': env.ref('stock.picking_type_out').id,
+    'location_id': env.ref('stock.stock_location_suppliers').id,
+    'location_dest_id': env.ref('stock.stock_location_customers').id,
+})
+env['stock.move.line'].create({'picking_id': picking.id, 'lot_id': lot.id, 'product_id': record.x_device_id.id, 'quantity': 1, })
+picking.with_context(skip_sms=True).button_validate()
+picking.write({'date_done': record.x_delivery_date})
+action = {'type': 'ir.actions.client', 'tag': 'display_notification','params': {'type': 'success', 'sticky': False,'message': ("New device created."), 'next': {'type': 'ir.actions.act_window_close'}, }}
+    ]]></field>
+    </record>
 </odoo>

--- a/hvac_services/data/ir_model_access.xml
+++ b/hvac_services/data/ir_model_access.xml
@@ -9,4 +9,13 @@
         <field name="perm_unlink" eval="True"/>
         <field name="perm_write" eval="True"/>
     </record>
+    <record id="x_new_devices_ir_model_access_2" model="ir.model.access">
+        <field name="name">x_new_devices_user_access</field>
+        <field name="group_id" ref="base.group_user"/>
+        <field name="model_id" ref="x_new_devices"/>
+        <field name="perm_create" eval="True"/>
+        <field name="perm_read" eval="True"/>
+        <field name="perm_unlink" eval="True"/>
+        <field name="perm_write" eval="True"/>
+    </record>
 </odoo>

--- a/hvac_services/data/ir_model_fields.xml
+++ b/hvac_services/data/ir_model_fields.xml
@@ -201,4 +201,37 @@ for record in self:
         <field name="field_description">Worker Signature</field>
         <field name="model_id" ref="x_project_task_worksheet_template"/>
     </record>
+    <record id="x_partner_id_field" model="ir.model.fields">
+        <field name="name">x_partner_id</field>
+        <field name="ttype">many2one</field>
+        <field name="field_description">Customer</field>
+        <field name="model_id" ref="x_new_devices"/>
+        <field name="relation">res.partner</field>
+        <field name="required" eval="True"/>
+        <field name="on_delete">cascade</field>
+    </record>
+    <record id="x_device_id_field" model="ir.model.fields">
+        <field name="name">x_device_id</field>
+        <field name="ttype">many2one</field>
+        <field name="field_description">Device</field>
+        <field name="model_id" ref="x_new_devices"/>
+        <field name="relation">product.template</field>
+        <field name="domain" eval="[('categ_id', '=', ref('product_category_devices'))]"/>
+        <field name="required" eval="True"/>
+        <field name="on_delete">cascade</field>
+    </record>
+    <record id="x_serial_number_field" model="ir.model.fields">
+        <field name="name">x_serial_number</field>
+        <field name="ttype">char</field>
+        <field name="field_description">Serial</field>
+        <field name="model_id" ref="x_new_devices"/>
+        <field name="required" eval="True"/>
+    </record>
+    <record id="x_delivery_date_field" model="ir.model.fields">
+        <field name="name">x_delivery_date</field>
+        <field name="ttype">date</field>
+        <field name="field_description">Delivery Date</field>
+        <field name="model_id" ref="x_new_devices"/>
+        <field name="required" eval="True"/>
+    </record>
 </odoo>

--- a/hvac_services/data/ir_models.xml
+++ b/hvac_services/data/ir_models.xml
@@ -4,4 +4,9 @@
         <field name="name">INST/MAIN/REPA Worksheet</field>
         <field name="model">x_project_task_worksheet_template</field>
     </record>
+    <record id="x_new_devices" model="ir.model">
+        <field name="name">Add new devices</field>
+        <field name="model">x_new_devices</field>
+        <field name="transient" eval="True" />
+    </record>
 </odoo>

--- a/hvac_services/data/ir_ui_view.xml
+++ b/hvac_services/data/ir_ui_view.xml
@@ -256,4 +256,36 @@
     <record id="x_project_task_worksheet_template_ir_actions_get_worksheets" model="ir.actions.act_window">
         <field name="search_view_id" ref="x_project_task_worksheet_template_search_view"/>
     </record>
+    <record id="x_new_devices_view_form" model="ir.ui.view">
+        <field name="name">x.new.devices.view.form</field>
+        <field name="model">x_new_devices</field>
+        <field name="active" eval="True"/>
+        <field name="arch" type="xml">
+            <form string="New Device">
+                <sheet>
+                    <field name="x_partner_id" invisible="1"/>
+                    <group>
+                        <field name="x_device_id" options="{'no_quick_create': True, 'no_create_edit': True}"/>
+                        <field name="x_serial_number" string="Serial"/>
+                        <field name="x_delivery_date" string="Delivery Date"/>
+                    </group>
+                </sheet>
+                <footer>
+                    <button string="Save" type="action" class="oe_highlight" name="%(add_new_device_to_customer)d" />
+                    <button string="Cancel" class="btn btn-secondary" special="cancel" />
+                </footer>
+            </form>
+        </field>
+    </record>
+    <record id="show_lot_ids_in_view_picking_form" model="ir.ui.view">
+        <field name="name">show.lot.ids.in.view.picking.form</field>
+        <field name="model">stock.picking</field>
+        <field name="inherit_id" ref="stock.view_picking_form" />
+        <field name="active" eval="True" />
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='lot_ids']" position="attributes">
+                <attribute name="optional">show</attribute>
+            </xpath>
+        </field>
+    </record>
 </odoo>

--- a/hvac_services/data/knowledge_article.xml
+++ b/hvac_services/data/knowledge_article.xml
@@ -305,6 +305,27 @@
         <p>
             <br />
         </p>
+        <h3>🧯&#160;Creating an existing device for a customer&#160;</h3>
+        <hr/>
+        <p>In some cases, your business might as well handle existing devices on customer sites you didn't installed.<br/>
+        In such case, we enabled the creation of a device from the Contact App so that all your work can take place the same way as if you installed it!</p>
+        <p>A customer calls you to handle a device you didn't install?</p>
+        <ul>
+            <li>Open the Contact App and find your customer, "Second Company" maybe?</li>
+            <li>From the gear icon (⚙️) menu, select the New Device option.</li>
+            <li>Select a product, add the customer provided serial and delivery date.</li>
+        </ul>
+        <div data-oe-role="status"
+            class="o_editor_banner user-select-none o-contenteditable-false lh-1 d-flex align-items-center alert alert-info pb-0 pt-3">
+            <i data-oe-aria-label="Banner Info" class="o_editor_banner_icon mb-3 fst-normal">💡</i>
+            <div class="o_editor_banner_content o-contenteditable-true w-100 px-3">
+                <p>Worse case if those details are missing, input placeholder data and create an activity to update those in the future!</p>
+            </div>
+        </div>
+        <p>You're all set to setup a maintenance contract or repair task the same way as if you've always worked for this customer!</p>
+        <p>
+            <br />
+        </p>
         <h3>📊&#160;Monitoring refrigerant consumption&#160;</h3>
         <hr />
         <p>From the <strong>Field Service&#160;App</strong>, you can monitor the consumed


### PR DESCRIPTION
- Added "New device" button on contact form to quickly register delivered devices.
- Wizard allows selecting an existing serial-tracked product, entering a new serial (cannot be an existing one), and choosing a delivery date (can be in the past).
- On save: • Creates the corresponding serial in a virtual inventory adjustment. • Generates a stock move from inventory adjustment to customer with the product/serial. • Sets the move to done with `date_done` from the wizard.
- As a result, the device appears as delivered and is available from the contact’s "Serials" smart button.

Task ID: 4968837