### PR TITLE
[FIX] * : add required email_from value in 'mailing.mailing'

### DIFF
--- a/dropshipping/data/mailing_mailing.xml
+++ b/dropshipping/data/mailing_mailing.xml
@@ -587,6 +587,7 @@ width:75%;
 </table>
 ]]></field>
     <field name="medium_id" ref="utm.utm_medium_email"/>
+    <field name="email_from">dropshipping@example.com</field>
     <field name="user_id" ref="base.user_admin"/>
     <field name="reply_to_mode">new</field>
     <field name="mailing_domain" eval="[('list_ids', 'in', [ref('mass_mailing.mailing_list_data')])]"/>

--- a/members_club/data/mailing_mailing.xml
+++ b/members_club/data/mailing_mailing.xml
@@ -6,6 +6,7 @@
     <field name="medium_id" ref="utm.utm_medium_email"/>
     <field name="mailing_model_id" ref="base.model_res_partner"/>
     <field name="reply_to_mode">new</field>
+    <field name="email_from">members_club@example.com</field>
     <field name="mailing_domain">[("is_blacklisted", "=", False), ("grade_id", "=", False)]</field>
   </record>
 </odoo>

--- a/student_organization/data/mailing_mailing.xml
+++ b/student_organization/data/mailing_mailing.xml
@@ -3,6 +3,7 @@
   <record id="mailing_mailing_1" model="mailing.mailing">
     <field name="subject">Email Marketing</field>
     <field name="medium_id" ref="utm.utm_medium_email"/>
+    <field name="email_from">student_organization@example.com</field>
     <field name="user_id" ref="base.user_admin"/>
     <field name="mailing_model_id" ref="base.model_res_partner"/>
     <field name="reply_to_mode">new</field>


### PR DESCRIPTION
*= dropshipping, members_club, student_organization

Users are currently unable to install the above industries because the required `email_from` field is missing in the mailing data.

A recent commit [1] introduced a constraint that raises an error if the `email_from` field is not set and `mailing_type` is mail (default value).

This commit will fix the above issue by adding the `email_from` value in the data.

[1] - https://github.com/odoo/odoo/commit/92c5b0699dffab98f55ed1a54a0236dbc4b5626a

Task-No