### PR TITLE
[IMP] *: Do not pollute message and notification box when installing an industry

### DIFF
--- a/3pl_logistic_company/demo/crm_lead.xml
+++ b/3pl_logistic_company/demo/crm_lead.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
   <record id="crm_lead_1" model="crm.lead">
     <field name="name">Contact with Auto 5</field>
     <field name="user_id" ref="base.user_admin"/>

--- a/3pl_logistic_company/demo/sale_order.xml
+++ b/3pl_logistic_company/demo/sale_order.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
   <record id="sale_order_4" model="sale.order">
     <field name="partner_id" ref="base_industry_data.res_partner_35"/>
     <field name="prepayment_percent">1.0</field>

--- a/3pl_logistic_company/demo/sale_order_confirm.xml
+++ b/3pl_logistic_company/demo/sale_order_confirm.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True, 'mail_notrack': True}">
     <function model="sale.order" name="action_confirm" eval="[[ref('sale_order_4'),ref('sale_order_3'),ref('sale_order_1')]]"/>
 
     <record id="sale_advance_payment_inv_1" model="sale.advance.payment.inv">

--- a/3pl_logistic_company/demo/stock_picking.xml
+++ b/3pl_logistic_company/demo/stock_picking.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
     <function model="ir.model.data" name="_update_xmlids">
         <value model="base" eval="[{
             'xml_id': '3pl_logistic_company.picking_type_pick',

--- a/account_pos_settle_due/__manifest__.py
+++ b/account_pos_settle_due/__manifest__.py
@@ -13,8 +13,5 @@
         'data/base_automation.xml',
         'data/ir_ui_view.xml',
     ],
-    'demo': [
-        'demo/res_users.xml',
-    ],
     'license': 'OEEL-1',
 }

--- a/account_pos_settle_due/demo/res_users.xml
+++ b/account_pos_settle_due/demo/res_users.xml
@@ -1,6 +1,0 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
-    <record id="base.user_admin" model="res.users" forcecreate="0">
-        <field name="notification_type">inbox</field>
-    </record>
-</odoo>

--- a/accounting_firm/demo/crm_lead.xml
+++ b/accounting_firm/demo/crm_lead.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
     <record id="crm_lead_1" model="crm.lead">
         <field name="partner_id" ref="base_industry_data.res_partner_21" />
         <field name="name">First Company</field>

--- a/accounting_firm/demo/mail_activity.xml
+++ b/accounting_firm/demo/mail_activity.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_activity_quick_update': True}">
     <record id="mail_activity_1" model="mail.activity">
         <field name="res_model_id" ref="sale.model_sale_order" />
         <field name="res_id" ref="sale_order_1" />

--- a/accounting_firm/demo/sale_order.xml
+++ b/accounting_firm/demo/sale_order.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
     <record id="sale_order_1" model="sale.order">
         <field name="partner_id" ref="base_industry_data.res_partner_32" />
         <field name="sale_order_template_id" ref="sale_order_template_1" />

--- a/agriculture_shop/__manifest__.py
+++ b/agriculture_shop/__manifest__.py
@@ -39,7 +39,6 @@
         'data/product_ribbon.xml',
     ],
     'demo': [
-        'demo/res_users.xml',
         'demo/res_partner.xml',
         'demo/product_product.xml',
         'demo/crm_tag.xml',

--- a/agriculture_shop/demo/crm_lead.xml
+++ b/agriculture_shop/demo/crm_lead.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
     <record id="crm_lead_1" model="crm.lead">
     <field name="name">Heavy Harrow Best Price</field>
     <field name="user_id" ref="base.user_admin"/>

--- a/agriculture_shop/demo/mail_activity.xml
+++ b/agriculture_shop/demo/mail_activity.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_activity_quick_update': True}">
     <record id="mail_activity_1" model="mail.activity">
         <field name="res_model_id" ref="crm.model_crm_lead"/>
         <field name="date_deadline" eval="DateTime.today()"/>

--- a/agriculture_shop/demo/purchase_order.xml
+++ b/agriculture_shop/demo/purchase_order.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
     <record id="purchase_order_1" model="purchase.order">
         <field name="partner_id" ref="res_partner_7"/>
         <field name="user_id" ref="base.user_admin"/>

--- a/agriculture_shop/demo/res_users.xml
+++ b/agriculture_shop/demo/res_users.xml
@@ -1,6 +1,0 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
-    <record id="base.user_admin" model="res.users" forcecreate="0">
-        <field name="notification_type">inbox</field>
-    </record>
-</odoo>

--- a/agriculture_shop/demo/sale_order.xml
+++ b/agriculture_shop/demo/sale_order.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
     <record id="sale_order_1" model="sale.order">
         <field name="partner_id" ref="res_partner_10"/>
         <field name="user_id" ref="base.user_admin"/>

--- a/agriculture_shop/demo/sale_order_post.xml
+++ b/agriculture_shop/demo/sale_order_post.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
     <!-- Confirm action -->
     <function name="action_confirm" model="sale.order" eval="[[ref('sale_order_1'), ref('sale_order_2'), ref('sale_order_3'), ref('sale_order_4'), ref('sale_order_5')]]"/>
 

--- a/architects/__manifest__.py
+++ b/architects/__manifest__.py
@@ -47,7 +47,6 @@
         'data/uninstall_hook.xml',
     ],
     'demo': [
-        'demo/res_users.xml',
         'demo/res_partner.xml',
         'demo/appointment_type.xml',
         'demo/crm_lead.xml',

--- a/architects/demo/crm_lead.xml
+++ b/architects/demo/crm_lead.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True, 'mail_activity_quick_update': True}">
     <record id="crm_lead_1" model="crm.lead">
         <field name="name">Paris Apartment XIV</field>
         <field name="stage_id" ref="crm_stage_5" />

--- a/architects/demo/res_users.xml
+++ b/architects/demo/res_users.xml
@@ -1,6 +1,0 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
-    <record id="base.user_admin" model="res.users" forcecreate="0">
-        <field name="notification_type">inbox</field>
-    </record>
-</odoo>

--- a/architects/demo/sale_order.xml
+++ b/architects/demo/sale_order.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
     <record id="sale_order_1" model="sale.order">
         <field name="partner_id" ref="res_partner_11"/>
         <field name="user_id" ref="base.user_admin"/>

--- a/art_craft/__manifest__.py
+++ b/art_craft/__manifest__.py
@@ -47,7 +47,6 @@
         'data/knowledge_tour.xml',
     ],
     'demo': [
-        'demo/res_users.xml',
         'demo/res_partner.xml',
         'demo/crm_lead.xml',
         'demo/product_supplierinfo.xml',

--- a/art_craft/demo/crm_lead.xml
+++ b/art_craft/demo/crm_lead.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
     <record id="crm_lead_1" model="crm.lead">
         <field name="name">I need this painting, tell me the process</field>
         <field name="type">opportunity</field>

--- a/art_craft/demo/purchase_order.xml
+++ b/art_craft/demo/purchase_order.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
 
     <record id="purchase_order_8" model="purchase.order">
         <field name="partner_id" ref="res_partner_12"/>

--- a/art_craft/demo/res_users.xml
+++ b/art_craft/demo/res_users.xml
@@ -1,6 +1,0 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
-    <record id="base.user_admin" model="res.users" forcecreate="0">
-        <field name="notification_type">inbox</field>
-    </record>
-</odoo>

--- a/art_craft/demo/sale_order.xml
+++ b/art_craft/demo/sale_order.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
     <record id="sale_order_1" model="sale.order">
         <field name="partner_id" ref="res_partner_11"/>
         <field name="pricelist_id" ref="product_pricelist_3"/>

--- a/automobile/__manifest__.py
+++ b/automobile/__manifest__.py
@@ -45,7 +45,6 @@
         'data/knowledge_tour.xml',
     ],
     'demo': [
-        'demo/res_users.xml',
         'demo/res_partner.xml',
         'demo/stock_lot.xml',
         'demo/product_supplierinfo.xml',

--- a/automobile/demo/purchase_order.xml
+++ b/automobile/demo/purchase_order.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
     <record id="purchase_order_1" model="purchase.order">
         <field name="partner_id" ref="res_partner_8"/>
         <field name="user_id" ref="base.user_admin"/>

--- a/automobile/demo/res_users.xml
+++ b/automobile/demo/res_users.xml
@@ -1,6 +1,0 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
-    <record id="base.user_admin" model="res.users" forcecreate="0">
-        <field name="notification_type">inbox</field>
-    </record>
-</odoo>

--- a/automobile/demo/sale_order.xml
+++ b/automobile/demo/sale_order.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
     <record id="sale_order_1" model="sale.order">
         <field name="partner_id" ref="res_partner_9"/>
         <field name="user_id" ref="base.user_admin"/>

--- a/bakery/__manifest__.py
+++ b/bakery/__manifest__.py
@@ -25,7 +25,6 @@
         'data/hr_job.xml',
     ],
     'demo': [
-        'demo/res_users.xml',
         'demo/website_view.xml',
         'demo/delivery_carrier.xml',
         'demo/crm_tag.xml',

--- a/bakery/demo/purchase_order.xml
+++ b/bakery/demo/purchase_order.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
     <record id="purchase_order_2" model="purchase.order">
         <field name="partner_id" ref="res_partner_16"/>
         <field name="user_id" ref="base.user_admin"/>

--- a/bakery/demo/res_users.xml
+++ b/bakery/demo/res_users.xml
@@ -1,6 +1,0 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
-    <record id="base.user_admin" model="res.users" forcecreate="0">
-        <field name="notification_type">inbox</field>
-    </record>
-</odoo>

--- a/bakery/demo/sale_order.xml
+++ b/bakery/demo/sale_order.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
     <record id="sale_order_4" model="sale.order">
         <field name="partner_id" ref="res_partner_22"/>
         <field name="user_id" ref="base.user_admin"/>

--- a/bakery/demo/sale_order_confirm.xml
+++ b/bakery/demo/sale_order_confirm.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
     <function model="sale.order" name="action_confirm" eval="[[ref('sale_order_4'), ref('sale_order_3'), ref('sale_order_2')]]"/>
     <function name="_create_invoices" model="sale.order" eval="[ref('sale_order_3')]"/>
 </odoo>

--- a/bar_industry/__manifest__.py
+++ b/bar_industry/__manifest__.py
@@ -32,7 +32,6 @@
         'data/kitchen_display.xml',
     ],
     'demo': [
-        'demo/res_users.xml',
         'demo/res_partner.xml',
         'demo/hr_department.xml',
         'demo/hr_employee.xml',

--- a/bar_industry/demo/purchase_order.xml
+++ b/bar_industry/demo/purchase_order.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
     <record id="purchase_order_1" model="purchase.order">
         <field name="partner_id" ref="res_partner_13"/>
         <field name="user_id" ref="base.user_admin"/>

--- a/bar_industry/demo/res_users.xml
+++ b/bar_industry/demo/res_users.xml
@@ -1,6 +1,0 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
-    <record id="base.user_admin" model="res.users" forcecreate="0">
-        <field name="notification_type">inbox</field>
-    </record>
-</odoo>

--- a/base_industry_data/demo/res_users.xml
+++ b/base_industry_data/demo/res_users.xml
@@ -2,13 +2,11 @@
 <odoo noupdate="1">
     <record id="base.user_admin" model="res.users" forcecreate="0">
         <field name="image_1920" type="base64" file="base_industry_data/static/src/binary/res_users/1-image_1920"/>
-        <field name="notification_type">inbox</field>
     </record>
     <record id="res_users_7" model="res.users">
         <field name="name">Michael Demo</field>
         <field name="image_1920" type="base64" file="base_industry_data/static/src/binary/res_users/4-image_1920"/>
         <field name="login">michael.demo@yourcompany.example.com</field>
-        <field name="notification_type">inbox</field>
     </record>
     <record id="res_users_8" model="res.users">
         <field name="name">Lee Portal</field>

--- a/beverage_distributor/__manifest__.py
+++ b/beverage_distributor/__manifest__.py
@@ -44,7 +44,6 @@
         'data/knowledge_tour.xml',
     ],
     'demo': [
-        'demo/res_users.xml',
         'demo/res_partner.xml',
         'demo/crm_lead.xml',
         'demo/product_template.xml',

--- a/beverage_distributor/demo/crm_lead.xml
+++ b/beverage_distributor/demo/crm_lead.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
     <record id="crm_lead_1" model="crm.lead">
         <field name="name">Weekly Supply Contract</field>
         <field name="partner_id" ref="res_partner_20"/>

--- a/beverage_distributor/demo/mail_activity.xml
+++ b/beverage_distributor/demo/mail_activity.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_activity_quick_update': True}">
     <record id="mail_activity_1" model="mail.activity">
         <field name="res_model_id" ref="crm.model_crm_lead"/>
         <field name="date_deadline" eval="(DateTime.today() + relativedelta(days=3)).strftime('%Y-%m-%d %H:%M')"/>

--- a/beverage_distributor/demo/purchase_order.xml
+++ b/beverage_distributor/demo/purchase_order.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
     <record id="purchase_order_4" model="purchase.order">
         <field name="partner_id" ref="res_partner_39"/>
         <field name="user_id" ref="base.user_admin"/>

--- a/beverage_distributor/demo/res_users.xml
+++ b/beverage_distributor/demo/res_users.xml
@@ -1,6 +1,0 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
-    <record id="base.user_admin" model="res.users" forcecreate="0">
-        <field name="notification_type">inbox</field>
-    </record>
-</odoo>

--- a/beverage_distributor/demo/sale_order.xml
+++ b/beverage_distributor/demo/sale_order.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
     <record id="sale_order_21" model="sale.order">
         <field name="partner_id" ref="res_partner_22"/>
         <field name="user_id" ref="base.user_admin"/>

--- a/bike_leasing/__manifest__.py
+++ b/bike_leasing/__manifest__.py
@@ -46,7 +46,6 @@
         'data/knowledge_tour.xml',
     ],
     'demo': [
-        'demo/res_users.xml',
         'demo/res_partner.xml',
         'demo/hr_employee.xml',
         'demo/product_supplierinfo.xml',

--- a/bike_leasing/demo/helpdesk_ticket.xml
+++ b/bike_leasing/demo/helpdesk_ticket.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
-    <record id="helpdesk_ticket_1" model="helpdesk.ticket" context="{'mail_notrack': True}">
+<odoo noupdate="1" context="{'mail_notrack': True}">
+    <record id="helpdesk_ticket_1" model="helpdesk.ticket">
         <field name="name">Delivery Issue</field>
         <field name="partner_id" ref="res_partner_17"/>
         <field name="description"><![CDATA[ 
@@ -12,7 +12,7 @@
         <field name="team_id" ref="helpdesk.helpdesk_team1"/>
         <field name="stage_id" ref="helpdesk.stage_new"/>
     </record>
-    <record id="helpdesk_ticket_2" model="helpdesk.ticket" context="{'mail_notrack': True}">
+    <record id="helpdesk_ticket_2" model="helpdesk.ticket">
         <field name="name">Maintenance Request</field>
         <field name="partner_id" ref="res_partner_18"/>
         <field name="description"><![CDATA[ 

--- a/bike_leasing/demo/purchase_order.xml
+++ b/bike_leasing/demo/purchase_order.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
     <record id="purchase_order_1" model="purchase.order">
         <field name="partner_id" ref="res_partner_14"/>
         <field name="user_id" ref="base.user_admin"/>

--- a/bike_leasing/demo/res_users.xml
+++ b/bike_leasing/demo/res_users.xml
@@ -1,6 +1,0 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
-    <record id="base.user_admin" model="res.users" forcecreate="0">
-        <field name="notification_type">inbox</field>
-    </record>
-</odoo>

--- a/bike_leasing/demo/sale_order.xml
+++ b/bike_leasing/demo/sale_order.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
     <record id="sale_order_44" model="sale.order">
         <field name="partner_id" ref="res_partner_19"/>
         <field name="user_id" ref="base.user_admin"/>

--- a/bike_shop/__manifest__.py
+++ b/bike_shop/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Bike Shop',
-    'version': '1.0',
+    'version': '1.1',
     'category': 'Retail',
     'author': 'Odoo S.A.',
     'depends': [

--- a/bike_shop/demo/helpdesk_ticket.xml
+++ b/bike_shop/demo/helpdesk_ticket.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
-    <record id="helpdesk_ticket_1" model="helpdesk.ticket" context="{'mail_notrack': True}">
+<odoo noupdate="1" context="{'mail_notrack': True, 'mail_auto_subscribe_no_notify': True}">
+    <record id="helpdesk_ticket_1" model="helpdesk.ticket">
         <field name="name">WARRANTY-2025-0142</field>
         <field name="description">
             <![CDATA[<div data-oe-version="1.2">Customer reports a crack in the carbon frame near the seat tube after only ~4 months of use. No crash occurred, and the bike was maintained correctly. The issue appeared progressively over a

--- a/bike_shop/demo/purchase_order.xml
+++ b/bike_shop/demo/purchase_order.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
     <record id="purchase_order_1" model="purchase.order">
         <field name="user_id" ref="base.user_admin"/>
         <field name="partner_id" ref="res_partner_8" />

--- a/bike_shop/demo/res_partner.xml
+++ b/bike_shop/demo/res_partner.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
     <record id="base.main_partner" model="res.partner" forcecreate="1">
         <field name="is_published" eval="True" />
         <field name="image_1920" type="base64" file="bike_shop/static/src/binary/res_partner/1-image_1920" />

--- a/bike_shop/demo/sale_order.xml
+++ b/bike_shop/demo/sale_order.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
     <record id="sale_order_1" model="sale.order">
         <field name="partner_id" ref="res_partner_15" />
         <field name="user_id" ref="base.user_admin" />

--- a/billboard_rental/__manifest__.py
+++ b/billboard_rental/__manifest__.py
@@ -41,7 +41,6 @@
         'data/knowledge_tour.xml',
     ],
     'demo': [
-        'demo/res_users.xml',
         'demo/res_partner.xml',
         'demo/account_analytic_plan.xml',
         'demo/account_analytic_account.xml',

--- a/billboard_rental/demo/res_users.xml
+++ b/billboard_rental/demo/res_users.xml
@@ -1,6 +1,0 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
-    <record id="base.user_admin" model="res.users" forcecreate="0">
-        <field name="notification_type">inbox</field>
-    </record>
-</odoo>

--- a/billboard_rental/demo/sale_order.xml
+++ b/billboard_rental/demo/sale_order.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
     <record id="sale_order_1" model="sale.order">
         <field name="plan_id" ref="sale_subscription.subscription_plan_month"/>
         <field name="partner_id" ref="res_partner_14"/>

--- a/billboard_rental/demo/sale_order_post.xml
+++ b/billboard_rental/demo/sale_order_post.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True, 'mail_notrack': True}">
     <function name="action_confirm" model="sale.order" eval="[[ref('sale_order_1'), ref('sale_order_2'), ref('sale_order_3'), ref('sale_order_4'), ref('sale_order_5'), ref('sale_order_6'), ref('sale_order_7'), ref('sale_order_8'), ref('sale_order_9')]]"/>
 
     <function name="_create_invoices" model="sale.order">

--- a/booking_engine/__manifest__.py
+++ b/booking_engine/__manifest__.py
@@ -39,7 +39,6 @@
         'data/product_attribute_value.xml',
     ],
     'demo': [
-        'demo/res_users.xml',
         'demo/website_menu.xml',
         'demo/payment_provider_demo.xml',
     ],

--- a/booking_engine/demo/res_users.xml
+++ b/booking_engine/demo/res_users.xml
@@ -1,6 +1,0 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
-    <record id="base.user_admin" model="res.users" forcecreate="0">
-        <field name="notification_type">inbox</field>
-    </record>
-</odoo>

--- a/bookstore/__manifest__.py
+++ b/bookstore/__manifest__.py
@@ -38,7 +38,6 @@
         'data/knowledge_tour.xml',
     ],
     'demo': [
-        'demo/res_users.xml',
         'demo/res_partner.xml',
         'demo/product_supplierinfo.xml',
         'demo/loyalty_program.xml',

--- a/bookstore/demo/purchase_order.xml
+++ b/bookstore/demo/purchase_order.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
     <record id="purchase_order_1" model="purchase.order">
         <field name="x_purchase_type" eval="False"/>
         <field name="partner_id" ref="res_partner_14"/>

--- a/bookstore/demo/res_users.xml
+++ b/bookstore/demo/res_users.xml
@@ -1,6 +1,0 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
-    <record id="base.user_admin" model="res.users" forcecreate="0">
-        <field name="notification_type">inbox</field>
-    </record>
-</odoo>

--- a/bookstore/demo/sale_order.xml
+++ b/bookstore/demo/sale_order.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
     <record id="sale_order_1" model="sale.order">
         <field name="partner_id" ref="res_partner_13"/>
         <field name="user_id" ref="base.user_admin"/>

--- a/bowling/demo/calendar_event.xml
+++ b/bowling/demo/calendar_event.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
-  <record id="calendar_event_1" model="calendar.event" context="{'no_mail_to_attendees': True}">
+<odoo noupdate="1" context="{'mail_notrack': True, 'no_mail_to_attendees': True}">
+  <record id="calendar_event_1" model="calendar.event">
     <field name="name">Mark Demo - Book a Bowling Game Booking</field>
     <field name="user_id" ref="base.user_admin"/>
     <field name="location">MyCompany, Rue des Bourlottes 9, 1367 Ramillies, Belgium</field>
@@ -17,7 +17,7 @@
     <field name="appointment_status">booked</field>
     <field name="appointment_booker_id" ref="res_partner_44"/>
   </record>
-  <record id="calendar_event_3" model="calendar.event" context="{'no_mail_to_attendees': True}">
+  <record id="calendar_event_3" model="calendar.event">
     <field name="name">John Smith - Book a Bowling Game Booking</field>
     <field name="user_id" ref="base.user_admin"/>
     <field name="location">MyCompany, Rue des Bourlottes 9, 1367 Ramillies, Belgium</field>

--- a/cake_shop/__manifest__.py
+++ b/cake_shop/__manifest__.py
@@ -30,7 +30,6 @@
         'data/pos_config.xml',
     ],
     'demo': [
-        'demo/res_users.xml',
         'demo/res_company.xml',
         'demo/delivery_carrier.xml',
         'demo/ir_attachment.xml',

--- a/cake_shop/demo/purchase_order.xml
+++ b/cake_shop/demo/purchase_order.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
     <record id="purchase_order_1" model="purchase.order">
         <field name="partner_id" ref="res_partner_15"/>
         <field name="user_id" ref="base.user_admin"/>

--- a/cake_shop/demo/res_users.xml
+++ b/cake_shop/demo/res_users.xml
@@ -1,6 +1,0 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
-    <record id="base.user_admin" model="res.users" forcecreate="0">
-        <field name="notification_type">inbox</field>
-    </record>
-</odoo>

--- a/cake_shop/demo/sale_order.xml
+++ b/cake_shop/demo/sale_order.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
     <record id="sale_order_1" model="sale.order">
         <field name="partner_id" ref="res_partner_8"/>
         <field name="user_id" ref="base.user_admin"/>

--- a/campsite/demo/sale_order.xml
+++ b/campsite/demo/sale_order.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
     <record id="sale_order_1" model="sale.order">
         <field name="partner_id" ref="base_industry_data.res_partner_20"/>
         <field name="user_id" ref="base.user_admin"/>

--- a/candy_shop/demo/purchase_order.xml
+++ b/candy_shop/demo/purchase_order.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
   <record id="purchase_order_3" model="purchase.order">
     <field name="partner_id" ref="base_industry_data.res_partner_28"/>
     <field name="user_id" ref="base.user_admin"/>

--- a/candy_shop/demo/sale_order.xml
+++ b/candy_shop/demo/sale_order.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
   <record id="sale_order_4" model="sale.order">
     <field name="partner_id" ref="res_partner_38"/>
     <field name="user_id" ref="base.user_admin"/>

--- a/carpenter/demo/crm_lead.xml
+++ b/carpenter/demo/crm_lead.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
   <record id="crm_lead_1" model="crm.lead">
     <field name="name">Info for new roof's opportunity</field>
     <field name="stage_id" ref="crm.stage_lead2"/>

--- a/carpenter/demo/purchase_order.xml
+++ b/carpenter/demo/purchase_order.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
   <record id="purchase_order_2" model="purchase.order">
     <field name="user_id" ref="base.user_admin"/>
     <field name="partner_id" ref="base_industry_data.res_partner_21"/>

--- a/carpenter/demo/sale_order.xml
+++ b/carpenter/demo/sale_order.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
   <record id="sale_order_1" model="sale.order">
     <field name="partner_id" ref="base_industry_data.res_users_8_res_partner"/>
     <field name="sale_order_template_id" ref="sale_order_template_1"/>

--- a/carpenter/demo/sale_order_line.xml
+++ b/carpenter/demo/sale_order_line.xml
@@ -3,6 +3,7 @@
   <record id="sale_order_line_1" model="sale.order.line">
     <field name="order_id" ref="sale_order_1"/>
     <field name="product_id" ref="product_product_3"/>
+    <field name="product_uom_qty">8.0</field>
     <field name="price_unit">7100.0</field>
     <field name="name"><![CDATA[Site protection
 Demolition and Preparation

--- a/carpenter/demo/sale_order_post.xml
+++ b/carpenter/demo/sale_order_post.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
   <!--Update sale order stages-->
   <function model="sale.order" name="action_confirm" eval="[[ref('sale_order_1')]]"/>
 

--- a/catering/demo/calendar_event.xml
+++ b/catering/demo/calendar_event.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
-  <record id="calendar_event_2" model="calendar.event" context="{'no_mail_to_attendees': True}">
+<odoo noupdate="1" context="{'no_mail_to_attendees': True}">
+  <record id="calendar_event_2" model="calendar.event">
     <field name="name">Tasting Food Corporate Holiday Party Catering</field>
     <field name="description"><![CDATA[<div><strong>Organized by</strong><br>Admin<br><a href="mailto:****@example.com">****@example.com</a></div>]]></field>
     <field name="location">My Office</field>
@@ -9,7 +9,7 @@
     <field name="res_model_id" ref="crm.model_crm_lead"/>
     <field name="opportunity_id" ref="crm_lead_6"/>
   </record>
-  <record id="calendar_event_1" model="calendar.event" context="{'no_mail_to_attendees': True}">
+  <record id="calendar_event_1" model="calendar.event">
     <field name="partner_ids" eval="[(6, 0, [ref('base.partner_admin'), ref('base_industry_data.res_partner_29')])]"/>
     <field name="name">Won - Sarah Davis Wedding</field>
     <field name="description"><![CDATA[<div><strong>Organized by</strong><br>Admin<br><a href="mailto:****@example.com">****@example.com</a><br><br><strong>Contact Details</strong><br>Sarah Davis<br><a href="mailto:sarah.davis@b2c.example.com">sarah.davis@b2c.example.com</a></div>]]></field>

--- a/catering/demo/crm_lead.xml
+++ b/catering/demo/crm_lead.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True, 'mail_activity_quick_update': True}">
   <record id="crm_lead_1" model="crm.lead">
     <field name="partner_id" ref="base_industry_data.res_partner_29"/>
     <field name="name">Won - Sarah Davis Wedding</field>

--- a/catering/demo/purchase_order.xml
+++ b/catering/demo/purchase_order.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
   <record id="purchase_order_3" model="purchase.order">
     <field name="partner_id" ref="base_industry_data.res_partner_20"/>
     <field name="dest_address_id" ref="res_partner_38"/>

--- a/catering/demo/sale_order.xml
+++ b/catering/demo/sale_order.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
   <record id="sale_order_3" model="sale.order">
     <field name="partner_id" ref="base_industry_data.res_partner_34"/>
     <field name="sale_order_template_id" ref="sale_order_template_3"/>

--- a/catering/demo/sale_order_confirm.xml
+++ b/catering/demo/sale_order_confirm.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
     <function model="sale.order" name="action_confirm" eval="[[ref('sale_order_1'),ref('sale_order_2')]]"/>
     <function model="sale.order" name="action_quotation_sent" eval="[[ref('sale_order_3')]]"/>
 

--- a/certification_organism/__manifest__.py
+++ b/certification_organism/__manifest__.py
@@ -40,7 +40,6 @@
         'data/knowledge_tour.xml',
     ],
     'demo': [
-        'demo/res_users.xml',
         'demo/res_partner.xml',
         'demo/hr_leave.xml',
         'demo/crm_tag.xml',

--- a/certification_organism/demo/crm_lead.xml
+++ b/certification_organism/demo/crm_lead.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
     <record id="crm_lead_1" model="crm.lead">
         <field name="name">Certification Inquiry for Residential Charging Station</field>
         <field name="partner_id" ref="res_partner_8" />

--- a/certification_organism/demo/hr_leave.xml
+++ b/certification_organism/demo/hr_leave.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_activity_quick_update': True}">
     <record id="hr_leave_1" model="hr.leave">
         <field name="request_date_from" eval="DateTime.today() + relativedelta(days=10)"/>
         <field name="request_date_to" eval="DateTime.today() + relativedelta(days=14)"/>

--- a/certification_organism/demo/res_partner.xml
+++ b/certification_organism/demo/res_partner.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
     <record id="res_partner_10" model="res.partner">
         <field name="name">PowerTech Solutions Ltd.</field>
         <field name="email">nathan.bennett@powertech-solutions-example.com</field>

--- a/certification_organism/demo/res_users.xml
+++ b/certification_organism/demo/res_users.xml
@@ -1,6 +1,0 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
-    <record id="base.user_admin" model="res.users" forcecreate="0">
-        <field name="notification_type">inbox</field>
-    </record>
-</odoo>

--- a/certification_organism/demo/sale_order.xml
+++ b/certification_organism/demo/sale_order.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
     <record id="sale_order_1" model="sale.order">
         <field name="partner_id" ref="res_partner_8" />
         <field name="tag_ids" eval="[(6, 0, [ref('crm_tag_2')])]" />

--- a/certification_organism/demo/sale_order_post_action.xml
+++ b/certification_organism/demo/sale_order_post_action.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
 	<!-- Confirm action -->
     <function model="sale.order" name="action_confirm">
         <value eval="[ref('sale_order_1'), ref('sale_order_2'), ref('sale_order_3'), ref('sale_order_4')]"/>

--- a/cleaning_services/demo/crm_lead.xml
+++ b/cleaning_services/demo/crm_lead.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
   <record id="crm_lead_1" model="crm.lead">
     <field name="name">Emily Johnson's opportunity</field>
     <field name="partner_id" ref="base_industry_data.res_partner_24"/>

--- a/cleaning_services/demo/purchase_order.xml
+++ b/cleaning_services/demo/purchase_order.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
   <record id="purchase_order_2" model="purchase.order">
     <field name="partner_id" ref="res_partner_36"/>
     <field name="user_id" ref="base.user_admin"/>

--- a/cleaning_services/demo/sale_order.xml
+++ b/cleaning_services/demo/sale_order.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
   <record id="sale_order_1" model="sale.order">
     <field name="partner_id" ref="base_industry_data.res_partner_27"/>
     <field name="sale_order_template_id" ref="sale_order_template_1"/>

--- a/cleaning_services/demo/sale_order_confirm.xml
+++ b/cleaning_services/demo/sale_order_confirm.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True, 'mail_notrack': True}">
     <function model="sale.order" name="action_confirm" eval="[[ref('sale_order_1'),ref('sale_order_2'),ref('sale_order_3'),ref('sale_order_4')]]"/>
 
     <function model="project.task" name="write">

--- a/climbing_gym/demo/event_event.xml
+++ b/climbing_gym/demo/event_event.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
     <record id="event_event_1" model="event.event">
         <field name="cover_properties"><![CDATA[{"background-image":"url(/web/image/climbing_gym.ir_attachment_1013)","background_color_class":"o_cc3 o_cc","background_color_style":"","opacity":"0.4","resize_class":"o_half_screen_height o_record_has_cover","text_align_class":""}]]></field>
         <field name="name">Annual Bouldering Showdown</field>

--- a/climbing_gym/demo/sale_order.xml
+++ b/climbing_gym/demo/sale_order.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
     <record id="sale_order_1" model="sale.order">
         <field name="partner_id" ref="base_industry_data.res_partner_29"/>
         <field name="prepayment_percent">1.0</field>

--- a/climbing_gym/demo/sale_order_confirm.xml
+++ b/climbing_gym/demo/sale_order_confirm.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True, 'mail_notrack': True}">
     <function model="sale.order" name="action_confirm" eval="[[ref('sale_order_3'), ref('sale_order_2'), ref('sale_order_1')]]"/>
     
     <function model="sale.order" name="action_open_reward_wizard" eval="[[ref('sale_order_6')]]"/>

--- a/clothing_boutique/__manifest__.py
+++ b/clothing_boutique/__manifest__.py
@@ -34,7 +34,6 @@
         'data/knowledge_tour.xml',
     ],
     'demo': [
-        'demo/res_users.xml',
         'demo/res_partner.xml',
         'demo/product_supplierinfo.xml',
         'demo/loyalty_program.xml',

--- a/clothing_boutique/demo/purchase_order.xml
+++ b/clothing_boutique/demo/purchase_order.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
     <record id="purchase_order_1" model="purchase.order">
         <field name="partner_id" ref="res_partner_7"/>
         <field name="user_id" ref="base.user_admin"/>

--- a/clothing_boutique/demo/res_users.xml
+++ b/clothing_boutique/demo/res_users.xml
@@ -1,6 +1,0 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
-    <record id="base.user_admin" model="res.users" forcecreate="0">
-        <field name="notification_type">inbox</field>
-    </record>
-</odoo>

--- a/clothing_boutique/demo/sale_order.xml
+++ b/clothing_boutique/demo/sale_order.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
     <record id="sale_order_1" model="sale.order">
         <field name="partner_id" ref="res_partner_16"/>
         <field name="user_id" ref="base.user_admin"/>

--- a/clothing_boutique/demo/sale_order_confirm.xml
+++ b/clothing_boutique/demo/sale_order_confirm.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
     <function model="sale.order" name="action_confirm" eval="[[ref('sale_order_1'), ref('sale_order_2')]]"/>
     <function model="stock.picking" name="button_validate">
         <value model="stock.picking" eval="(

--- a/coal_petroleum/__manifest__.py
+++ b/coal_petroleum/__manifest__.py
@@ -43,7 +43,6 @@
         'data/knowledge_tour.xml',
     ],
     'demo': [
-        'demo/res_users.xml',
         'demo/res_partner.xml',
         'demo/product_supplierinfo.xml',
         'demo/stock_lot.xml',

--- a/coal_petroleum/demo/purchase_order.xml
+++ b/coal_petroleum/demo/purchase_order.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
     <record id="purchase_order_1" model="purchase.order">
         <field name="partner_id" ref="res_partner_9"/>
         <field name="user_id" ref="base.user_admin"/>

--- a/coal_petroleum/demo/res_users.xml
+++ b/coal_petroleum/demo/res_users.xml
@@ -1,6 +1,0 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
-    <record id="base.user_admin" model="res.users" forcecreate="0">
-        <field name="notification_type">inbox</field>
-    </record>
-</odoo>

--- a/coal_petroleum/demo/sale_order.xml
+++ b/coal_petroleum/demo/sale_order.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
     <record id="sale_order_1" model="sale.order">
         <field name="partner_id" ref="res_partner_10"/>
         <field name="user_id" ref="base.user_admin"/>

--- a/coal_petroleum/demo/sale_order_post.xml
+++ b/coal_petroleum/demo/sale_order_post.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
     <function model="sale.order" name="action_confirm">
         <value eval="[
             ref('sale_order_1'),

--- a/concert_halls/demo/crm_lead.xml
+++ b/concert_halls/demo/crm_lead.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
   <record id="crm_lead_1" model="crm.lead">
     <field name="name">Venue request for winter tour</field>
     <field name="team_id" ref="sales_team.team_sales_department"/>

--- a/concert_halls/demo/event_event.xml
+++ b/concert_halls/demo/event_event.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
     <record id="event_event_2" model="event.event">
         <field name="name">The Beatles</field>
         <field name="cover_properties"><![CDATA[{"background-image":"url(/web/image/concert_halls.ir_attachment_1112)","resize_class":"cover_auto o_record_has_cover","opacity":"0.4","background_color_class":"o_cc o_cc3"}]]></field>

--- a/condominium/__manifest__.py
+++ b/condominium/__manifest__.py
@@ -55,7 +55,6 @@
         'data/x_properties_tag.xml',
     ],
     'demo': [
-        'demo/res_users.xml',
         'demo/res_partner.xml',
         'demo/res_company.xml',
         'demo/x_buildings.xml',

--- a/condominium/demo/calendar_event.xml
+++ b/condominium/demo/calendar_event.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
-  <record id="calendar_event_30" model="calendar.event" context="{'no_mail_to_attendees': True}">
+<odoo noupdate="1" context="{'no_mail_to_attendees': True}">
+  <record id="calendar_event_30" model="calendar.event">
     <field name="name">General Meeting</field>
     <field name="x_voting_key_id" ref="x_distribution_key_3"/>
     <field name="user_id" ref="base.user_admin"/>

--- a/condominium/demo/helpdesk_ticket.xml
+++ b/condominium/demo/helpdesk_ticket.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
-  <record id="helpdesk_ticket_7" model="helpdesk.ticket" context="{'mail_notrack': True}">
+<odoo noupdate="1" context="{'mail_notrack': True}">
+  <record id="helpdesk_ticket_7" model="helpdesk.ticket">
     <field name="name">Raj Sharma's Ticket</field>
     <field name="stage_id" ref="helpdesk.stage_solved"/>
     <field name="team_id" ref="helpdesk_team_1"/>

--- a/condominium/demo/res_partner.xml
+++ b/condominium/demo/res_partner.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
   <record id="base.main_partner" model="res.partner" forcecreate="1">
     <field name="image_1920" type="base64" file="condominium/static/src/binary/res_partner/main_partner_image"/>
     <field name="name">My Company</field>
@@ -8,7 +8,7 @@
     <field name="is_company" eval="True"/>
     <field name="supplier_rank">3</field>
   </record>
-  <record id="res_partner_32" model="res.partner" context="{'mail_auto_subscribe_no_notify': True}">
+  <record id="res_partner_32" model="res.partner">
     <field name="name">Charlotte M. Warren</field>
     <field name="user_id" ref="base.user_admin"/>
     <field name="country_id" ref="base.us"/>
@@ -19,7 +19,7 @@
     <field name="phone">+1 559-667-9088</field>
     <field name="supplier_rank">5</field>
   </record>
-  <record id="res_partner_46" model="res.partner" context="{'mail_auto_subscribe_no_notify': True}">
+  <record id="res_partner_46" model="res.partner">
     <field name="name">Archi</field>
     <field name="user_id" ref="base.user_admin"/>
     <field name="country_id" ref="base.us"/>
@@ -30,7 +30,7 @@
     <field name="phone">+1 559-667-9088</field>
     <field name="supplier_rank">5</field>
   </record>
-  <record id="res_partner_7" model="res.partner" context="{'mail_auto_subscribe_no_notify': True}">
+  <record id="res_partner_7" model="res.partner">
     <field name="image_1920" type="base64" file="condominium/static/src/binary/res_partner/res_partner_7"/>
     <field name="name">Green Island Condominium</field>
     <field name="user_id" ref="base.user_admin"/>
@@ -42,7 +42,7 @@
     <field name="is_company" eval="True"/>
     <field name="supplier_rank">1</field>
   </record>
-  <record id="res_partner_34" model="res.partner" context="{'mail_auto_subscribe_no_notify': True}">
+  <record id="res_partner_34" model="res.partner">
     <field name="name">Harold J. Butler</field>
     <field name="user_id" ref="base.user_admin"/>
     <field name="country_id" ref="base.us"/>
@@ -52,7 +52,7 @@
     <field name="email">HaroldJButler@dayrep.com</field>
     <field name="phone">+1 310-704-6950</field>
   </record>
-  <record id="res_partner_36" model="res.partner" context="{'mail_auto_subscribe_no_notify': True}">
+  <record id="res_partner_36" model="res.partner">
     <field name="name">Janet D. Halle</field>
     <field name="user_id" ref="base.user_admin"/>
     <field name="country_id" ref="base.us"/>
@@ -63,7 +63,7 @@
     <field name="phone">+1 620-778-6587</field>
     <field name="supplier_rank">1</field>
   </record>
-  <record id="res_partner_40" model="res.partner" context="{'mail_auto_subscribe_no_notify': True}">
+  <record id="res_partner_40" model="res.partner">
     <field name="name">Jesse C. Clark</field>
     <field name="country_id" ref="base.us"/>
     <field name="street">4103 Bassell Avenue</field>
@@ -72,7 +72,7 @@
     <field name="email">JesseCClark@dayrep.com</field>
     <field name="phone">+1 501-764-3011</field>
   </record>
-  <record id="res_partner_20" model="res.partner" context="{'mail_auto_subscribe_no_notify': True}">
+  <record id="res_partner_20" model="res.partner">
     <field name="name">Margaret E. Lowe</field>
     <field name="user_id" ref="base.user_admin"/>
     <field name="country_id" ref="base.us"/>
@@ -82,7 +82,7 @@
     <field name="email">MargaretELowe@jourrapide.com</field>
     <field name="phone">+1 509-232-0348</field>
   </record>
-  <record id="res_partner_33" model="res.partner" context="{'mail_auto_subscribe_no_notify': True}">
+  <record id="res_partner_33" model="res.partner">
     <field name="name">Micheal E. Rosales</field>
     <field name="country_id" ref="base.us"/>
     <field name="street2">2175 Haymond Rocks Road</field>
@@ -93,12 +93,12 @@
     <field name="email">MichealERosales@teleworm.us</field>
     <field name="phone">+1 541-488-6003</field>
   </record>
-  <record id="res_partner_45" model="res.partner" context="{'mail_auto_subscribe_no_notify': True}">
+  <record id="res_partner_45" model="res.partner">
     <field name="name">OXO Insurances</field>
     <field name="is_company" eval="True"/>
     <field name="supplier_rank">9</field>
   </record>
-  <record id="res_partner_41" model="res.partner" context="{'mail_auto_subscribe_no_notify': True}">
+  <record id="res_partner_41" model="res.partner">
     <field name="name">Oscar S. Hoffman</field>
     <field name="country_id" ref="base.us"/>
     <field name="street">4588 Glen Falls Road</field>
@@ -107,7 +107,7 @@
     <field name="email">OscarSHoffman@armyspy.com</field>
     <field name="phone">+1 215-867-0874</field>
   </record>
-  <record id="res_partner_39" model="res.partner" context="{'mail_auto_subscribe_no_notify': True}">
+  <record id="res_partner_39" model="res.partner">
     <field name="name">Peter E. Lee</field>
     <field name="country_id" ref="base.us"/>
     <field name="street">2970 George Avenue</field>
@@ -116,7 +116,7 @@
     <field name="email">PeterELee@teleworm.us</field>
     <field name="phone">+1 530-512-9589</field>
   </record>
-  <record id="res_partner_38" model="res.partner" context="{'mail_auto_subscribe_no_notify': True}">
+  <record id="res_partner_38" model="res.partner">
     <field name="name">Ronda V. Jones</field>
     <field name="user_id" ref="base.user_admin"/>
     <field name="country_id" ref="base.us"/>
@@ -126,12 +126,12 @@
     <field name="email">RondaVJones@jourrapide.com</field>
     <field name="phone">+1 847-616-6527</field>
   </record>
-  <record id="res_partner_37" model="res.partner" context="{'mail_auto_subscribe_no_notify': True}">
+  <record id="res_partner_37" model="res.partner">
     <field name="name">Water Distribution Inc.</field>
     <field name="is_company" eval="True"/>
     <field name="supplier_rank">7</field>
   </record>
-  <record id="res_partner_35" model="res.partner" context="{'mail_auto_subscribe_no_notify': True}">
+  <record id="res_partner_35" model="res.partner">
     <field name="name">Steven S. Jackson</field>
     <field name="user_id" ref="base.user_admin"/>
     <field name="street">921 Lynn Avenue</field>
@@ -140,7 +140,7 @@
     <field name="email">StevenSJackson@armyspy.com</field>
     <field name="phone">+1 715-503-2752</field>
   </record>
-  <record id="res_partner_42" model="res.partner" context="{'mail_auto_subscribe_no_notify': True}">
+  <record id="res_partner_42" model="res.partner">
     <field name="name">Todd S. Zimmerman</field>
     <field name="country_id" ref="base.us"/>
     <field name="street">2631 Pickens Way</field>

--- a/condominium/demo/res_users.xml
+++ b/condominium/demo/res_users.xml
@@ -1,6 +1,0 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
-    <record id="base.user_admin" model="res.users" forcecreate="0">
-        <field name="notification_type">inbox</field>
-    </record>
-</odoo>

--- a/condominium/demo/sale_order.xml
+++ b/condominium/demo/sale_order.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
   <record id="sale_order_128" model="sale.order">
     <field name="partner_id" ref="res_partner_35"/>
     <field name="company_id" ref="res_company_2"/>

--- a/condominium/demo/sale_order_confirm.xml
+++ b/condominium/demo/sale_order_confirm.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo>
+<odoo context="{'mail_auto_subscribe_no_notify': True, 'mail_notrack': True}">
   <function name="run" model="ir.actions.server" context="{'active_model': 'sale.order', 'active_id': ref('sale_order_119')}" eval="[ref('ir_act_server_split_per_property')]"/>
   <function name="run" model="ir.actions.server" context="{'active_model': 'sale.order', 'active_id': ref('sale_order_112')}" eval="[ref('ir_act_server_split_per_property')]"/>
   <function name="run" model="ir.actions.server" context="{'active_model': 'sale.order', 'active_id': ref('sale_order_105')}" eval="[ref('ir_act_server_split_per_property')]"/>

--- a/construction/demo/crm_lead.xml
+++ b/construction/demo/crm_lead.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
     <record id="crm_lead_1" model="crm.lead">
         <field name="name">Construction of a new house</field>
         <field name="partner_id" ref="base_industry_data.res_partner_22" />

--- a/construction/demo/mail_activity.xml
+++ b/construction/demo/mail_activity.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_activity_quick_update': True}">
   <record id="mail_activity_2" model="mail.activity">
     <field name="res_model_id" ref="project.model_project_task"/>
     <field name="res_id" ref="project_task_26"/>

--- a/construction/demo/project_project.xml
+++ b/construction/demo/project_project.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
     <record id="industry_fsm.fsm_project" model="project.project" forcecreate="True">
         <field name="stage_id" ref="project.project_project_stage_1"/>
         <field name="allow_material" eval="True"/>

--- a/construction/demo/project_task.xml
+++ b/construction/demo/project_task.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<odoo noupdate="1" auto_sequence="1">
+<odoo noupdate="1" auto_sequence="1" context="{'mail_auto_subscribe_no_notify': True}">
     <!-- project template tasks: needed before sale orders are created -->
     <record id="project_task_5" model="project.task">
         <field name="name">Architect</field>
@@ -22,8 +22,7 @@
         <field name="stage_id" ref="planning_project_stage_0" />
         <field name="allocated_hours">4.0</field>
     </record>
-    <record id="project_task_8"
-        model="project.task">
+    <record id="project_task_8" model="project.task">
         <field name="name">Planification</field>
         <field name="user_ids" eval="[Command.set([ref('base.user_admin')])]" />
         <field name="project_id" ref="project_project_3" />

--- a/construction/demo/project_task_post.xml
+++ b/construction/demo/project_task_post.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<odoo noupdate="1" auto_sequence="1">
+<odoo noupdate="1" auto_sequence="1" context="{'mail_auto_subscribe_no_notify': True}">
     <record id="project_task_14" model="project.task">
         <field name="name">The wall fell</field>
         <field name="user_ids" eval="[Command.set([ref('base.user_admin')])]" />

--- a/construction/demo/purchase_order.xml
+++ b/construction/demo/purchase_order.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
     <record id="purchase_order_1" model="purchase.order">
         <field name="partner_id" ref="base_industry_data.res_partner_34"/>
         <field name="user_id" ref="base.user_admin"/>

--- a/construction/demo/sale_order.xml
+++ b/construction/demo/sale_order.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
     <record id="sale_order_1" model="sale.order">
         <field name="partner_id" ref="base_industry_data.res_partner_25" />
         <field name="user_id" ref="base.user_admin" />

--- a/construction/demo/sale_order_confirm.xml
+++ b/construction/demo/sale_order_confirm.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
 
     <!-- Confirm sale orders and assign XML IDs to their created projects -->
     <!-- S00001 -->

--- a/construction_developer/demo/project_project.xml
+++ b/construction_developer/demo/project_project.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
     <record id="project_project_16" model="project.project">
         <field name="name">S00003 - Rodriguez / Carport Installation</field>
         <field name="allow_material" eval="True"/>

--- a/construction_developer/demo/sale_order.xml
+++ b/construction_developer/demo/sale_order.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
   <record id="sale_order_41" model="sale.order">
     <field name="partner_id" ref="res_partner_30"/>
     <field name="sale_order_template_id" ref="sale_order_template_2"/>

--- a/construction_developer/demo/sale_order_confirm.xml
+++ b/construction_developer/demo/sale_order_confirm.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
 
     <!-- Confirm sale orders and assign XML IDs to their created projects -->
     <!-- S00003 -->

--- a/corporate_gifts/__manifest__.py
+++ b/corporate_gifts/__manifest__.py
@@ -54,7 +54,6 @@
         'data/knowledge_tour.xml',
     ],
     'demo': [
-        'demo/res_users.xml',
         'demo/res_partner.xml',
         'demo/hr_employee.xml',
         'demo/crm_lead.xml',

--- a/corporate_gifts/demo/crm_lead.xml
+++ b/corporate_gifts/demo/crm_lead.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
-    <record id="crm_lead_1" model="crm.lead" >
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
+    <record id="crm_lead_1" model="crm.lead">
         <field name="name">50 corporate t-shirts</field>
         <field name="stage_id" ref="crm.stage_lead4" />
         <field name="tag_ids" eval="[(6, 0, [ref('crm_tag_2')])]" />
@@ -11,7 +11,7 @@
         <field name="probability">100.0</field>
         <field name="user_id" ref="base.user_admin"/>
     </record>
-    <record id="crm_lead_2" model="crm.lead" >
+    <record id="crm_lead_2" model="crm.lead">
         <field name="name">Need T-Shirt for AsusTek</field>
         <field name="stage_id" ref="crm.stage_lead4" />
         <field name="tag_ids" eval="[(6, 0, [ref('crm_tag_2')])]" />
@@ -39,7 +39,7 @@
         ]]>
         </field>
     </record>
-    <record id="crm_lead_3" model="crm.lead" >
+    <record id="crm_lead_3" model="crm.lead">
         <field name="name">20 Tshirts Women - pocket printing</field>
         <field name="stage_id" ref="crm.stage_lead2" />
         <field name="tag_ids" eval="[(6, 0, [ref('crm_tag_2')])]" />

--- a/corporate_gifts/demo/purchase_order.xml
+++ b/corporate_gifts/demo/purchase_order.xml
@@ -1,16 +1,16 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
-    <record id="purchase_order_1" model="purchase.order" >
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
+    <record id="purchase_order_1" model="purchase.order">
         <field name="partner_id" ref="res_partner_11"/>
         <field name="picking_type_id" ref="stock.picking_type_in"/>
         <field name="user_id" ref="base.user_admin"/>
     </record>
-    <record id="purchase_order_2" model="purchase.order" >
+    <record id="purchase_order_2" model="purchase.order">
         <field name="partner_id" ref="res_partner_11"/>
         <field name="picking_type_id" ref="stock.picking_type_in"/>
         <field name="user_id" ref="base.user_admin"/>
     </record>
-    <record id="purchase_order_3" model="purchase.order" >
+    <record id="purchase_order_3" model="purchase.order">
         <field name="partner_id" ref="res_partner_11"/>
         <field name="picking_type_id" ref="stock.picking_type_in"/>
         <field name="user_id" ref="base.user_admin"/>

--- a/corporate_gifts/demo/res_users.xml
+++ b/corporate_gifts/demo/res_users.xml
@@ -1,6 +1,0 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
-    <record id="base.user_admin" model="res.users" forcecreate="0">
-        <field name="notification_type">inbox</field>
-    </record>
-</odoo>

--- a/corporate_gifts/demo/sale_order.xml
+++ b/corporate_gifts/demo/sale_order.xml
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
-    <record id="sale_order_10" model="sale.order" >
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
+    <record id="sale_order_10" model="sale.order">
         <field name="sale_order_template_id" ref="sale_order_template_1"/>
         <field name="partner_id" ref="base.partner_admin"/>
         <field name="opportunity_id" ref="crm_lead_3"/>
         <field name="tag_ids" eval="[(6, 0, [ref('crm_tag_2')])]"/>
         <field name="user_id" ref="base.user_admin"/>
     </record>
-    <record id="sale_order_4" model="sale.order" >
+    <record id="sale_order_4" model="sale.order">
         <field name="partner_id" ref="base.partner_admin"/>
         <field name="website_id" ref="website.default_website"/>
         <field name="user_id" ref="base.user_admin"/>

--- a/cosmetics_store/__manifest__.py
+++ b/cosmetics_store/__manifest__.py
@@ -37,7 +37,6 @@
         'data/knowledge_tour.xml',
     ],
     'demo': [
-        'demo/res_users.xml',
         'demo/payment_provider_demo.xml',
         'demo/stock_quant.xml',
         'demo/product_template.xml',

--- a/cosmetics_store/demo/purchase_order.xml
+++ b/cosmetics_store/demo/purchase_order.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
   <record id="purchase_order_2" model="purchase.order">
     <field name="partner_id" ref="res_partner_12"/>
     <field name="user_id" ref="base.user_admin"/>

--- a/cosmetics_store/demo/res_partner.xml
+++ b/cosmetics_store/demo/res_partner.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
   <record id="res_partner_11" model="res.partner">
     <field name="image_1920" type="base64" file="cosmetics_store/static/src/binary/res_partner/res_partner_11"/>
     <field name="name">Alexis Moreau</field>

--- a/cosmetics_store/demo/res_users.xml
+++ b/cosmetics_store/demo/res_users.xml
@@ -1,6 +1,0 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
-    <record id="base.user_admin" model="res.users" forcecreate="0">
-        <field name="notification_type">inbox</field>
-    </record>
-</odoo>

--- a/cosmetics_store/demo/sale_order.xml
+++ b/cosmetics_store/demo/sale_order.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
   <record id="sale_order_9" model="sale.order">
     <field name="partner_id" ref="base.partner_admin"/>
     <field name="user_id" ref="base.user_admin"/>

--- a/coworking/demo/calendar_event.xml
+++ b/coworking/demo/calendar_event.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
-  <record id="calendar_event_4" model="calendar.event" context="{'no_mail_to_attendees': True}">
+<odoo noupdate="1" context="{'no_mail_to_attendees': True, 'mail_notrack': True}">
+  <record id="calendar_event_4" model="calendar.event">
     <field name="name">Sarah Davis - Meeting Room Booking</field>
     <field name="location">MyCompany, Rue des Bourlottes 9, 1367 Ramillies, Belgium</field>
     <field name="duration">1.0</field>
@@ -18,7 +18,7 @@
     <field name="alarm_ids" eval="[(6, 0, [ref('calendar.alarm_mail_1'), ref('appointment_sms.calendar_alarm_data_1h_sms')])]"/>
     <field name="appointment_status">booked</field>
   </record>
-  <record id="calendar_event_5" model="calendar.event" context="{'no_mail_to_attendees': True}">
+  <record id="calendar_event_5" model="calendar.event">
     <field name="name">Sarah Davis - Shared desk Booking</field>
     <field name="user_id" ref="base.user_admin"/>
     <field name="location">MyCompany, Rue des Bourlottes 9, 1367 Ramillies, Belgium</field>
@@ -37,7 +37,7 @@
     <field name="alarm_ids" eval="[(6, 0, [ref('calendar.alarm_mail_1'), ref('appointment_sms.calendar_alarm_data_1h_sms')])]"/>
     <field name="appointment_status">booked</field>
   </record>
-  <record id="calendar_event_1" model="calendar.event" context="{'no_mail_to_attendees': True}">
+  <record id="calendar_event_1" model="calendar.event">
     <field name="name">Rana - 1st tour</field>
     <field name="duration">0.5</field>
     <field name="start" model="appointment.type" eval="

--- a/coworking/demo/crm_lead.xml
+++ b/coworking/demo/crm_lead.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
   <record id="crm_lead_1" model="crm.lead">
     <field name="name">Second Company's opportunity</field>
     <field name="partner_id" ref="base_industry_data.res_partner_22"/>

--- a/coworking/demo/event_event.xml
+++ b/coworking/demo/event_event.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
     <record id="event_event_1" model="event.event">
         <field name="name">Afterwork September</field>
         <field name="user_id" ref="base.user_admin"/>

--- a/coworking/demo/res_partner.xml
+++ b/coworking/demo/res_partner.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
   <record id="res_partner_38" model="res.partner">
     <field name="image_1920" type="base64" file="coworking/static/src/binary/res_partner/38-image_1920"/>
     <field name="name">Chloe Nguyen</field>

--- a/coworking/demo/sale_order.xml
+++ b/coworking/demo/sale_order.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
   <record id="sale_order_12" model="sale.order">
     <field name="user_id" ref="base.user_admin"/>
     <field name="partner_id" ref="base_industry_data.res_partner_29"/>

--- a/coworking/demo/sale_order_confirm.xml
+++ b/coworking/demo/sale_order_confirm.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True, 'mail_notrack': True}">
   <!--Update sale order stages-->
   <function model="sale.order" name="action_open_reward_wizard" eval="[[ref('sale_order_12')]]"/>
   <function model="sale.order" name="action_confirm" eval="[[ref('sale_order_12'),ref('sale_order_11'),ref('sale_order_9'),ref('sale_order_8')]]"/>

--- a/custom_furniture/__manifest__.py
+++ b/custom_furniture/__manifest__.py
@@ -51,7 +51,6 @@
         'data/knowledge_tour.xml',
     ],
     'demo': [
-        'demo/res_users.xml',
         'demo/res_partner.xml',
         'demo/hr_employee.xml',
         'demo/crm_lead.xml',

--- a/custom_furniture/demo/crm_lead.xml
+++ b/custom_furniture/demo/crm_lead.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
     <record id="crm_lead_1" model="crm.lead">
         <field name="name">Office Furniture Refresh</field>
         <field name="user_id" ref="base.user_admin"/>

--- a/custom_furniture/demo/purchase_order.xml
+++ b/custom_furniture/demo/purchase_order.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
     <record id="purchase_order_4" model="purchase.order">
         <field name="partner_id" ref="res_partner_24"/>
         <field name="user_id" ref="base.user_admin"/>

--- a/custom_furniture/demo/res_users.xml
+++ b/custom_furniture/demo/res_users.xml
@@ -1,6 +1,0 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
-    <record id="base.user_admin" model="res.users" forcecreate="0">
-        <field name="notification_type">inbox</field>
-    </record>
-</odoo>

--- a/custom_furniture/demo/sale_order.xml
+++ b/custom_furniture/demo/sale_order.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
     <record id="sale_order_5" model="sale.order">
         <field name="user_id" ref="base.user_admin"/>
         <field name="partner_id" ref="res_partner_21"/>

--- a/custom_furniture/demo/sale_order_post.xml
+++ b/custom_furniture/demo/sale_order_post.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
     <function name="action_confirm" model="sale.order" eval="[[ref('sale_order_5')]]"/>
 
     <record id="sale_advance_payment_inv_1" model="sale.advance.payment.inv">

--- a/deposit_management/__manifest__.py
+++ b/deposit_management/__manifest__.py
@@ -20,9 +20,6 @@
         'data/account_tax.xml',
         'data/res_config_settings.xml',
     ],
-    'demo': [
-        'demo/res_users.xml',
-    ],
     'cloc_exclude': [
         'data/qweb_view.xml',
     ],

--- a/deposit_management/demo/res_users.xml
+++ b/deposit_management/demo/res_users.xml
@@ -1,6 +1,0 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
-    <record id="base.user_admin" model="res.users" forcecreate="0">
-        <field name="notification_type">inbox</field>
-    </record>
-</odoo>

--- a/diy_workshops/demo/crm_lead.xml
+++ b/diy_workshops/demo/crm_lead.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
   <record id="crm_lead_1" model="crm.lead">
     <field name="name">Team Building Workshop Request for 15 Participants in October</field>
     <field name="team_id" ref="sales_team.team_sales_department"/>

--- a/diy_workshops/demo/event_event.xml
+++ b/diy_workshops/demo/event_event.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
     <record id="event_event_1" model="event.event">
     <field name="cover_properties"><![CDATA[{"background-image": "url(/web/image/diy_workshops.ir_attachment_1273)", "resize_class": "cover_auto", "opacity": "0.4", "background_color_class": "o_cc o_cc3"}]]></field>
     <field name="is_published" eval="True"/>

--- a/diy_workshops/demo/mail_activity.xml
+++ b/diy_workshops/demo/mail_activity.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_activity_quick_update': True}">
   <record id="mail_activity_2" model="mail.activity">
     <field name="res_model_id" ref="crm.model_crm_lead"/>
     <field name="res_id" ref="crm_lead_2"/>

--- a/diy_workshops/demo/purchase_order.xml
+++ b/diy_workshops/demo/purchase_order.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
   <record id="purchase_order_1" model="purchase.order">
     <field name="partner_id" ref="res_partner_12"/>
     <field name="user_id" ref="base.user_admin"/>

--- a/diy_workshops/demo/res_partner.xml
+++ b/diy_workshops/demo/res_partner.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
   <record id="res_partner_26" model="res.partner">
     <field name="image_1920" type="base64" file="diy_workshops/static/src/binary/res_partner/26-image_1920"/>
     <field name="name">Amélie Tredart</field>

--- a/diy_workshops/demo/sale_order.xml
+++ b/diy_workshops/demo/sale_order.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
   <record id="sale_order_1" model="sale.order">
     <field name="user_id" ref="base.user_admin"/>
     <field name="partner_id" ref="res_partner_16"/>

--- a/diy_workshops/demo/sale_order_post.xml
+++ b/diy_workshops/demo/sale_order_post.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True, 'mail_notrack': True}">
   <!--Update sale order stages-->
   <function model="sale.order" name="action_confirm"
   eval="[[ref('sale_order_1'),ref('sale_order_2'),ref('sale_order_3'),ref('sale_order_4'),ref('sale_order_5'),ref('sale_order_6'),ref('sale_order_7')]]" context="{'loyalty_no_mail': True, 'install_mode': True}"/>

--- a/driving_school/demo/calendar_event.xml
+++ b/driving_school/demo/calendar_event.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
-  <record id="calendar_event_1" model="calendar.event" context="{'no_mail_to_attendees': True}">
+<odoo noupdate="1" context="{'no_mail_to_attendees': True, 'mail_notrack': True}">
+  <record id="calendar_event_1" model="calendar.event">
     <field name="name">John Doe - Practical Lesson A Booking</field>
     <field name="location">MyCompany, Rue des Bourlottes 9, 1367 Ramillies, Belgium</field>
     <field name="partner_ids" eval="[(6, 0, [ref('res_partner_44'), ref('res_users_10_res_partner')])]"/>
@@ -20,7 +20,7 @@
     <field name="alarm_ids" eval="[(6, 0, [ref('calendar.alarm_mail_1'), ref('appointment_sms.calendar_alarm_data_1h_sms')])]"/>
     <field name="appointment_status">booked</field>
   </record>
-  <record id="calendar_event_2" model="calendar.event" context="{'no_mail_to_attendees': True}">
+  <record id="calendar_event_2" model="calendar.event">
     <field name="name">John Doe - Practical Lesson A Booking</field>
     <field name="location">MyCompany, Rue des Bourlottes 9, 1367 Ramillies, Belgium</field>
     <field name="partner_ids" eval="[(6, 0, [ref('res_partner_44'), ref('res_users_10_res_partner')])]"/>
@@ -40,7 +40,7 @@
     <field name="alarm_ids" eval="[(6, 0, [ref('calendar.alarm_mail_1'), ref('appointment_sms.calendar_alarm_data_1h_sms')])]"/>
     <field name="appointment_status">booked</field>
   </record>
-  <record id="calendar_event_3" model="calendar.event" context="{'no_mail_to_attendees': True}">
+  <record id="calendar_event_3" model="calendar.event">
     <field name="name">John Doe - Practical Lesson A Booking</field>
     <field name="location">MyCompany, Rue des Bourlottes 9, 1367 Ramillies, Belgium</field>
     <field name="partner_ids" eval="[(6, 0, [ref('res_partner_44'), ref('res_users_10_res_partner')])]"/>
@@ -60,7 +60,7 @@
     <field name="alarm_ids" eval="[(6, 0, [ref('calendar.alarm_mail_1'), ref('appointment_sms.calendar_alarm_data_1h_sms')])]"/>
     <field name="appointment_status">booked</field>
   </record>
-  <record id="calendar_event_4" model="calendar.event" context="{'no_mail_to_attendees': True}">
+  <record id="calendar_event_4" model="calendar.event">
     <field name="name">John Doe - Practical Lesson A Booking</field>
     <field name="location">MyCompany, Rue des Bourlottes 9, 1367 Ramillies, Belgium</field>
     <field name="partner_ids" eval="[(6, 0, [ref('res_partner_44'), ref('res_users_10_res_partner')])]"/>
@@ -80,7 +80,7 @@
     <field name="alarm_ids" eval="[(6, 0, [ref('calendar.alarm_mail_1'), ref('appointment_sms.calendar_alarm_data_1h_sms')])]"/>
     <field name="appointment_status">booked</field>
   </record>
-  <record id="calendar_event_7" model="calendar.event" context="{'no_mail_to_attendees': True}">
+  <record id="calendar_event_7" model="calendar.event">
     <field name="name">Jessica Martinez - Theory Lesson C+D Booking</field>
     <field name="location">MyCompany, Rue des Bourlottes 9, 1367 Ramillies, Belgium</field>
     <field name="duration">1.0</field>
@@ -101,7 +101,7 @@
     <field name="appointment_status">booked</field>
     <field name="appointment_booker_id" ref="base_industry_data.res_partner_25"/>
   </record>
-  <record id="calendar_event_19" model="calendar.event" context="{'no_mail_to_attendees': True}">
+  <record id="calendar_event_19" model="calendar.event">
     <field name="name">Sarah Davis - Practical Lesson B Booking</field>
     <field name="location">MyCompany, Rue des Bourlottes 9, 1367 Ramillies, Belgium</field>
     <field name="duration">1.0</field>
@@ -122,7 +122,7 @@
     <field name="appointment_status">booked</field>
     <field name="appointment_booker_id" ref="base_industry_data.res_partner_29"/>
   </record>
-  <record id="calendar_event_18" model="calendar.event" context="{'no_mail_to_attendees': True}">
+  <record id="calendar_event_18" model="calendar.event">
     <field name="name">Sarah Davis - Practical Lesson B Booking</field>
     <field name="location">MyCompany, Rue des Bourlottes 9, 1367 Ramillies, Belgium</field>
     <field name="duration">1.0</field>
@@ -143,7 +143,7 @@
     <field name="appointment_status">booked</field>
     <field name="appointment_booker_id" ref="base_industry_data.res_partner_29"/>
   </record>
-  <record id="calendar_event_8" model="calendar.event" context="{'no_mail_to_attendees': True}">
+  <record id="calendar_event_8" model="calendar.event">
     <field name="name">Jessica Martinez - Practical Lesson C Booking</field>
     <field name="location">MyCompany, Rue des Bourlottes 9, 1367 Ramillies, Belgium</field>
     <field name="duration">1.0</field>
@@ -164,7 +164,7 @@
     <field name="appointment_status">booked</field>
     <field name="appointment_booker_id" ref="base_industry_data.res_partner_25"/>
   </record>
-  <record id="calendar_event_13" model="calendar.event" context="{'no_mail_to_attendees': True}">
+  <record id="calendar_event_13" model="calendar.event">
     <field name="name">Jane Doe - Practical Lesson B Booking</field>
     <field name="location">MyCompany, Rue des Bourlottes 9, 1367 Ramillies, Belgium</field>
     <field name="duration">1.0</field>
@@ -184,7 +184,7 @@
     <field name="alarm_ids" eval="[(6, 0, [ref('calendar.alarm_mail_1'), ref('appointment_sms.calendar_alarm_data_1h_sms')])]"/>
     <field name="appointment_status">booked</field>
   </record>
-  <record id="calendar_event_17" model="calendar.event" context="{'no_mail_to_attendees': True}">
+  <record id="calendar_event_17" model="calendar.event">
     <field name="name">Sarah Davis - Practical Lesson B Booking</field>
     <field name="location">MyCompany, Rue des Bourlottes 9, 1367 Ramillies, Belgium</field>
     <field name="duration">1.0</field>
@@ -205,7 +205,7 @@
     <field name="appointment_status">booked</field>
     <field name="appointment_booker_id" ref="base_industry_data.res_partner_29"/>
   </record>
-  <record id="calendar_event_16" model="calendar.event" context="{'no_mail_to_attendees': True}">
+  <record id="calendar_event_16" model="calendar.event">
     <field name="name">Sarah Davis - Theory Lesson B Booking</field>
     <field name="location">MyCompany, Rue des Bourlottes 9, 1367 Ramillies, Belgium</field>
     <field name="duration">1.0</field>
@@ -226,7 +226,7 @@
     <field name="appointment_status">booked</field>
     <field name="appointment_booker_id" ref="base_industry_data.res_partner_29"/>
   </record>
-  <record id="calendar_event_12" model="calendar.event" context="{'no_mail_to_attendees': True}">
+  <record id="calendar_event_12" model="calendar.event">
     <field name="name">Jane Doe - Practical Lesson B Booking</field>
     <field name="user_id" ref="res_users_7"/>
     <field name="location">MyCompany, Rue des Bourlottes 9, 1367 Ramillies, Belgium</field>
@@ -246,7 +246,7 @@
     <field name="alarm_ids" eval="[(6, 0, [ref('calendar.alarm_mail_1'), ref('appointment_sms.calendar_alarm_data_1h_sms')])]"/>
     <field name="appointment_status">booked</field>
   </record>
-  <record id="calendar_event_15" model="calendar.event" context="{'no_mail_to_attendees': True}">
+  <record id="calendar_event_15" model="calendar.event">
     <field name="name">Sarah Davis - Theory Lesson B Booking</field>
     <field name="location">MyCompany, Rue des Bourlottes 9, 1367 Ramillies, Belgium</field>
     <field name="duration">1.0</field>
@@ -267,7 +267,7 @@
     <field name="appointment_status">booked</field>
     <field name="appointment_booker_id" ref="base_industry_data.res_partner_29"/>
   </record>
-  <record id="calendar_event_10" model="calendar.event" context="{'no_mail_to_attendees': True}">
+  <record id="calendar_event_10" model="calendar.event">
     <field name="name">Jane Doe - Practical Lesson B Booking</field>
     <field name="location">MyCompany, Rue des Bourlottes 9, 1367 Ramillies, Belgium</field>
     <field name="duration">1.0</field>
@@ -287,7 +287,7 @@
     <field name="alarm_ids" eval="[(6, 0, [ref('calendar.alarm_mail_1'), ref('appointment_sms.calendar_alarm_data_1h_sms')])]"/>
     <field name="appointment_status">booked</field>
   </record>
-  <record id="calendar_event_6" model="calendar.event" context="{'no_mail_to_attendees': True}">
+  <record id="calendar_event_6" model="calendar.event">
     <field name="name">Jessica Martinez - Theory Lesson C+D Booking</field>
     <field name="location">MyCompany, Rue des Bourlottes 9, 1367 Ramillies, Belgium</field>
     <field name="duration">1.0</field>
@@ -308,7 +308,7 @@
     <field name="appointment_status">booked</field>
     <field name="appointment_booker_id" ref="base_industry_data.res_partner_25"/>
   </record>
-  <record id="calendar_event_9" model="calendar.event" context="{'no_mail_to_attendees': True}">
+  <record id="calendar_event_9" model="calendar.event">
     <field name="name">Jane Doe - Practical Lesson B Booking</field>
     <field name="user_id" ref="res_users_7"/>
     <field name="location">MyCompany, Rue des Bourlottes 9, 1367 Ramillies, Belgium</field>
@@ -328,7 +328,7 @@
     <field name="alarm_ids" eval="[(6, 0, [ref('calendar.alarm_mail_1'), ref('appointment_sms.calendar_alarm_data_1h_sms')])]"/>
     <field name="appointment_status">booked</field>
   </record>
-  <record id="calendar_event_14" model="calendar.event" context="{'no_mail_to_attendees': True}">
+  <record id="calendar_event_14" model="calendar.event">
     <field name="name">Sarah Davis - Theory Lesson B Booking</field>
     <field name="location">MyCompany, Rue des Bourlottes 9, 1367 Ramillies, Belgium</field>
     <field name="duration">1.0</field>
@@ -349,7 +349,7 @@
     <field name="appointment_status">booked</field>
     <field name="appointment_booker_id" ref="base_industry_data.res_partner_29"/>
   </record>
-  <record id="calendar_event_5" model="calendar.event" context="{'no_mail_to_attendees': True}">
+  <record id="calendar_event_5" model="calendar.event">
     <field name="name">Jessica Martinez - Theory Lesson C+D Booking</field>
     <field name="location">MyCompany, Rue des Bourlottes 9, 1367 Ramillies, Belgium</field>
     <field name="duration">1.0</field>

--- a/driving_school/demo/res_users.xml
+++ b/driving_school/demo/res_users.xml
@@ -4,24 +4,20 @@
         <field name="name">Jane Doe</field>
         <field name="login">janedoe@email.com</field>
         <field name="image_1920" type="base64" file="driving_school/static/src/binary/hr_employee/4-image_1920"/>
-        <field name="notification_type">inbox</field>
     </record>
     <record id="res_users_7" model="res.users">
         <field name="name">Karl Park</field>
         <field name="login">karlpark@mycompany.com</field>
         <field name="image_1920" type="base64" file="driving_school/static/src/binary/hr_employee/3-image_1920"/>
-        <field name="notification_type">inbox</field>
     </record>
     <record id="res_users_9" model="res.users">
         <field name="name">Otto Matic</field>
         <field name="login">ottomatic@mycompany.com</field>
         <field name="image_1920" type="base64" file="driving_school/static/src/binary/hr_employee/4-image_1920"/>
-        <field name="notification_type">inbox</field>
     </record>
     <record id="res_users_10" model="res.users">
         <field name="name">Lane Change</field>
         <field name="login">lanechange@mycompany.com</field>
         <field name="image_1920" type="base64" file="driving_school/static/src/binary/hr_employee/2-image_1920"/>
-        <field name="notification_type">inbox</field>
     </record>
 </odoo>

--- a/driving_school/demo/sale_order.xml
+++ b/driving_school/demo/sale_order.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
     <record id="sale_order_29" model="sale.order">
         <field name="partner_id" ref="base_industry_data.res_partner_29"/>
         <field name="user_id" ref="base.user_admin"/>

--- a/dropshipping/demo/purchase_order.xml
+++ b/dropshipping/demo/purchase_order.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
   <record id="purchase_order_1" model="purchase.order">
     <field name="picking_type_id" ref="stock_picking_type_9"/>
     <field name="user_id" ref="base.user_admin"/>

--- a/dropshipping/demo/sale_order.xml
+++ b/dropshipping/demo/sale_order.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
   <record id="sale_order_3" model="sale.order">
     <field name="partner_id" ref="base.partner_admin"/>
     <field name="user_id" ref="base.user_admin"/>

--- a/elearning_platform/demo/res_partner.xml
+++ b/elearning_platform/demo/res_partner.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
   <record id="res_partner_88" model="res.partner">
     <field name="name">Michael Demo</field>
     <field name="user_id" ref="base.user_admin"/>

--- a/elearning_platform/demo/sale_order.xml
+++ b/elearning_platform/demo/sale_order.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
   <record id="sale_order_40" model="sale.order">
     <field name="partner_id" ref="res_partner_88"/>
     <field name="user_id" ref="base.user_admin"/>

--- a/elearning_platform/demo/slide_channel.xml
+++ b/elearning_platform/demo/slide_channel.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
     <record id="slide_channel_8" model="slide.channel">
         <field name="name">Intro to Programming</field>
         <field name="cover_properties"><![CDATA[{"background-image":"none","resize_class":"cover_auto","text_align_class":"","opacity":"0","background_color_class":"o_cc o_cc3","background_color_style":"background-color: rgb(0, 170, 255);"}]]></field>
@@ -16,7 +16,6 @@
         <field name="description_short"><![CDATA[<p>A lot of nice documentation: trees, wood, gardens. A gold mine for references.</p>]]></field>
         <field name="channel_type">documentation</field>
         <field name="is_published" eval="True"/>
-        <field name="user_id" ref="base.user_admin"/>
         <field name="tag_ids" eval="[(6, 0, [ref('website_slides.slide_channel_tag_level_intermediate'), ref('website_slides.slide_channel_tag_role_gardener'), ref('website_slides.slide_channel_tag_role_carpenter'), ref('website_slides.slide_channel_tag_other_0'), ref('website_slides.slide_channel_tag_other_2')])]"/>
         <field name="promote_strategy">most_viewed</field>
         <field name="enroll">payment</field>
@@ -91,7 +90,6 @@
         <field name="is_published" eval="True"/>
         <field name="description"><![CDATA[<p>So much amazing certification.</p>]]></field>
         <field name="description_short"><![CDATA[<p>So much amazing certification.</p>]]></field>
-        <field name="user_id" ref="base.user_admin"/>
         <field name="tag_ids" eval="[(6, 0, [ref('website_slides.slide_channel_tag_level_advanced'), ref('website_slides.slide_channel_tag_role_carpenter'), ref('website_slides.slide_channel_tag_role_furniture'), ref('website_slides.slide_channel_tag_other_1')])]"/>
         <field name="promote_strategy">most_voted</field>
         <field name="enroll">payment</field>

--- a/elearning_platform/demo/survey_survey.xml
+++ b/elearning_platform/demo/survey_survey.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
     <record id="survey.survey_feedback" model="survey.survey" forcecreate="1">
         <field name="title">Feedback Form</field>
         <field name="user_id" ref="base.user_admin"/>

--- a/electrician/demo/crm_lead.xml
+++ b/electrician/demo/crm_lead.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
   <record id="crm_lead_8" model="crm.lead">
     <field name="partner_id" ref="base_industry_data.res_partner_32"/>
     <field name="name">EV Charger installation</field>

--- a/electrician/demo/project_project.xml
+++ b/electrician/demo/project_project.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
   <record id="project_project_3" model="project.project">
     <field name="name">S00001 - Tasks</field>
     <field name="is_fsm" eval="True"/>

--- a/electrician/demo/purchase_order.xml
+++ b/electrician/demo/purchase_order.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
   <record id="purchase_order_2" model="purchase.order">
     <field name="partner_id" ref="res_partner_36"/>
     <field name="user_id" ref="base.user_admin"/>

--- a/electrician/demo/sale_order.xml
+++ b/electrician/demo/sale_order.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
   <record id="sale_order_10" model="sale.order">
     <field name="partner_id" ref="base_industry_data.res_partner_34"/>
     <field name="sale_order_template_id" ref="sale_order_template_1"/>

--- a/electronic_store/__manifest__.py
+++ b/electronic_store/__manifest__.py
@@ -50,7 +50,6 @@
         'data/knowledge_tour.xml',
     ],
     'demo': [
-        'demo/res_users.xml',
         'demo/res_partner.xml',
         'demo/account_analytic_plan.xml',
         'demo/account_analytic_account.xml',

--- a/electronic_store/demo/crm_lead.xml
+++ b/electronic_store/demo/crm_lead.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
     <record id="crm_lead_2" model="crm.lead">
         <field name="name">Slow Food Chicago</field>
         <field name="partner_id" ref="res_partner_13"/>

--- a/electronic_store/demo/helpdesk_ticket.xml
+++ b/electronic_store/demo/helpdesk_ticket.xml
@@ -1,19 +1,19 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
-    <record id="helpdesk_ticket_1" model="helpdesk.ticket" context="{'mail_notrack': True}">
+<odoo noupdate="1" context="{'mail_notrack': True}">
+    <record id="helpdesk_ticket_1" model="helpdesk.ticket">
         <field name="name">AC Repair</field>
         <field name="partner_id" ref="res_partner_6"/>
         <field name="stage_id" ref="helpdesk.stage_new"/>
         <field name="assign_date"  eval="datetime.today() - relativedelta(months=3)"/>
         <field name="team_id" ref="helpdesk.helpdesk_team1"/>
     </record>
-    <record id="helpdesk_ticket_2" model="helpdesk.ticket" context="{'mail_notrack': True}">
+    <record id="helpdesk_ticket_2" model="helpdesk.ticket">
         <field name="name">Microwave issue</field>
         <field name="partner_name">Aero-Space Fasteners &amp; Electronics</field>
         <field name="stage_id" ref="helpdesk.stage_new"/>
         <field name="team_id" ref="helpdesk.helpdesk_team1"/>
     </record>
-    <record id="helpdesk_ticket_3" model="helpdesk.ticket" context="{'mail_notrack': True}">
+    <record id="helpdesk_ticket_3" model="helpdesk.ticket">
         <field name="name">Gas Leakage issue</field>
         <field name="partner_name">Saddlebrook Resort</field>
         <field name="partner_id" ref="res_partner_6"/>
@@ -27,7 +27,7 @@
             ]]>
         </field>
     </record>
-    <record id="helpdesk_ticket_4" model="helpdesk.ticket" context="{'mail_notrack': True}">
+    <record id="helpdesk_ticket_4" model="helpdesk.ticket">
         <field name="name">Gas Leakage problem</field>
         <field name="partner_id" ref="base.main_partner"/>
         <field name="stage_id" ref="helpdesk.stage_new"/>

--- a/electronic_store/demo/purchase_order.xml
+++ b/electronic_store/demo/purchase_order.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
     <record id="purchase_order_1" model="purchase.order">
         <field name="partner_id" ref="res_partner_12"/>
         <field name="user_id" ref="base.user_admin"/>

--- a/electronic_store/demo/res_users.xml
+++ b/electronic_store/demo/res_users.xml
@@ -1,6 +1,0 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
-    <record id="base.user_admin" model="res.users" forcecreate="0">
-        <field name="notification_type">inbox</field>
-    </record>
-</odoo>

--- a/electronic_store/demo/sale_order.xml
+++ b/electronic_store/demo/sale_order.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
     <record id="sale_order_2" model="sale.order">
         <field name="partner_id" ref="res_partner_7"/>
         <field name="opportunity_id" ref="crm_lead_4"/>

--- a/electronic_store/demo/sale_order_post.xml
+++ b/electronic_store/demo/sale_order_post.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
     <function name="action_confirm" model="sale.order">
         <value eval="[
             ref('sale_order_2'),

--- a/environmental_agency/demo/calendar_event.xml
+++ b/environmental_agency/demo/calendar_event.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
-    <record id="calendar_event_1" model="calendar.event" context="{'no_mail_to_attendees': True}">
+<odoo noupdate="1" context="{'no_mail_to_attendees': True}">
+    <record id="calendar_event_1" model="calendar.event">
         <field name="name">Discovery Call Booking</field>
         <field name="start" model="appointment.type" eval="
             pytz.timezone(obj().env.ref('environmental_agency.appointment_type_2').appointment_tz).localize(

--- a/environmental_agency/demo/crm_lead.xml
+++ b/environmental_agency/demo/crm_lead.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
     <record id="crm_lead_4" model="crm.lead">
         <field name="partner_id" ref="base_industry_data.res_partner_34"/>
         <field name="name">Energy Efficiency Plan for Hotel Chain</field>

--- a/environmental_agency/demo/mail_activity.xml
+++ b/environmental_agency/demo/mail_activity.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_activity_quick_update': True}">
     <record id="mail_activity_1" model="mail.activity">
         <field name="res_model_id" ref="crm.model_crm_lead"/>
         <field name="date_deadline" eval="(DateTime.today() - relativedelta(days=3)).strftime('%Y-%m-%d %H:%M')"/>

--- a/environmental_agency/demo/sale_order.xml
+++ b/environmental_agency/demo/sale_order.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
     <record id="sale_order_4" model="sale.order">
         <field name="partner_id" ref="res_partner_52"/>
         <field name="user_id" ref="base.user_admin"/>

--- a/environmental_agency/demo/sale_order_confirm.xml
+++ b/environmental_agency/demo/sale_order_confirm.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_activity_quick_update': True, 'mail_auto_subscribe_no_notify': True}">
     <function model="sale.order" name="action_confirm" eval="[[ref('sale_order_4'),ref('sale_order_3'),ref('sale_order_2'),ref('sale_order_1')]]"/>
     <function name="_create_invoices" model="sale.order" eval="[[ref('sale_order_4'),ref('sale_order_3'),ref('sale_order_2'),ref('sale_order_1')]]"/>
 

--- a/escape_rooms/demo/calendar_event.xml
+++ b/escape_rooms/demo/calendar_event.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
-  <record id="calendar_event_4" model="calendar.event" context="{'no_mail_to_attendees': True}">
+<odoo noupdate="1" context="{'no_mail_to_attendees': True, 'mail_notrack': True}">
+  <record id="calendar_event_4" model="calendar.event">
     <field name="name">John Smith - 🕵️ The Holmes Paradox Booking</field>
     <field name="user_id" ref="base.user_admin"/>
     <field name="location" ref="base.main_partner"/>
@@ -12,7 +12,7 @@
     <field name="appointment_status">booked</field>
     <field name="appointment_booker_id" ref="base_industry_data.res_partner_26"/>
   </record>
-  <record id="calendar_event_2" model="calendar.event" context="{'no_mail_to_attendees': True}">
+  <record id="calendar_event_2" model="calendar.event">
     <field name="name">Jessica Martinez - 👽 Specimen X Booking</field>
     <field name="user_id" ref="base.user_admin"/>
     <field name="location" ref="base.main_partner"/>
@@ -24,7 +24,7 @@
     <field name="appointment_status">booked</field>
     <field name="appointment_booker_id" ref="base_industry_data.res_partner_25"/>
   </record>
-  <record id="calendar_event_1" model="calendar.event" context="{'no_mail_to_attendees': True}">
+  <record id="calendar_event_1" model="calendar.event">
     <field name="name">Jessica Martinez - 🕵️ The Holmes Paradox Booking</field>
     <field name="user_id" ref="base.user_admin"/>
     <field name="location" ref="base.main_partner"/>
@@ -36,7 +36,7 @@
     <field name="appointment_status">booked</field>
     <field name="appointment_booker_id" ref="base_industry_data.res_partner_25"/>
   </record>
-  <record id="calendar_event_5" model="calendar.event" context="{'no_mail_to_attendees': True}">
+  <record id="calendar_event_5" model="calendar.event">
     <field name="name">John Smith - 🏺 Curse of the Pharaoh Booking</field>
     <field name="user_id" ref="base.user_admin"/>
     <field name="location" ref="base.main_partner"/>
@@ -48,7 +48,7 @@
     <field name="appointment_status">booked</field>
     <field name="appointment_booker_id" ref="base_industry_data.res_partner_26"/>
   </record>
-  <record id="calendar_event_6" model="calendar.event" context="{'no_mail_to_attendees': True}">
+  <record id="calendar_event_6" model="calendar.event">
     <field name="name">John Smith - 🏺 Curse of the Pharaoh Booking</field>
     <field name="user_id" ref="base.user_admin"/>
     <field name="location" ref="base.main_partner"/>
@@ -60,7 +60,7 @@
     <field name="appointment_status">booked</field>
     <field name="appointment_booker_id" ref="base_industry_data.res_partner_26"/>
   </record>
-  <record id="calendar_event_3" model="calendar.event" context="{'no_mail_to_attendees': True}">
+  <record id="calendar_event_3" model="calendar.event">
     <field name="name">John Smith - 🏺 Curse of the Pharaoh Booking</field>
     <field name="user_id" ref="base.user_admin"/>
     <field name="location" ref="base.main_partner"/>

--- a/escape_rooms/demo/crm_lead.xml
+++ b/escape_rooms/demo/crm_lead.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
   <record id="crm_lead_1" model="crm.lead">
     <field name="name">Staff retreat planning request</field>
     <field name="user_id" ref="base.user_admin"/>

--- a/escape_rooms/demo/sale_order.xml
+++ b/escape_rooms/demo/sale_order.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
   <record id="sale_order_7" model="sale.order">
     <field name="partner_id" ref="base_industry_data.res_partner_26"/>
     <field name="user_id" ref="base.user_admin"/>

--- a/event_management/demo/crm_lead.xml
+++ b/event_management/demo/crm_lead.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
   <record id="crm_lead_4" model="crm.lead">
     <field name="name">Product Release Event + Evening Cocktail Networking</field>
     <field name="user_id" ref="base.user_admin"/>

--- a/event_management/demo/event_event.xml
+++ b/event_management/demo/event_event.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
   <record id="event_event_1" model="event.event">
     <field name="cover_properties"><![CDATA[{"background-image":"url(/web/image/event_management.ir_attachment_2)","background_color_class":"o_cc3 o_cc","background_color_style":"","opacity":"0.4","resize_class":"o_half_screen_height o_record_has_cover","text_align_class":""}]]></field>
     <field name="name">Summer Afterwork</field>

--- a/event_management/demo/mail_activity.xml
+++ b/event_management/demo/mail_activity.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_activity_quick_update': True}">
     <record id="mail_activity_1" model="mail.activity">
         <field name="res_model_id" ref="crm.model_crm_lead"/>
         <field name="date_deadline" eval="(DateTime.today() + relativedelta(days=13)).strftime('%Y-%m-%d %H:%M')"/>

--- a/event_management/demo/maintenance_request.xml
+++ b/event_management/demo/maintenance_request.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True, 'mail_activity_quick_update': True}">
     <record id="maintenance_request_1" model="maintenance.request">
         <field name="name">Hole in 100m² tent</field>
         <field name="user_id" ref="base_industry_data.res_users_7"/>

--- a/event_management/demo/project_project.xml
+++ b/event_management/demo/project_project.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
     <record id="project_project_5" model="project.project">
         <field name="name">S00001 - Event Management Template</field>
         <field name="user_id" ref="base.user_admin"/>

--- a/event_management/demo/project_task.xml
+++ b/event_management/demo/project_task.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
   <record id="project_task_17" model="project.task">
     <field name="name">Venue Selection and Booking</field>
     <field name="description"><![CDATA[<div data-oe-version="2.0">Booked EcoFun Adventure Parks for the event date.</div><div><br></div><div>--&gt;&nbsp;Booked EcoFun Adventure Parks for the event date.&nbsp;</div><div><br></div>]]></field>

--- a/event_management/demo/purchase_order.xml
+++ b/event_management/demo/purchase_order.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
   <record id="purchase_order_9" model="purchase.order">
     <field name="partner_id" ref="res_partner_69"/>
     <field name="user_id" ref="base.user_admin"/>

--- a/event_management/demo/sale_order.xml
+++ b/event_management/demo/sale_order.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
   <record id="sale_order_4" model="sale.order">
     <field name="partner_id" ref="base_industry_data.res_partner_21"/>
     <field name="sale_order_template_id" ref="sale_order_template_2"/>

--- a/excise_management/__manifest__.py
+++ b/excise_management/__manifest__.py
@@ -27,9 +27,6 @@
         'data/x_excise_category.xml',
         'data/res_config_setting.xml',
     ],
-    'demo': [
-        'demo/res_users.xml',
-    ],
     'cloc_exclude': [
         'data/qweb_view.xml',
     ],

--- a/excise_management/demo/res_users.xml
+++ b/excise_management/demo/res_users.xml
@@ -1,6 +1,0 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
-    <record id="base.user_admin" model="res.users" forcecreate="0">
-        <field name="notification_type">inbox</field>
-    </record>
-</odoo>

--- a/eyewear_shop/demo/crm_lead.xml
+++ b/eyewear_shop/demo/crm_lead.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
   <record id="crm_lead_1" model="crm.lead">
     <field name="name">Custom Prescription Glasses</field>
     <field name="partner_id" ref="base_industry_data.res_partner_21"/>

--- a/eyewear_shop/demo/purchase_order.xml
+++ b/eyewear_shop/demo/purchase_order.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
   <record id="purchase_order_2" model="purchase.order">
     <field name="partner_id" ref="res_partner_40"/>
     <field name="user_id" ref="base.user_admin"/>

--- a/eyewear_shop/demo/res_partner.xml
+++ b/eyewear_shop/demo/res_partner.xml
@@ -1,10 +1,10 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
   <record id="res_partner_38" model="res.partner">
     <field name="name">Accessory Vendor</field>
     <field name="is_company" eval="True"/>
   </record>
-   <record id="res_partner_35" model="res.partner">
+  <record id="res_partner_35" model="res.partner">
     <field name="image_1920" type="base64" file="eyewear_shop/static/src/binary/res_partner/35-image_1920"/>
     <field name="name">Sarah Thompson</field>
     <field name="parent_id" ref="base.main_partner"/>

--- a/eyewear_shop/demo/sale_order.xml
+++ b/eyewear_shop/demo/sale_order.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
   <record id="sale_order_3" model="sale.order">
     <field name="partner_id" ref="res_partner_43"/>
     <field name="user_id" ref="base.user_admin"/>

--- a/fast_food/__manifest__.py
+++ b/fast_food/__manifest__.py
@@ -29,7 +29,6 @@
         'data/knowledge_tour.xml',
     ],
     'demo': [
-        'demo/res_users.xml',
         'demo/pos_payment_method.xml',
         'demo/res_partner.xml',
         'demo/hr_employee.xml',

--- a/fast_food/demo/purchase_order.xml
+++ b/fast_food/demo/purchase_order.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
     <record id="purchase_order_1" model="purchase.order">
         <field name="partner_id" ref="res_partner_11"/>
         <field name="user_id" ref="base.user_admin"/>

--- a/fast_food/demo/res_users.xml
+++ b/fast_food/demo/res_users.xml
@@ -1,6 +1,0 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
-    <record id="base.user_admin" model="res.users" forcecreate="0">
-        <field name="notification_type">inbox</field>
-    </record>
-</odoo>

--- a/fitness/__manifest__.py
+++ b/fitness/__manifest__.py
@@ -43,7 +43,6 @@
         'data/knowledge_tour.xml',
     ],
     'demo': [
-        'demo/res_users.xml',
         'demo/res_partner.xml',
         'demo/hr_employee.xml',
         'demo/appointment_type.xml',

--- a/fitness/demo/calendar_event.xml
+++ b/fitness/demo/calendar_event.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
-    <record id="calendar_event_1" model="calendar.event" context="{'no_mail_to_attendees': True}">
+<odoo noupdate="1" context="{'no_mail_to_attendees': True}">
+    <record id="calendar_event_1" model="calendar.event">
         <field name="name">Hit Course Appointment</field>
         <field name="appointment_type_id" ref="appointment_type_1"/>
         <field name="start" model="appointment.type" eval="

--- a/fitness/demo/purchase_order.xml
+++ b/fitness/demo/purchase_order.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
     <record id="purchase_order_1" model="purchase.order">
         <field name="partner_id" ref="res_partner_9"/>
         <field name="user_id" ref="base.user_admin"/>

--- a/fitness/demo/res_users.xml
+++ b/fitness/demo/res_users.xml
@@ -1,6 +1,0 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
-    <record id="base.user_admin" model="res.users" forcecreate="0">
-        <field name="notification_type">inbox</field>
-    </record>
-</odoo>

--- a/fitness/demo/sale_order.xml
+++ b/fitness/demo/sale_order.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
     <record id="sale_order_1" model="sale.order">
         <field name="user_id" ref="base.user_admin"/>
         <field name="plan_id" ref="sale_subscription.subscription_plan_month"/>

--- a/fitness/demo/sale_order_post.xml
+++ b/fitness/demo/sale_order_post.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True, 'mail_notrack': True}">
     <function name="action_confirm" model="sale.order">
         <value eval="[
             ref('sale_order_1'),

--- a/florist/demo/crm_lead.xml
+++ b/florist/demo/crm_lead.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
     <record id="crm_lead_3" model="crm.lead">
         <field name="name">Valentine’s Day Bulk</field>
         <field name="partner_id" ref="res_partner_23"/>

--- a/florist/demo/project_project.xml
+++ b/florist/demo/project_project.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
     <record id="project_project_1" model="project.project">
         <field name="name">Emily &amp; Paul Wedding</field>
         <field name="type_ids" eval="[(6, 0, [ref('project_task_type_1'), ref('project_task_type_2'), ref('project_task_type_3')])]"/>

--- a/florist/demo/project_task.xml
+++ b/florist/demo/project_task.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
     <record id="project_task_3" model="project.task">
         <field name="name">Prepare floral arrangements</field>
         <field name="priority">1</field>

--- a/florist/demo/purchase_order.xml
+++ b/florist/demo/purchase_order.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
     <record id="purchase_order_2" model="purchase.order">
         <field name="partner_id" ref="res_partner_9"/>
         <field name="user_id" ref="base.user_admin"/>

--- a/florist/demo/res_partner.xml
+++ b/florist/demo/res_partner.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
     <record id="res_partner_9" model="res.partner">
         <field name="image_1920" type="base64" file="florist/static/src/binary/res_partner/9-image_1920"/>
         <field name="name">BloomVibes Co.</field>

--- a/florist/demo/res_users.xml
+++ b/florist/demo/res_users.xml
@@ -6,6 +6,5 @@
         <field name="phone">+1 650-691-3277</field>
         <field name="company_id" ref="base.main_company"/>
         <field name="image_1920" type="base64" file="florist/static/src/binary/hr_employee/5-image_1920"/>
-        <field name="notification_type">inbox</field>
     </record>
 </odoo>

--- a/florist/demo/sale_order.xml
+++ b/florist/demo/sale_order.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
     <record id="sale_order_1" model="sale.order">
         <field name="partner_id" ref="res_partner_19"/>
         <field name="sale_order_template_id" ref="sale_order_template_1"/>

--- a/fmcg_store/__manifest__.py
+++ b/fmcg_store/__manifest__.py
@@ -35,7 +35,6 @@
         'data/knowledge_tour.xml',
     ],
     'demo': [
-        'demo/res_users.xml',
         'demo/res_partner.xml',
         'demo/product_supplierinfo.xml',
         'demo/loyalty_program.xml',

--- a/fmcg_store/demo/purchase_order.xml
+++ b/fmcg_store/demo/purchase_order.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
     <record id="purchase_order_1" model="purchase.order">
         <field name="partner_id" ref="res_partner_13"/>
         <field name="user_id" ref="base.user_admin"/>

--- a/fmcg_store/demo/res_users.xml
+++ b/fmcg_store/demo/res_users.xml
@@ -1,6 +1,0 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
-    <record id="base.user_admin" model="res.users" forcecreate="0">
-        <field name="notification_type">inbox</field>
-    </record>
-</odoo>

--- a/fmcg_store/demo/sale_order.xml
+++ b/fmcg_store/demo/sale_order.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
     <record id="sale_order_1" model="sale.order">
         <field name="partner_id" ref="res_partner_9"/>
         <field name="user_id" ref="base.user_admin"/>

--- a/fmcg_store/demo/sale_order_post.xml
+++ b/fmcg_store/demo/sale_order_post.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
     <function name="action_confirm" model="sale.order" eval="[[
         ref('sale_order_1'),
         ref('sale_order_2'),

--- a/food_distribution/demo/sale_order.xml
+++ b/food_distribution/demo/sale_order.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
   <record id="sale_order_3" model="sale.order">
     <field name="partner_id" ref="base_industry_data.res_partner_35"/>
     <field name="sale_order_template_id" ref="sale_order_template_2"/>

--- a/food_trucks/demo/crm_lead.xml
+++ b/food_trucks/demo/crm_lead.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
   <record id="crm_lead_6" model="crm.lead">
     <field name="partner_id" ref="res_partner_37"/>
     <field name="name">Odoo Campus</field>

--- a/food_trucks/demo/res_partner.xml
+++ b/food_trucks/demo/res_partner.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
   <record id="res_partner_10" model="res.partner">
     <field name="name">Americas Sales Office</field>
     <field name="parent_id" ref="base.main_partner"/>

--- a/food_trucks/demo/sale_order.xml
+++ b/food_trucks/demo/sale_order.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
   <record id="sale_order_4" model="sale.order">
     <field name="partner_id" ref="res_partner_37"/>
     <field name="user_id" ref="base.user_admin"/>

--- a/furniture_store/demo/crm_lead.xml
+++ b/furniture_store/demo/crm_lead.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
   <record id="crm_lead_3" model="crm.lead">
     <field name="partner_id" ref="base_industry_data.res_partner_27"/>
     <field name="name">Quote for 12 Tables</field>

--- a/furniture_store/demo/sale_order.xml
+++ b/furniture_store/demo/sale_order.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
   <record id="sale_order_3" model="sale.order">
     <field name="partner_id" ref="base_industry_data.res_partner_28"/>
     <field name="user_id" ref="base.user_admin"/>

--- a/gallery/demo/crm_lead.xml
+++ b/gallery/demo/crm_lead.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
   <record id="crm_lead_10" model="crm.lead">
     <field name="partner_id" ref="base_industry_data.res_partner_23"/>
     <field name="name">Will you take my art into your catalogue?</field>

--- a/gallery/demo/purchase_order.xml
+++ b/gallery/demo/purchase_order.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
   <record id="purchase_order_3" model="purchase.order">
     <field name="partner_id" ref="base_industry_data.res_partner_29"/>
     <field name="user_id" ref="base.user_admin"/>

--- a/gallery/demo/sale_order.xml
+++ b/gallery/demo/sale_order.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
   <record id="sale_order_10" model="sale.order">
     <field name="partner_id" ref="base_industry_data.res_partner_26"/>
     <field name="user_id" ref="base.user_admin"/>

--- a/gardening/demo/crm_lead.xml
+++ b/gardening/demo/crm_lead.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True, 'mail_activity_quick_update': True}">
     <record id="crm_lead_1" model="crm.lead">
         <field name="partner_id" ref="res_partner_19"/>
         <field name="name">Zen Garden Makeover</field>

--- a/gardening/demo/purchase_order.xml
+++ b/gardening/demo/purchase_order.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
     <record id="purchase_order_1" model="purchase.order">
         <field name="partner_id" ref="res_partner_14"/>
         <field name="user_id" ref="base.user_admin"/>

--- a/gardening/demo/res_user.xml
+++ b/gardening/demo/res_user.xml
@@ -1,15 +1,11 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-    <record id="base.user_admin" model="res.users" forcecreate="0">
-        <field name="notification_type">inbox</field>
-    </record>
     <record id="tomate" model="res.users">
         <field name="login">tom.mates@gardening.odoo</field>
         <field name="phone">+1 650-691-3277</field>
         <field name="partner_id" ref="res_partner_30"/>
         <field name="company_id" ref="base.main_company"/>
         <field name="image_1920" type="base64" file="gardening/static/src/binary/hr_employee/tomate.jpg"/>
-        <field name="notification_type">inbox</field>
     </record>
     <record id="eleonore" model="res.users">
         <field name="login">eleonore.chidee@gardening.odoo</field>
@@ -18,6 +14,5 @@
         <field name="password">123456</field> 
         <field name="company_id" ref="base.main_company"/>
         <field name="image_1920" type="base64" file="gardening/static/src/binary/hr_employee/eleonore.jpg"/>
-        <field name="notification_type">inbox</field>
     </record>
 </odoo>

--- a/gardening/demo/sale_order.xml
+++ b/gardening/demo/sale_order.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
     <record id="sale_order_1" model="sale.order">
         <field name="partner_id" ref="res_partner_26"/>
         <field name="user_id" ref="base.user_admin"/>

--- a/gardening/demo/sale_order_line.xml
+++ b/gardening/demo/sale_order_line.xml
@@ -46,6 +46,7 @@
     <record id="sale_order_line_23" model="sale.order.line">
         <field name="order_id" ref="sale_order_5"/>
         <field name="product_id" ref="product_product_11"/>
+        <field name="product_uom_qty">2.0</field>
     </record>
     <record id="sale_order_line_24" model="sale.order.line">
         <field name="order_id" ref="sale_order_6"/>

--- a/gardening/demo/timesheet.xml
+++ b/gardening/demo/timesheet.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
     <function model="ir.model.data" name="_update_xmlids">
         <value model="base" eval="[{
                   'xml_id': 'gardening.field_task_1',

--- a/guest_house/demo/sale_order.xml
+++ b/guest_house/demo/sale_order.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
     <record id="sale_order_1" model="sale.order">
         <field name="partner_id" ref="base_industry_data.res_partner_28"/>
         <field name="user_id" ref="base.user_admin"/>

--- a/guided_tours/demo/event_event.xml
+++ b/guided_tours/demo/event_event.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
   <record id="event_event_1" model="event.event">
     <field name="cover_properties"><![CDATA[{"background-image":"url(\"/web/image/guided_tours.ir_attachment_9\")","resize_class":"o_half_screen_height o_record_has_cover","opacity":"0.4","background_color_class":"o_cc o_cc1"}]]></field>
     <field name="name">Brussels City Tours</field>

--- a/hair_salon/demo/calendar_event.xml
+++ b/hair_salon/demo/calendar_event.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'no_mail_to_attendees': True}">
 
-    <record id="calendar_event_9" model="calendar.event" context="{'no_mail_to_attendees': True}">
+    <record id="calendar_event_9" model="calendar.event">
         <field name="name">Haircut &amp; Brushing</field>
         <field name="appointment_type_id" ref="appointment_type_1" />
         <field name="start" model="appointment.type" eval="
@@ -18,7 +18,7 @@
         <field name="partner_ids" eval="[(6, 0, [ref('res_partner_10'), ref('res_partner_8')])]" />
     </record>
 
-    <record id="calendar_event_11" model="calendar.event" context="{'no_mail_to_attendees': True}">
+    <record id="calendar_event_11" model="calendar.event">
         <field name="name">Haircut &amp; Color &amp; Brushing</field>
         <field name="appointment_type_id" ref="appointment_type_2" />
         <field name="start" model="appointment.type" eval="
@@ -35,7 +35,7 @@
         <field name="partner_ids" eval="[(6, 0, [ref('res_partner_13'), ref('res_partner_8')])]" />
     </record>
 
-    <record id="calendar_event_13" model="calendar.event" context="{'no_mail_to_attendees': True}">
+    <record id="calendar_event_13" model="calendar.event">
         <field name="name">Brushing</field>
         <field name="appointment_type_id" ref="appointment_type_3"/>
         <field name="start" model="appointment.type" eval="
@@ -52,7 +52,7 @@
         <field name="partner_ids" eval="[(6, 0, [ref('res_partner_10'), ref('res_partner_9')])]" />
     </record>
 
-    <record id="calendar_event_12" model="calendar.event" context="{'no_mail_to_attendees': True}">
+    <record id="calendar_event_12" model="calendar.event">
         <field name="name">Haircut &amp; Brushing</field>
         <field name="appointment_type_id" ref="appointment_type_1" />
         <field name="start" model="appointment.type" eval="
@@ -69,7 +69,7 @@
         <field name="partner_ids" eval="[(6, 0, [ref('res_partner_15'), ref('res_partner_9')])]" />
     </record>
 
-    <record id="calendar_event_14" model="calendar.event" context="{'no_mail_to_attendees': True}">
+    <record id="calendar_event_14" model="calendar.event">
         <field name="name">Haircut &amp; Color &amp; Brushing</field>
         <field name="appointment_type_id" ref="appointment_type_2" />
         <field name="start" model="appointment.type" eval="
@@ -86,7 +86,7 @@
         <field name="partner_ids" eval="[(6, 0, [ref('res_partner_14'), ref('res_partner_7')])]" />
     </record>
 
-    <record id="calendar_event_17" model="calendar.event" context="{'no_mail_to_attendees': True}">
+    <record id="calendar_event_17" model="calendar.event">
         <field name="name">Haircut &amp; Brushing with Olivia Ferrero</field>
         <field name="appointment_type_id" ref="appointment_type_1" />
         <field name="start" model="appointment.type" eval="
@@ -104,7 +104,7 @@
         <field name="partner_ids" eval="[(6, 0, [ref('res_partner_16'), ref('res_partner_8')])]" />
     </record>
 
-    <record id="calendar_event_16" model="calendar.event" context="{'no_mail_to_attendees': True}">
+    <record id="calendar_event_16" model="calendar.event">
         <field name="name">Brushing</field>
         <field name="appointment_type_id" ref="appointment_type_3" />
         <field name="start" model="appointment.type" eval="
@@ -121,7 +121,7 @@
         <field name="partner_ids" eval="[(6, 0, [ref('res_partner_14'), ref('res_partner_9')])]" />
     </record>
 
-    <record id="calendar_event_15" model="calendar.event" context="{'no_mail_to_attendees': True}">
+    <record id="calendar_event_15" model="calendar.event">
         <field name="name">Haircut &amp; Brushing</field>
         <field name="appointment_type_id" ref="appointment_type_1" />
         <field name="start" model="appointment.type" eval="
@@ -138,7 +138,7 @@
         <field name="partner_ids" eval="[(6, 0, [ref('res_partner_14'), ref('res_partner_8')])]" />
     </record>
 
-    <record id="calendar_event_10" model="calendar.event" context="{'no_mail_to_attendees': True}">
+    <record id="calendar_event_10" model="calendar.event">
         <field name="name">Haircut &amp; Color &amp; Brushing</field>
         <field name="appointment_type_id" ref="appointment_type_2" />
         <field name="start" model="appointment.type" eval="
@@ -155,7 +155,7 @@
         <field name="partner_ids" eval="[(6, 0, [ref('res_partner_14'), ref('res_partner_9')])]" />
     </record>
 
-    <record id="calendar_event_18" model="calendar.event" context="{'no_mail_to_attendees': True}">
+    <record id="calendar_event_18" model="calendar.event">
         <field name="name">Haircut &amp; Brushing with Laura Sullivan</field>
         <field name="appointment_type_id" ref="appointment_type_1" />
         <field name="start" model="appointment.type" eval="
@@ -172,7 +172,7 @@
         <field name="partner_ids" eval="[(6, 0, [ref('res_partner_17'), ref('res_partner_8')])]" />
     </record>
 
-    <record id="calendar_event_3" model="calendar.event" context="{'no_mail_to_attendees': True}">
+    <record id="calendar_event_3" model="calendar.event">
         <field name="name">Haircut &amp; Color &amp; Brushing with Customer 2</field>
         <field name="appointment_type_id" ref="appointment_type_2" />
         <field name="start" model="appointment.type" eval="

--- a/hair_salon/demo/purchase_order.xml
+++ b/hair_salon/demo/purchase_order.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
     <record id="purchase_order_1" model="purchase.order">
         <field name="partner_id" ref="res_partner_24"/>
         <field name="picking_type_id" ref="stock.picking_type_in"/>

--- a/hair_salon/demo/res_users.xml
+++ b/hair_salon/demo/res_users.xml
@@ -1,26 +1,20 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-    <record id="base.user_admin" model="res.users" forcecreate="0">
-        <field name="notification_type">inbox</field>
-    </record>
     <record id="res_users_6" model="res.users">
         <field name="partner_id" ref="res_partner_7"/>
         <field name="login">hairdresser1@hairsalonindustry.example.com</field>
         <field name="company_ids" eval="[(6, 0, [ref('base.main_company')])]"/>
         <field name="company_id" ref="base.main_company"/>
-        <field name="notification_type">inbox</field>
     </record>
     <record id="res_users_7" model="res.users">
         <field name="partner_id" ref="res_partner_8"/>
         <field name="login">hairdresser2@hairsalonindustry.example.com</field>
         <field name="company_ids" eval="[(6, 0, [ref('base.main_company')])]"/>
         <field name="company_id" ref="base.main_company"/>
-        <field name="notification_type">inbox</field>
     </record>
     <record id="res_users_8" model="res.users">
         <field name="partner_id" ref="res_partner_9"/>
         <field name="login">hairdresser3@hairsalonindustry.example.com</field>
         <field name="company_id" ref="base.main_company"/>
-        <field name="notification_type">inbox</field>
     </record>
 </odoo>

--- a/handyman/demo/crm_lead.xml
+++ b/handyman/demo/crm_lead.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
     <record id="crm_lead_1" model="crm.lead">
         <field name="name">Paint and Repair</field>
         <field name="user_id" ref="base.user_admin"/>

--- a/handyman/demo/mail_activity.xml
+++ b/handyman/demo/mail_activity.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_activity_quick_update': True}">
     <record id="mail_activity_5" model="mail.activity">
         <field name="res_model_id" ref="crm.model_crm_lead"/>
         <field name="res_id" ref="crm_lead_6"/>

--- a/handyman/demo/purchase_order.xml
+++ b/handyman/demo/purchase_order.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
     <record id="purchase_order_1" model="purchase.order">
         <field name="partner_id" ref="res_partner_33"/>
         <field name="user_id" ref="base.user_admin"/>

--- a/handyman/demo/sale_order.xml
+++ b/handyman/demo/sale_order.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
     <record id="sale_order_1" model="sale.order">
         <field name="partner_id" ref="base_industry_data.res_partner_21"/>
         <field name="user_id" ref="base.user_admin"/>

--- a/hardware_shop/__manifest__.py
+++ b/hardware_shop/__manifest__.py
@@ -36,7 +36,6 @@
         'data/knowledge_tour.xml',
     ],
     'demo': [
-        'demo/res_users.xml',
         'demo/product_quantity.xml',
         'demo/stock_warehouse_orderpoint.xml',
         'demo/res_partner.xml',

--- a/hardware_shop/demo/res_users.xml
+++ b/hardware_shop/demo/res_users.xml
@@ -1,6 +1,0 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
-    <record id="base.user_admin" model="res.users" forcecreate="0">
-        <field name="notification_type">inbox</field>
-    </record>
-</odoo>

--- a/hardware_shop/demo/sale_order.xml
+++ b/hardware_shop/demo/sale_order.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
     <record id="sale_order_3" model="sale.order">
         <field name="partner_id" ref="res_partner_420"/>
         <field name="user_id" ref="base.user_admin"/>

--- a/headhunter/__manifest__.py
+++ b/headhunter/__manifest__.py
@@ -42,7 +42,6 @@
         'data/knowledge_tour.xml',
     ],
     'demo': [
-        'demo/res_users.xml',
         'demo/res_partner.xml',
         'demo/calendar_event.xml',
         'demo/crm_lead.xml',

--- a/headhunter/demo/calendar_event.xml
+++ b/headhunter/demo/calendar_event.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
-    <record id="calendar_event_1" model="calendar.event" context="{'no_mail_to_attendees': True}">
+<odoo noupdate="1" context="{'no_mail_to_attendees': True}">
+    <record id="calendar_event_1" model="calendar.event">
         <field name="name">First Interview with Shane Williams</field>
         <field name="partner_ids" eval="[(6, 0, [ref('base.partner_admin'), ref('res_partner_24')])]"/>
         <field name="start" model="appointment.type" eval="
@@ -23,7 +23,7 @@
             ]]>
         </field>
     </record>
-    <record id="calendar_event_2" model="calendar.event" context="{'no_mail_to_attendees': True}">
+    <record id="calendar_event_2" model="calendar.event">
         <field name="name">First Interview with Wonderful Coder</field>
         <field name="partner_ids" eval="[(6, 0, [ref('base.partner_admin'), ref('res_partner_35')])]"/>
         <field name="start" model="appointment.type" eval="

--- a/headhunter/demo/crm_lead.xml
+++ b/headhunter/demo/crm_lead.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True, 'mail_activity_quick_update': True}">
     <record id="crm_lead_12" model="crm.lead">
         <field name="name">SecondTest - Python Dev</field>
         <field name="partner_id" ref="res_partner_28"/>

--- a/headhunter/demo/hr_applicant.xml
+++ b/headhunter/demo/hr_applicant.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
-    <record id="hr_applicant_10" model="hr.applicant" context="{'mail_notrack': True}">
+<odoo noupdate="1" context="{'mail_notrack': True}">
+    <record id="hr_applicant_10" model="hr.applicant">
         <field name="partner_name">Wonderful Coder</field>
         <field name="partner_id" ref="res_partner_35"/>
         <field name="attachment_ids" eval="[(6, 0, [ref('ir_attachment_623')])]"/>
@@ -8,7 +8,7 @@
         <field name="priority">3</field>
         <field name="stage_id" ref="hr_recruitment_stage_9"/>
     </record>
-    <record id="hr_applicant_2" model="hr.applicant" context="{'mail_notrack': True}">
+    <record id="hr_applicant_2" model="hr.applicant">
         <field name="partner_name">Keanu Fictional</field>
         <field name="partner_id" ref="res_partner_25"/>
         <field name="type_id" ref="hr_recruitment.degree_licenced"/>
@@ -19,13 +19,13 @@
         <field name="salary_expected">3000.0</field>
         <field name="stage_id" ref="hr_recruitment.stage_job5"/>
     </record>
-    <record id="hr_applicant_3" model="hr.applicant" context="{'mail_notrack': True}">
+    <record id="hr_applicant_3" model="hr.applicant">
         <field name="partner_name">Sylvester Fanfiction</field>
         <field name="partner_id" ref="res_partner_22"/>
         <field name="job_id" ref="hr_job_6"/>
         <field name="stage_id" ref="hr_recruitment_stage_9"/>
     </record>
-    <record id="hr_applicant_5" model="hr.applicant" context="{'mail_notrack': True}">
+    <record id="hr_applicant_5" model="hr.applicant">
         <field name="partner_name">Shane</field>
         <field name="partner_id" ref="res_partner_24"/>
         <field name="x_opportunities" eval="[(6, 0, [ref('crm_lead_14')])]"/>
@@ -34,12 +34,12 @@
         <field name="priority">2</field>
         <field name="stage_id" ref="hr_recruitment.stage_job5"/>
     </record>
-    <record id="hr_applicant_6" model="hr.applicant" context="{'mail_notrack': True}">
+    <record id="hr_applicant_6" model="hr.applicant">
         <field name="partner_name">rambo</field>
         <field name="job_id" ref="hr_job_7"/>
         <field name="stage_id" ref="hr_recruitment_stage_9"/>
     </record>
-    <record id="hr_applicant_7" model="hr.applicant" context="{'mail_notrack': True}">
+    <record id="hr_applicant_7" model="hr.applicant">
         <field name="partner_name">Morgan Busyman</field>
         <field name="partner_id" ref="res_partner_26"/>
         <field name="categ_ids" eval="[(6, 0, [ref('hr_recruitment.tag_applicant_reserve')])]"/>
@@ -47,14 +47,14 @@
         <field name="job_id" ref="hr_job_6"/>
         <field name="stage_id" ref="hr_recruitment.stage_job0"/>
     </record>
-    <record id="hr_applicant_8" model="hr.applicant" context="{'mail_notrack': True}">
+    <record id="hr_applicant_8" model="hr.applicant">
         <field name="partner_name">Marc Demo</field>
         <field name="partner_id" ref="res_partner_29"/>
         <field name="attachment_ids" eval="[(6, 0, [ref('ir_attachment_623')])]"/>
         <field name="job_id" ref="hr_job_6"/>
         <field name="stage_id" ref="hr_recruitment.stage_job5"/>
     </record>
-    <record id="hr_applicant_9" model="hr.applicant" context="{'mail_notrack': True}">
+    <record id="hr_applicant_9" model="hr.applicant">
         <field name="partner_name">William Wonder</field>
         <field name="partner_id" ref="res_partner_32"/>
         <field name="availability" eval="(datetime.now() - relativedelta(months=1)).strftime('%Y-%m-%d')"/>

--- a/headhunter/demo/res_users.xml
+++ b/headhunter/demo/res_users.xml
@@ -1,6 +1,0 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
-    <record id="base.user_admin" model="res.users" forcecreate="0">
-        <field name="notification_type">inbox</field>
-    </record>
-</odoo>

--- a/headhunter/demo/sale_order.xml
+++ b/headhunter/demo/sale_order.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
     <record id="sale_order_11" model="sale.order">
         <field name="partner_id" ref="res_partner_28"/>
         <field name="opportunity_id" ref="crm_lead_12"/>

--- a/headhunter/demo/sale_order_confirm.xml
+++ b/headhunter/demo/sale_order_confirm.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
     <function model="sale.order" name="action_confirm">
         <value eval="[ref('sale_order_11'), ref('sale_order_12'), ref('sale_order_13')]"/>
     </function>

--- a/holiday_house/demo/sale_order.xml
+++ b/holiday_house/demo/sale_order.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
     <record id="sale_order_1" model="sale.order">
         <field name="partner_id" ref="base_industry_data.res_partner_20"/>
         <field name="user_id" ref="base.user_admin"/>

--- a/hotel/demo/sale_order.xml
+++ b/hotel/demo/sale_order.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
     <record id="sale_order_1" model="sale.order">
         <field name="partner_id" ref="base_industry_data.res_partner_20"/>
         <field name="user_id" ref="base.user_admin"/>

--- a/hvac_services/demo/project_task.xml
+++ b/hvac_services/demo/project_task.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
     <record id="project_task_3" model="project.task">
         <field name="sale_line_id" ref="sale_order_line_5"/>
     </record>

--- a/hvac_services/demo/res_users.xml
+++ b/hvac_services/demo/res_users.xml
@@ -3,11 +3,9 @@
     <record id="res_users_1" model="res.users">
         <field name="partner_id" ref="res_partner_1"/>
         <field name="login">andrew.blake@example.com</field>
-        <field name="notification_type">inbox</field>
     </record>
     <record id="res_users_2" model="res.users">
         <field name="partner_id" ref="res_partner_2"/>
         <field name="login">tom.white@example.com</field>
-        <field name="notification_type">inbox</field>
     </record>
 </odoo>

--- a/hvac_services/demo/sale_order.xml
+++ b/hvac_services/demo/sale_order.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
     <record id="sale_order_1" model="sale.order">
         <field name="partner_id" ref="base_industry_data.res_partner_35"/>
         <field name="sale_order_template_id" ref="sale_order_template_3"/>

--- a/hvac_services/demo/sale_order_post.xml
+++ b/hvac_services/demo/sale_order_post.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
     <record id="sale_order_11" model="sale.order">
         <field name="x_maintained_serials_ids" eval="[(6, 0, [ref('stock_lot_14')])]"/>
     </record>

--- a/industry_lawyer/__manifest__.py
+++ b/industry_lawyer/__manifest__.py
@@ -41,7 +41,6 @@
         'data/website_theme_apply.xml',
     ],
     'demo': [
-        'demo/res_users.xml',
         'demo/res_partner.xml',
         'demo/crm_lead.xml',
         'demo/mail_activity.xml',

--- a/industry_lawyer/demo/crm_lead.xml
+++ b/industry_lawyer/demo/crm_lead.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
     <record id="crm_lead_7" model="crm.lead">
         <field name="user_id" ref="base.user_admin"/>
         <field name="partner_id" ref="res_partner_221"/>

--- a/industry_lawyer/demo/mail_activity.xml
+++ b/industry_lawyer/demo/mail_activity.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_activity_quick_update': True}">
     <record id="mail_activity_3" model="mail.activity">
         <field name="user_id" ref="base.user_admin"/>
         <field name="res_model_id" ref="crm.model_crm_lead"/>

--- a/industry_lawyer/demo/res_users.xml
+++ b/industry_lawyer/demo/res_users.xml
@@ -1,6 +1,0 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
-    <record id="base.user_admin" model="res.users" forcecreate="0">
-        <field name="notification_type">inbox</field>
-    </record>
-</odoo>

--- a/industry_lawyer/demo/sale_order.xml
+++ b/industry_lawyer/demo/sale_order.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
     <record id="sale_order_26" model="sale.order">
         <field name="partner_id" ref="res_partner_221"/>
         <field name="sale_order_template_id" ref="sale_order_template_1"/>

--- a/industry_lawyer/demo/sale_order_post.xml
+++ b/industry_lawyer/demo/sale_order_post.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
     <function model="sale.order" name="action_confirm" eval="[[
         ref('sale_order_21'),
         ref('sale_order_24'),

--- a/industry_real_estate/__manifest__.py
+++ b/industry_real_estate/__manifest__.py
@@ -46,7 +46,6 @@
         'data/uninstall_hook.xml',
     ],
     'demo': [
-        'demo/res_users.xml',
         'demo/x_buildings.xml',
         'demo/account_analytic_account.xml',
         'demo/ir_attachment.xml',

--- a/industry_real_estate/demo/crm_lead.xml
+++ b/industry_real_estate/demo/crm_lead.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
     <record id="crm_lead_45" model="crm.lead">
         <field name="name">John Doe</field>
         <field name="partner_id" ref="res_partner_51" />

--- a/industry_real_estate/demo/res_users.xml
+++ b/industry_real_estate/demo/res_users.xml
@@ -1,6 +1,0 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
-    <record id="base.user_admin" model="res.users" forcecreate="0">
-        <field name="notification_type">inbox</field>
-    </record>
-</odoo>

--- a/industry_real_estate/demo/sale_order.xml
+++ b/industry_real_estate/demo/sale_order.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
     <record id="sale_order_25" model="sale.order">
         <field name="start_date" eval="datetime.today().date().replace(month=3, day=1)"/>
         <field name="end_date" eval="datetime.today().date().replace(month=3, day=1) + relativedelta(months=12)"/>

--- a/industry_real_estate/demo/sale_order_confirm.xml
+++ b/industry_real_estate/demo/sale_order_confirm.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True, 'mail_notrack': True}">
     <!-- update sale order stages -->
     <function model="sale.order" name="action_confirm" eval="[[
         ref('sale_order_25'),

--- a/industry_restaurant/demo/calendar_event.xml
+++ b/industry_restaurant/demo/calendar_event.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
-    <record id="calendar_event_3" model="calendar.event" context="{'no_mail_to_attendees': True}">
+<odoo noupdate="1" context="{'no_mail_to_attendees': True, 'mail_notrack': True}">
+    <record id="calendar_event_3" model="calendar.event">
         <field name="name">David Lee</field>
         <field name="user_id" ref="base.user_admin"/>
         <field name="start" model="appointment.type" eval="pytz.timezone(obj().env.ref('industry_restaurant.appointment_type_1').appointment_tz).localize(
@@ -14,7 +14,7 @@
         <field name="appointment_type_id" ref="appointment_type_1"/>
         <field name="appointment_status">booked</field>
     </record>
-    <record id="calendar_event_11" model="calendar.event" context="{'no_mail_to_attendees': True}">
+    <record id="calendar_event_11" model="calendar.event">
         <field name="name">David Lee</field>
         <field name="user_id" ref="base.user_admin"/>
         <field name="start" model="appointment.type" eval="pytz.timezone(obj().env.ref('industry_restaurant.appointment_type_1').appointment_tz).localize(
@@ -28,7 +28,7 @@
         <field name="appointment_type_id" ref="appointment_type_1"/>
         <field name="appointment_status">booked</field>
     </record>
-    <record id="calendar_event_7" model="calendar.event" context="{'no_mail_to_attendees': True}">
+    <record id="calendar_event_7" model="calendar.event">
         <field name="name">John Smith</field>
         <field name="user_id" ref="base.user_admin"/>
         <field name="start" model="appointment.type" eval="pytz.timezone(obj().env.ref('industry_restaurant.appointment_type_1').appointment_tz).localize(
@@ -42,7 +42,7 @@
         <field name="appointment_type_id" ref="appointment_type_1"/>
         <field name="appointment_status">booked</field>
     </record>
-    <record id="calendar_event_12" model="calendar.event" context="{'no_mail_to_attendees': True}">
+    <record id="calendar_event_12" model="calendar.event">
         <field name="name">John Smith</field>
         <field name="user_id" ref="base.user_admin"/>
         <field name="start" model="appointment.type" eval="pytz.timezone(obj().env.ref('industry_restaurant.appointment_type_1').appointment_tz).localize(
@@ -56,7 +56,7 @@
         <field name="appointment_type_id" ref="appointment_type_1"/>
         <field name="appointment_status">booked</field>
     </record>
-    <record id="calendar_event_2" model="calendar.event" context="{'no_mail_to_attendees': True}">
+    <record id="calendar_event_2" model="calendar.event">
         <field name="name">Chris Taylor</field>
         <field name="user_id" ref="base.user_admin"/>
         <field name="start" model="appointment.type" eval="pytz.timezone(obj().env.ref('industry_restaurant.appointment_type_1').appointment_tz).localize(
@@ -70,7 +70,7 @@
         <field name="appointment_type_id" ref="appointment_type_1"/>
         <field name="appointment_status">booked</field>
     </record>
-    <record id="calendar_event_13" model="calendar.event" context="{'no_mail_to_attendees': True}">
+    <record id="calendar_event_13" model="calendar.event">
         <field name="name">Chris Taylor</field>
         <field name="user_id" ref="base.user_admin"/>
         <field name="start" model="appointment.type" eval="pytz.timezone(obj().env.ref('industry_restaurant.appointment_type_1').appointment_tz).localize(
@@ -84,7 +84,7 @@
         <field name="appointment_type_id" ref="appointment_type_1"/>
         <field name="appointment_status">booked</field>
     </record>
-    <record id="calendar_event_9" model="calendar.event" context="{'no_mail_to_attendees': True}">
+    <record id="calendar_event_9" model="calendar.event">
         <field name="name">Mike Brown</field>
         <field name="user_id" ref="base.user_admin"/>
         <field name="start" model="appointment.type" eval="pytz.timezone(obj().env.ref('industry_restaurant.appointment_type_1').appointment_tz).localize(
@@ -98,7 +98,7 @@
         <field name="appointment_type_id" ref="appointment_type_1"/>
         <field name="appointment_status">booked</field>
     </record>
-    <record id="calendar_event_14" model="calendar.event" context="{'no_mail_to_attendees': True}">
+    <record id="calendar_event_14" model="calendar.event">
         <field name="name">Mike Brown</field>
         <field name="user_id" ref="base.user_admin"/>
         <field name="start" model="appointment.type" eval="pytz.timezone(obj().env.ref('industry_restaurant.appointment_type_1').appointment_tz).localize(
@@ -112,7 +112,7 @@
         <field name="appointment_type_id" ref="appointment_type_1"/>
         <field name="appointment_status">booked</field>
     </record>
-    <record id="calendar_event_10" model="calendar.event" context="{'no_mail_to_attendees': True}">
+    <record id="calendar_event_10" model="calendar.event">
         <field name="name">Mike Brown</field>
         <field name="user_id" ref="base.user_admin"/>
         <field name="start" model="appointment.type" eval="pytz.timezone(obj().env.ref('industry_restaurant.appointment_type_1').appointment_tz).localize(
@@ -126,7 +126,7 @@
         <field name="appointment_type_id" ref="appointment_type_1"/>
         <field name="appointment_status">booked</field>
     </record>
-    <record id="calendar_event_15" model="calendar.event" context="{'no_mail_to_attendees': True}">
+    <record id="calendar_event_15" model="calendar.event">
         <field name="name">Mike Brown</field>
         <field name="user_id" ref="base.user_admin"/>
         <field name="start" model="appointment.type" eval="pytz.timezone(obj().env.ref('industry_restaurant.appointment_type_1').appointment_tz).localize(
@@ -140,7 +140,7 @@
         <field name="appointment_type_id" ref="appointment_type_1"/>
         <field name="appointment_status">booked</field>
     </record>
-    <record id="calendar_event_4" model="calendar.event" context="{'no_mail_to_attendees': True}">
+    <record id="calendar_event_4" model="calendar.event">
         <field name="name">Emily Johnson</field>
         <field name="user_id" ref="base.user_admin"/>
         <field name="start" model="appointment.type" eval="pytz.timezone(obj().env.ref('industry_restaurant.appointment_type_1').appointment_tz).localize(
@@ -154,7 +154,7 @@
         <field name="appointment_type_id" ref="appointment_type_1"/>
         <field name="appointment_status">booked</field>
     </record>
-    <record id="calendar_event_16" model="calendar.event" context="{'no_mail_to_attendees': True}">
+    <record id="calendar_event_16" model="calendar.event">
         <field name="name">Emily Johnson</field>
         <field name="user_id" ref="base.user_admin"/>
         <field name="start" model="appointment.type" eval="pytz.timezone(obj().env.ref('industry_restaurant.appointment_type_1').appointment_tz).localize(
@@ -168,7 +168,7 @@
         <field name="appointment_type_id" ref="appointment_type_1"/>
         <field name="appointment_status">booked</field>
     </record>
-    <record id="calendar_event_6" model="calendar.event" context="{'no_mail_to_attendees': True}">
+    <record id="calendar_event_6" model="calendar.event">
         <field name="name">Lisa Anderson</field>
         <field name="user_id" ref="base.user_admin"/>
         <field name="start" model="appointment.type" eval="pytz.timezone(obj().env.ref('industry_restaurant.appointment_type_1').appointment_tz).localize(
@@ -182,7 +182,7 @@
         <field name="appointment_type_id" ref="appointment_type_1"/>
         <field name="appointment_status">booked</field>
     </record>
-    <record id="calendar_event_17" model="calendar.event" context="{'no_mail_to_attendees': True}">
+    <record id="calendar_event_17" model="calendar.event">
         <field name="name">Lisa Anderson</field>
         <field name="user_id" ref="base.user_admin"/>
         <field name="start" model="appointment.type" eval="pytz.timezone(obj().env.ref('industry_restaurant.appointment_type_1').appointment_tz).localize(
@@ -196,7 +196,7 @@
         <field name="appointment_type_id" ref="appointment_type_1"/>
         <field name="appointment_status">booked</field>
     </record>
-    <record id="calendar_event_1" model="calendar.event" context="{'no_mail_to_attendees': True}">
+    <record id="calendar_event_1" model="calendar.event">
         <field name="name">Amanda White</field>
         <field name="user_id" ref="base.user_admin"/>
         <field name="start" model="appointment.type" eval="pytz.timezone(obj().env.ref('industry_restaurant.appointment_type_1').appointment_tz).localize(
@@ -210,7 +210,7 @@
         <field name="appointment_type_id" ref="appointment_type_1"/>
         <field name="appointment_status">booked</field>
     </record>
-    <record id="calendar_event_18" model="calendar.event" context="{'no_mail_to_attendees': True}">
+    <record id="calendar_event_18" model="calendar.event">
         <field name="name">Amanda White</field>
         <field name="user_id" ref="base.user_admin"/>
         <field name="start" model="appointment.type" eval="pytz.timezone(obj().env.ref('industry_restaurant.appointment_type_1').appointment_tz).localize(
@@ -224,7 +224,7 @@
         <field name="appointment_type_id" ref="appointment_type_1"/>
         <field name="appointment_status">booked</field>
     </record>
-    <record id="calendar_event_8" model="calendar.event" context="{'no_mail_to_attendees': True}">
+    <record id="calendar_event_8" model="calendar.event">
         <field name="name">Sarah Davis</field>
         <field name="user_id" ref="base.user_admin"/>
         <field name="start" model="appointment.type" eval="pytz.timezone(obj().env.ref('industry_restaurant.appointment_type_1').appointment_tz).localize(
@@ -238,7 +238,7 @@
         <field name="appointment_type_id" ref="appointment_type_1"/>
         <field name="appointment_status">booked</field>
     </record>
-    <record id="calendar_event_19" model="calendar.event" context="{'no_mail_to_attendees': True}">
+    <record id="calendar_event_19" model="calendar.event">
         <field name="name">Sarah Davis</field>
         <field name="user_id" ref="base.user_admin"/>
         <field name="start" model="appointment.type" eval="pytz.timezone(obj().env.ref('industry_restaurant.appointment_type_1').appointment_tz).localize(
@@ -252,7 +252,7 @@
         <field name="appointment_type_id" ref="appointment_type_1"/>
         <field name="appointment_status">booked</field>
     </record>
-    <record id="calendar_event_5" model="calendar.event" context="{'no_mail_to_attendees': True}">
+    <record id="calendar_event_5" model="calendar.event">
         <field name="name">Jessica Martinez</field>
         <field name="start" model="appointment.type" eval="pytz.timezone(obj().env.ref('industry_restaurant.appointment_type_1').appointment_tz).localize(
             DateTime.today().date() + relativedelta(hours=10)
@@ -266,7 +266,7 @@
         <field name="appointment_type_id" ref="appointment_type_1"/>
         <field name="appointment_status">booked</field>
     </record>
-    <record id="calendar_event_20" model="calendar.event" context="{'no_mail_to_attendees': True}">
+    <record id="calendar_event_20" model="calendar.event">
         <field name="name">Jessica Martinez</field>
         <field name="start" model="appointment.type" eval="pytz.timezone(obj().env.ref('industry_restaurant.appointment_type_1').appointment_tz).localize(
             DateTime.today().date() + relativedelta(days=1, hours=10)

--- a/industry_restaurant/demo/purchase_order.xml
+++ b/industry_restaurant/demo/purchase_order.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
     <record id="purchase_order_1" model="purchase.order">
         <field name="partner_id" ref="res_partner_11"/>
         <field name="user_id" ref="base.user_admin"/>

--- a/it_hardware/__manifest__.py
+++ b/it_hardware/__manifest__.py
@@ -40,7 +40,6 @@
         'data/knowledge_tour.xml',
     ],
     'demo': [
-        'demo/res_users.xml',
         'demo/res_partner.xml',
         'demo/product_supplierinfo.xml',
         'demo/product_template.xml',

--- a/it_hardware/demo/helpdesk_ticket.xml
+++ b/it_hardware/demo/helpdesk_ticket.xml
@@ -1,11 +1,11 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
-    <record id="helpdesk_ticket_1" model="helpdesk.ticket" context="{'mail_notrack': True}">
+<odoo noupdate="1" context="{'mail_notrack': True}">
+    <record id="helpdesk_ticket_1" model="helpdesk.ticket">
         <field name="name">Laptop Problem</field>
         <field name="partner_id" ref="res_partner_7"/>
         <field name="lot_id" ref="stock_lot_2"/>
     </record>
-    <record id="helpdesk_ticket_2" model="helpdesk.ticket" context="{'mail_notrack': True}">
+    <record id="helpdesk_ticket_2" model="helpdesk.ticket">
         <field name="name">Problem in the Laptop</field>
         <field name="partner_id" ref="res_partner_15"/>
         <field name="lot_id" ref="stock_lot_2"/>

--- a/it_hardware/demo/purchase_order.xml
+++ b/it_hardware/demo/purchase_order.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
     <record id="purchase_order_1" model="purchase.order">
         <field name="partner_id" ref="res_partner_9"/>
         <field name="user_id" ref="base.user_admin"/>

--- a/it_hardware/demo/res_users.xml
+++ b/it_hardware/demo/res_users.xml
@@ -1,6 +1,0 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
-    <record id="base.user_admin" model="res.users" forcecreate="0">
-        <field name="notification_type">inbox</field>
-    </record>
-</odoo>

--- a/it_hardware/demo/sale_order.xml
+++ b/it_hardware/demo/sale_order.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
     <record id="sale_order_1" model="sale.order">
         <field name="partner_id" ref="base.partner_admin"/>
         <field name="website_id" ref="website.default_website"/>

--- a/library/demo/event_event.xml
+++ b/library/demo/event_event.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
     <record id="event_event_2" model="event.event">
         <field name="cover_properties"><![CDATA[{"background-image":"url(/web/image/library.ir_attachment_5)","background_color_class":"o_cc3 o_cc","opacity":"0.4","resize_class":"o_half_screen_height o_record_has_cover","text_align_class":""}]]></field>
         <field name="name">Literary Exchange Club</field>

--- a/library/demo/sale_order.xml
+++ b/library/demo/sale_order.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
   <record id="sale_order_1" model="sale.order">
     <field name="partner_id" ref="base_industry_data.res_partner_28"/>
     <field name="user_id" ref="base.user_admin"/>

--- a/library/demo/sale_order_confirm.xml
+++ b/library/demo/sale_order_confirm.xml
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True, 'mail_notrack': True}">
   <function model="sale.order" name="action_confirm" eval="[[ref('sale_order_1')]]"/>
 </odoo>

--- a/machine_tool_rental/demo/crm_lead.xml
+++ b/machine_tool_rental/demo/crm_lead.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
   <record id="crm_lead_1" model="crm.lead">
     <field name="name">Power Plant Shutdown Rental</field>
     <field name="team_id" ref="sales_team.team_sales_department"/>

--- a/machine_tool_rental/demo/quality_check.xml
+++ b/machine_tool_rental/demo/quality_check.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
     <record id="quality_check_4" model="quality.check">
         <field name="name">QC00001</field>
         <field name="title">Return Check</field>

--- a/machine_tool_rental/demo/sale_order.xml
+++ b/machine_tool_rental/demo/sale_order.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
     <record id="sale_order_10" model="sale.order">
         <field name="partner_id" ref="base_industry_data.res_partner_35"/>
         <field name="user_id" ref="base.user_admin"/>

--- a/marketing_agency/demo/crm_lead.xml
+++ b/marketing_agency/demo/crm_lead.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
-    <record id="crm_lead_10" model="crm.lead" context="{'mail_auto_subscribe_no_notify': True}">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
+    <record id="crm_lead_10" model="crm.lead">
         <field name="partner_id" ref="base_industry_data.res_partner_22"/>
         <field name="name">Mobile App Marketing</field>
         <field name="user_id" ref="base.user_admin"/>
@@ -9,7 +9,7 @@
         <field name="tag_ids" eval="[(6, 0, [ref('crm_tag_1'), ref('crm_tag_2')])]"/>
         <field name="expected_revenue">20000.0</field>
     </record>
-    <record id="crm_lead_7" model="crm.lead" context="{'mail_auto_subscribe_no_notify': True}">
+    <record id="crm_lead_7" model="crm.lead">
         <field name="partner_id" ref="base_industry_data.res_partner_25"/>
         <field name="name">PPC Campaign Management</field>
         <field name="user_id" ref="base_industry_data.res_users_7"/>
@@ -20,7 +20,7 @@
         <field name="expected_revenue">10000.0</field>
         <field name="probability">95.45</field>
     </record>
-    <record id="crm_lead_5" model="crm.lead" context="{'mail_auto_subscribe_no_notify': True}">
+    <record id="crm_lead_5" model="crm.lead">
         <field name="partner_id" ref="base_industry_data.res_partner_23"/>
         <field name="name">Email Marketing Strategy</field>
         <field name="user_id" ref="base.user_admin"/>
@@ -32,7 +32,7 @@
         <field name="expected_revenue">7500.0</field>
         <field name="probability">91.67</field>
     </record>
-    <record id="crm_lead_3" model="crm.lead" context="{'mail_auto_subscribe_no_notify': True}">
+    <record id="crm_lead_3" model="crm.lead">
         <field name="partner_id" ref="base_industry_data.res_partner_28"/>
         <field name="name">SEO Optimization</field>
         <field name="user_id" ref="base.user_admin"/>
@@ -43,7 +43,7 @@
         <field name="expected_revenue">12000.0</field>
         <field name="probability">93.4</field>
     </record>
-    <record id="crm_lead_8" model="crm.lead" context="{'mail_auto_subscribe_no_notify': True}">
+    <record id="crm_lead_8" model="crm.lead">
         <field name="partner_id" ref="base_industry_data.res_partner_30"/>
         <field name="name">Market Research Project</field>
         <field name="user_id" ref="base.user_admin"/>
@@ -54,7 +54,7 @@
         <field name="expected_revenue">15000.0</field>
         <field name="probability">100.0</field>
     </record>
-    <record id="crm_lead_6" model="crm.lead" context="{'mail_auto_subscribe_no_notify': True}">
+    <record id="crm_lead_6" model="crm.lead">
         <field name="partner_id" ref="base_industry_data.res_partner_27"/>
         <field name="name">Video Content Production</field>
         <field name="user_id" ref="base.user_admin"/>
@@ -66,7 +66,7 @@
         <field name="expected_revenue">18000.0</field>
         <field name="probability">91.67</field>
     </record>
-    <record id="crm_lead_4" model="crm.lead" context="{'mail_auto_subscribe_no_notify': True}">
+    <record id="crm_lead_4" model="crm.lead">
         <field name="partner_id" ref="base_industry_data.res_partner_24"/>
         <field name="name">Corporate Rebranding</field>
         <field name="user_id" ref="base.user_admin"/>
@@ -78,7 +78,7 @@
         <field name="expected_revenue">25000.0</field>
         <field name="probability">100</field>
     </record>
-    <record id="crm_lead_1" model="crm.lead" context="{'mail_auto_subscribe_no_notify': True}">
+    <record id="crm_lead_1" model="crm.lead">
         <field name="partner_id" ref="base_industry_data.res_partner_26"/>
         <field name="name">Website Redesign Project</field>
         <field name="user_id" ref="base_industry_data.res_users_7"/>
@@ -89,7 +89,7 @@
         <field name="expected_revenue">15000.0</field>
         <field name="probability">95.45</field>
     </record>
-    <record id="crm_lead_9" model="crm.lead" context="{'mail_auto_subscribe_no_notify': True}">
+    <record id="crm_lead_9" model="crm.lead">
         <field name="partner_id" ref="base_industry_data.res_partner_21"/>
         <field name="name">PR Campaign</field>
         <field name="user_id" ref="base.user_admin"/>
@@ -100,7 +100,7 @@
         <field name="expected_revenue">9000.0</field>
         <field name="probability">95.45</field>
     </record>
-    <record id="crm_lead_2" model="crm.lead" context="{'mail_auto_subscribe_no_notify': True}">
+    <record id="crm_lead_2" model="crm.lead">
         <field name="partner_id" ref="base_industry_data.res_partner_29"/>
         <field name="name">Social Media Campaign</field>
         <field name="user_id" ref="base_industry_data.res_users_7"/>

--- a/marketing_agency/demo/event_event.xml
+++ b/marketing_agency/demo/event_event.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
     <record id="event_event_2" model="event.event">
         <field name="cover_properties"><![CDATA[{"background-image":"url(/web/image/marketing_agency.ir_attachment_1158)","background_color_class":"o_cc3 o_cc","background_color_style":"","opacity":"0.4","resize_class":"o_half_screen_height o_record_has_cover","text_align_class":""}]]></field>
         <field name="name">Influencer Marketing Masterclass </field>

--- a/marketing_agency/demo/mail_activity.xml
+++ b/marketing_agency/demo/mail_activity.xml
@@ -1,55 +1,55 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
-    <record id="mail_activity_8" model="mail.activity" context="{'mail_activity_quick_update': True}">
+<odoo noupdate="1" context="{'mail_activity_quick_update': True}">
+    <record id="mail_activity_8" model="mail.activity">
         <field name="res_model_id" ref="crm.model_crm_lead"/>
         <field name="res_id" ref="crm_lead_5"/>
         <field name="activity_type_id" ref="mail.mail_activity_data_todo"/>
         <field name="date_deadline" eval="(datetime.today() - timedelta(days=14)).strftime('%Y-%m-%d')"/>
         <field name="user_id" ref="base.user_admin"/>
     </record>
-    <record id="mail_activity_2" model="mail.activity" context="{'mail_activity_quick_update': True}">
+    <record id="mail_activity_2" model="mail.activity">
         <field name="res_model_id" ref="crm.model_crm_lead"/>
         <field name="res_id" ref="crm_lead_9"/>
         <field name="activity_type_id" ref="mail.mail_activity_data_todo"/>
         <field name="date_deadline" eval="(datetime.today() + timedelta(days=6)).strftime('%Y-%m-%d')"/>
         <field name="user_id" ref="base.user_admin"/>
     </record>
-    <record id="mail_activity_4" model="mail.activity" context="{'mail_activity_quick_update': True}">
+    <record id="mail_activity_4" model="mail.activity">
         <field name="res_model_id" ref="crm.model_crm_lead"/>
         <field name="res_id" ref="crm_lead_4"/>
         <field name="activity_type_id" ref="mail.mail_activity_data_call"/>
         <field name="date_deadline" eval="datetime.today().strftime('%Y-%m-%d')"/>
         <field name="user_id" ref="base.user_admin"/>
     </record>
-    <record id="mail_activity_1" model="mail.activity" context="{'mail_activity_quick_update': True}">
+    <record id="mail_activity_1" model="mail.activity">
         <field name="res_model_id" ref="crm.model_crm_lead"/>
         <field name="res_id" ref="crm_lead_10"/>
         <field name="activity_type_id" ref="mail.mail_activity_data_call"/>
         <field name="date_deadline" eval="(datetime.today() + timedelta(days=1)).strftime('%Y-%m-%d')"/>
         <field name="user_id" ref="base.user_admin"/>
     </record>
-    <record id="mail_activity_3" model="mail.activity" context="{'mail_activity_quick_update': True}">
+    <record id="mail_activity_3" model="mail.activity">
         <field name="res_model_id" ref="crm.model_crm_lead"/>
         <field name="res_id" ref="crm_lead_1"/>
         <field name="activity_type_id" ref="mail.mail_activity_data_upload_document"/>
         <field name="date_deadline" eval="(datetime.today() + timedelta(days=7)).strftime('%Y-%m-%d')"/>
         <field name="user_id" ref="base.user_admin"/>
     </record>
-    <record id="mail_activity_6" model="mail.activity" context="{'mail_activity_quick_update': True}">
+    <record id="mail_activity_6" model="mail.activity">
         <field name="res_model_id" ref="crm.model_crm_lead"/>
         <field name="res_id" ref="crm_lead_2"/>
         <field name="activity_type_id" ref="mail.mail_activity_data_todo"/>
         <field name="date_deadline" eval="(datetime.today() + timedelta(days=7)).strftime('%Y-%m-%d')"/>
         <field name="user_id" ref="base.user_admin"/>
     </record>
-    <record id="mail_activity_16" model="mail.activity" context="{'mail_activity_quick_update': True}">
+    <record id="mail_activity_16" model="mail.activity">
         <field name="res_model_id" ref="sale.model_sale_order"/>
         <field name="res_id" ref="sale_order_3"/>
         <field name="activity_type_id" ref="mail.mail_activity_data_call"/>
         <field name="date_deadline" eval="(datetime.today() - timedelta(days=4)).strftime('%Y-%m-%d')"/>
         <field name="user_id" ref="base.user_admin"/>
     </record>
-    <record id="mail_activity_14" model="mail.activity" context="{'mail_activity_quick_update': True}">
+    <record id="mail_activity_14" model="mail.activity">
         <field name="res_model_id" ref="sale.model_sale_order"/>
         <field name="res_id" ref="sale_order_6"/>
         <field name="activity_type_id" ref="mail.mail_activity_data_todo"/>
@@ -59,7 +59,7 @@
         <field name="automated" eval="True"/>
         <field name="user_id" ref="base.user_admin"/>
     </record>
-    <record id="mail_activity_17" model="mail.activity" context="{'mail_activity_quick_update': True}">
+    <record id="mail_activity_17" model="mail.activity">
         <field name="res_model_id" ref="sale.model_sale_order"/>
         <field name="res_id" ref="sale_order_4"/>
         <field name="activity_type_id" ref="mail.mail_activity_data_todo"/>

--- a/marketing_agency/demo/project_project.xml
+++ b/marketing_agency/demo/project_project.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
-    <record id="project_project_7" model="project.project" context="{'mail_auto_subscribe_no_notify': True}">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
+    <record id="project_project_7" model="project.project">
         <field name="user_id" ref="base_industry_data.res_users_7"/>
     </record>
 </odoo>

--- a/marketing_agency/demo/project_task.xml
+++ b/marketing_agency/demo/project_task.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
-    <record id="project_task_105" model="project.task" context="{'mail_auto_subscribe_no_notify': True}">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
+    <record id="project_task_105" model="project.task">
         <field name="name">Sitemap &amp; Information Architecture</field>
         <field name="description"><![CDATA[<div data-oe-version="1.1">Creating logical site structure and user flows to optimize navigation and content organization.</div><div><br></div>]]></field>
         <field name="priority">1</field>
@@ -9,7 +9,7 @@
         <field name="tag_ids" eval="[(6, 0, [ref('project_tags_18')])]"/>
         <field name="user_ids" eval="[(6, 0, [ref('base_industry_data.res_users_7')])]"/>
     </record>
-    <record id="project_task_104" model="project.task" context="{'mail_auto_subscribe_no_notify': True}">
+    <record id="project_task_104" model="project.task">
         <field name="name">Initial Requirements Gathering</field>
         <field name="description"><![CDATA[<div data-oe-version="1.1">Consultation to define project scope, objectives, target audience, and technical requirements.</div><div><br></div>]]></field>
         <field name="priority">1</field>
@@ -18,7 +18,7 @@
         <field name="tag_ids" eval="[(6, 0, [ref('project_tags_18')])]"/>
         <field name="user_ids" eval="[(6, 0, [ref('base_industry_data.res_users_7')])]"/>
     </record>
-    <record id="project_task_122" model="project.task" context="{'mail_auto_subscribe_no_notify': True}">
+    <record id="project_task_122" model="project.task">
         <field name="name">Content Population &amp; SEO Setup</field>
         <field name="description"><![CDATA[<div data-oe-version="1.1">Loading of initial content and configuration of meta tags, sitemaps, and SEO settings.</div><div><br></div>]]></field>
         <field name="project_id" ref="project_project_2"/>
@@ -26,7 +26,7 @@
         <field name="tag_ids" eval="[(6, 0, [ref('project_tags_22')])]"/>
         <field name="user_ids" eval="[(6, 0, [ref('base.user_admin')])]"/>
     </record>
-    <record id="project_task_121" model="project.task" context="{'mail_auto_subscribe_no_notify': True}">
+    <record id="project_task_121" model="project.task">
         <field name="name">Events Module Backend</field>
         <field name="description"><![CDATA[<div data-oe-version="1.1">Creation of database structure and management tools for online events.</div><div><br></div><div><br></div>]]></field>
         <field name="project_id" ref="project_project_2"/>
@@ -34,7 +34,7 @@
         <field name="tag_ids" eval="[(6, 0, [ref('project_tags_21')])]"/>
         <field name="user_ids" eval="[(6, 0, [ref('base_industry_data.res_users_7')])]"/>
     </record>
-    <record id="project_task_120" model="project.task" context="{'mail_auto_subscribe_no_notify': True}">
+    <record id="project_task_120" model="project.task">
         <field name="name">User Authentication System</field>
         <field name="description"><![CDATA[<div data-oe-version="1.1">Development of secure login, registration, and user management functionality.</div><div><br></div>]]></field>
         <field name="project_id" ref="project_project_2"/>
@@ -42,7 +42,7 @@
         <field name="tag_ids" eval="[(6, 0, [ref('project_tags_21')])]"/>
         <field name="user_ids" eval="[(6, 0, [ref('base_industry_data.res_users_7')])]"/>
     </record>
-    <record id="project_task_119" model="project.task" context="{'mail_auto_subscribe_no_notify': True}">
+    <record id="project_task_119" model="project.task">
         <field name="name">E-Commerce System Integration</field>
         <field name="description"><![CDATA[<div data-oe-version="1.1">Implementation of product catalog, inventory management, and payment processing.</div><div><br></div>]]></field>
         <field name="project_id" ref="project_project_2"/>
@@ -50,7 +50,7 @@
         <field name="tag_ids" eval="[(6, 0, [ref('project_tags_21')])]"/>
         <field name="user_ids" eval="[(6, 0, [ref('base.user_admin')])]"/>
     </record>
-    <record id="project_task_118" model="project.task" context="{'mail_auto_subscribe_no_notify': True}">
+    <record id="project_task_118" model="project.task">
         <field name="name">CMS Implementation</field>
         <field name="description"><![CDATA[<div data-oe-version="1.1">Setup and configuration of content management system for client content updates.</div><div><br></div>]]></field>
         <field name="project_id" ref="project_project_2"/>
@@ -58,7 +58,7 @@
         <field name="tag_ids" eval="[(6, 0, [ref('project_tags_21')])]"/>
         <field name="user_ids" eval="[(6, 0, [ref('base.user_admin')])]"/>
     </record>
-    <record id="project_task_117" model="project.task" context="{'mail_auto_subscribe_no_notify': True}">
+    <record id="project_task_117" model="project.task">
         <field name="name">Cross-Browser Testing</field>
         <field name="description"><![CDATA[<div data-oe-version="1.1">Testing and optimization for compatibility across major browsers and devices.</div><div><br></div><div><br></div>]]></field>
         <field name="project_id" ref="project_project_2"/>
@@ -66,7 +66,7 @@
         <field name="tag_ids" eval="[(6, 0, [ref('project_tags_20')])]"/>
         <field name="user_ids" eval="[(6, 0, [ref('base_industry_data.res_users_7')])]"/>
     </record>
-    <record id="project_task_116" model="project.task" context="{'mail_auto_subscribe_no_notify': True}">
+    <record id="project_task_116" model="project.task">
         <field name="name">Form Validation</field>
         <field name="description"><![CDATA[<div data-oe-version="1.1">Implementation of user-friendly form validation for all interactive elements.</div><div><br></div>]]></field>
         <field name="project_id" ref="project_project_2"/>
@@ -74,7 +74,7 @@
         <field name="tag_ids" eval="[(6, 0, [ref('project_tags_20')])]"/>
         <field name="user_ids" eval="[(6, 0, [ref('base_industry_data.res_users_7')])]"/>
     </record>
-    <record id="project_task_115" model="project.task" context="{'mail_auto_subscribe_no_notify': True}">
+    <record id="project_task_115" model="project.task">
         <field name="name">JavaScript Interactions</field>
         <field name="description"><![CDATA[<div data-oe-version="1.1">Development of interactive elements, animations, and client-side functionality.</div><div><br></div>]]></field>
         <field name="project_id" ref="project_project_2"/>
@@ -82,7 +82,7 @@
         <field name="tag_ids" eval="[(6, 0, [ref('project_tags_20')])]"/>
         <field name="user_ids" eval="[(6, 0, [ref('base.user_admin')])]"/>
     </record>
-    <record id="project_task_114" model="project.task" context="{'mail_auto_subscribe_no_notify': True}">
+    <record id="project_task_114" model="project.task">
         <field name="name">HTML/CSS Structure Implementation</field>
         <field name="description"><![CDATA[<div data-oe-version="1.1">Coding of base templates and global elements according to design specifications.</div><div><br></div>]]></field>
         <field name="project_id" ref="project_project_2"/>
@@ -90,7 +90,7 @@
         <field name="tag_ids" eval="[(6, 0, [ref('project_tags_20')])]"/>
         <field name="user_ids" eval="[(6, 0, [ref('base.user_admin')])]"/>
     </record>
-    <record id="project_task_113" model="project.task" context="{'mail_auto_subscribe_no_notify': True}">
+    <record id="project_task_113" model="project.task">
         <field name="name">Responsive Design Adaptation</field>
         <field name="description"><![CDATA[<div data-oe-version="1.1">Adaptation of all designs for mobile, tablet, and desktop viewports.</div><div><br></div><div><br></div>]]></field>
         <field name="project_id" ref="project_project_2"/>
@@ -98,7 +98,7 @@
         <field name="tag_ids" eval="[(6, 0, [ref('project_tags_10')])]"/>
         <field name="user_ids" eval="[(6, 0, [ref('base_industry_data.res_users_7')])]"/>
     </record>
-    <record id="project_task_112" model="project.task" context="{'mail_auto_subscribe_no_notify': True}">
+    <record id="project_task_112" model="project.task">
         <field name="name">User Space Interface Design</field>
         <field name="description"><![CDATA[<div data-oe-version="1.1">Design of login, account dashboard, and user settings screens.</div><div><br></div>]]></field>
         <field name="project_id" ref="project_project_2"/>
@@ -106,7 +106,7 @@
         <field name="tag_ids" eval="[(6, 0, [ref('project_tags_10')])]"/>
         <field name="user_ids" eval="[(6, 0, [ref('base_industry_data.res_users_7')])]"/>
     </record>
-    <record id="project_task_111" model="project.task" context="{'mail_auto_subscribe_no_notify': True}">
+    <record id="project_task_111" model="project.task">
         <field name="name">E-Commerce UI Design </field>
         <field name="description"><![CDATA[<div data-oe-version="1.1">Design of product listings, product detail pages, cart, and checkout flow.</div><div><br></div>]]></field>
         <field name="project_id" ref="project_project_2"/>
@@ -114,7 +114,7 @@
         <field name="tag_ids" eval="[(6, 0, [ref('project_tags_10')])]"/>
         <field name="user_ids" eval="[(6, 0, [ref('base_industry_data.res_users_7')])]"/>
     </record>
-    <record id="project_task_110" model="project.task" context="{'mail_auto_subscribe_no_notify': True}">
+    <record id="project_task_110" model="project.task">
         <field name="name">Content Page Templates</field>
         <field name="description"><![CDATA[<div data-oe-version="1.1">Design of reusable page templates for about, services, contact, and other informational pages.</div><div><br></div>]]></field>
         <field name="project_id" ref="project_project_2"/>
@@ -122,7 +122,7 @@
         <field name="tag_ids" eval="[(6, 0, [ref('project_tags_10')])]"/>
         <field name="user_ids" eval="[(6, 0, [ref('base.user_admin')])]"/>
     </record>
-    <record id="project_task_109" model="project.task" context="{'mail_auto_subscribe_no_notify': True}">
+    <record id="project_task_109" model="project.task">
         <field name="name">Homepage Design</field>
         <field name="description"><![CDATA[<div data-oe-version="1.1">Creation of high-fidelity mockup for homepage incorporating brand elements and key messaging.</div><div><br></div>]]></field>
         <field name="project_id" ref="project_project_2"/>
@@ -130,7 +130,7 @@
         <field name="tag_ids" eval="[(6, 0, [ref('project_tags_10')])]"/>
         <field name="user_ids" eval="[(6, 0, [ref('base_industry_data.res_users_7')])]"/>
     </record>
-    <record id="project_task_108" model="project.task" context="{'mail_auto_subscribe_no_notify': True}">
+    <record id="project_task_108" model="project.task">
         <field name="name">UX Wireframing</field>
         <field name="description"><![CDATA[<div data-oe-version="1.1">Development of low-fidelity wireframes to establish layout structure and content hierarchy.</div><div><br></div><div><br></div>]]></field>
         <field name="project_id" ref="project_project_2"/>
@@ -138,7 +138,7 @@
         <field name="tag_ids" eval="[(6, 0, [ref('project_tags_3')])]"/>
         <field name="user_ids" eval="[(6, 0, [ref('base.user_admin')])]"/>
     </record>
-    <record id="project_task_107" model="project.task" context="{'mail_auto_subscribe_no_notify': True}">
+    <record id="project_task_107" model="project.task">
         <field name="name">Brand Analysis &amp; Mood Board</field>
         <field name="description"><![CDATA[<div data-oe-version="1.1">Creation of visual direction reference including color, typography, imagery style, and UI elements.</div><div><br></div>]]></field>
         <field name="project_id" ref="project_project_2"/>
@@ -146,7 +146,7 @@
         <field name="tag_ids" eval="[(6, 0, [ref('project_tags_3')])]"/>
         <field name="user_ids" eval="[(6, 0, [ref('base_industry_data.res_users_7')])]"/>
     </record>
-    <record id="project_task_106" model="project.task" context="{'mail_auto_subscribe_no_notify': True}">
+    <record id="project_task_106" model="project.task">
         <field name="name">Technical Specifications</field>
         <field name="description"><![CDATA[<div data-oe-version="1.1">Documentation of technical requirements, including hosting, CMS, integrations, and security needs.</div>]]></field>
         <field name="priority">1</field>
@@ -155,7 +155,7 @@
         <field name="tag_ids" eval="[(6, 0, [ref('project_tags_18')])]"/>
         <field name="user_ids" eval="[(6, 0, [ref('base_industry_data.res_users_7')])]"/>
     </record>
-    <record id="project_task_123" model="project.task" context="{'mail_auto_subscribe_no_notify': True}">
+    <record id="project_task_123" model="project.task">
         <field name="name">User Acceptance Testing &amp; Launch</field>
         <field name="description"><![CDATA[<div data-oe-version="1.1">Comprehensive testing with client stakeholders and preparation for site launch.</div><div><br></div>]]></field>
         <field name="project_id" ref="project_project_2"/>
@@ -165,7 +165,7 @@
         <field name="state">04_waiting_normal</field>
         <field name="user_ids" eval="[(6, 0, [ref('base_industry_data.res_users_7')])]"/>
     </record>
-    <record id="project_task_21" model="project.task" context="{'mail_auto_subscribe_no_notify': True}">
+    <record id="project_task_21" model="project.task">
         <field name="name">Presentation to Client</field>
         <field name="description"><![CDATA[<div data-oe-version="1.1">Final presentation of complete brand identity system to client stakeholders.</div><div><br></div>]]></field>
         <field name="sequence" eval="False"/>
@@ -175,7 +175,7 @@
         <field name="user_ids" eval="[(6, 0, [ref('base.user_admin')])]"/>
         <field name="color">3</field>
     </record>
-    <record id="project_task_11" model="project.task" context="{'mail_auto_subscribe_no_notify': True}">
+    <record id="project_task_11" model="project.task">
         <field name="name">Logo Concepts Development</field>
         <field name="description"><![CDATA[<div data-oe-version="1.1">Creation of three distinct logo concepts aligned with brand strategy for client review.</div><div><br></div>]]></field>
         <field name="sequence">1</field>
@@ -185,7 +185,7 @@
         <field name="user_ids" eval="[(6, 0, [ref('base.user_admin')])]"/>
         <field name="color">4</field>
     </record>
-    <record id="project_task_12" model="project.task" context="{'mail_auto_subscribe_no_notify': True}">
+    <record id="project_task_12" model="project.task">
         <field name="name">Logo Refinement</field>
         <field name="description"><![CDATA[<div data-oe-version="1.1">Refinement of selected logo concept through two revision rounds based on client feedback.</div><div><br></div>]]></field>
         <field name="sequence">2</field>
@@ -195,7 +195,7 @@
         <field name="user_ids" eval="[(6, 0, [ref('base.user_admin')])]"/>
         <field name="color">4</field>
     </record>
-    <record id="project_task_14" model="project.task" context="{'mail_auto_subscribe_no_notify': True}">
+    <record id="project_task_14" model="project.task">
         <field name="name">Typography Selection</field>
         <field name="description"><![CDATA[<div data-oe-version="1.1">Identification of primary and secondary typefaces that enhance brand character and ensure readability.</div><div><br></div>]]></field>
         <field name="project_id" ref="project_project_3"/>
@@ -204,7 +204,7 @@
         <field name="user_ids" eval="[(6, 0, [ref('base_industry_data.res_users_7')])]"/>
         <field name="color">4</field>
     </record>
-    <record id="project_task_13" model="project.task" context="{'mail_auto_subscribe_no_notify': True}">
+    <record id="project_task_13" model="project.task">
         <field name="name">Color Palette Development</field>
         <field name="description"><![CDATA[<div data-oe-version="1.1">Selection and testing of primary and secondary color schemes that support brand identity.</div><div><br></div>]]></field>
         <field name="project_id" ref="project_project_3"/>
@@ -213,7 +213,7 @@
         <field name="user_ids" eval="[(6, 0, [ref('base_industry_data.res_users_7')])]"/>
         <field name="color">4</field>
     </record>
-    <record id="project_task_15" model="project.task" context="{'mail_auto_subscribe_no_notify': True}">
+    <record id="project_task_15" model="project.task">
         <field name="name">Create Brand Elements &amp; Patterns</field>
         <field name="description"><![CDATA[<div data-oe-version="1.1">Design of supporting visual elements, icons, and patterns for extended brand expression.</div><div><br></div><div><br></div>]]></field>
         <field name="sequence" eval="False"/>
@@ -223,7 +223,7 @@
         <field name="user_ids" eval="[(6, 0, [ref('base.user_admin')])]"/>
         <field name="color">4</field>
     </record>
-    <record id="project_task_23" model="project.task" context="{'mail_auto_subscribe_no_notify': True}">
+    <record id="project_task_23" model="project.task">
         <field name="name">Delivery of All Assets</field>
         <field name="description"><![CDATA[<div data-oe-version="1.1">Handover of all brand assets, files, and documentation to client in organized package.</div><div><br></div>]]></field>
         <field name="project_id" ref="project_project_3"/>
@@ -234,7 +234,7 @@
         <field name="user_ids" eval="[(6, 0, [ref('base.user_admin')])]"/>
         <field name="color">3</field>
     </record>
-    <record id="project_task_8" model="project.task" context="{'mail_auto_subscribe_no_notify': True}">
+    <record id="project_task_8" model="project.task">
         <field name="name">Define Brand Strategy</field>
         <field name="description"><![CDATA[<div data-oe-version="1.1">Development of core strategic framework including mission, vision, values, and brand personality.</div>]]></field>
         <field name="sequence" eval="False"/>
@@ -244,7 +244,7 @@
         <field name="user_ids" eval="[(6, 0, [ref('base.user_admin')])]"/>
         <field name="color">3</field>
     </record>
-    <record id="project_task_84" model="project.task" context="{'mail_auto_subscribe_no_notify': True}">
+    <record id="project_task_84" model="project.task">
         <field name="name">Trend Monitoring &amp; Implementation</field>
         <field name="project_id" ref="project_project_4"/>
         <field name="stage_id" ref="project_task_type_31"/>
@@ -252,7 +252,7 @@
         <field name="user_ids" eval="[(6, 0, [ref('base_industry_data.res_users_7')])]"/>
         <field name="color">3</field>
     </record>
-    <record id="project_task_83" model="project.task" context="{'mail_auto_subscribe_no_notify': True}">
+    <record id="project_task_83" model="project.task">
         <field name="name">Performance Analytics Review</field>
         <field name="project_id" ref="project_project_4"/>
         <field name="stage_id" ref="project_task_type_31"/>
@@ -261,7 +261,7 @@
         <field name="color">10</field>
         <field name="recurring_task" eval="True"/>
     </record>
-    <record id="project_task_82" model="project.task" context="{'mail_auto_subscribe_no_notify': True}">
+    <record id="project_task_82" model="project.task">
         <field name="name">Community Engagement &amp; Monitoring</field>
         <field name="project_id" ref="project_project_4"/>
         <field name="stage_id" ref="project_task_type_31"/>
@@ -270,7 +270,7 @@
         <field name="color">10</field>
         <field name="recurring_task" eval="True"/>
     </record>
-    <record id="project_task_81" model="project.task" context="{'mail_auto_subscribe_no_notify': True}">
+    <record id="project_task_81" model="project.task">
         <field name="name">Content Creation &amp; Scheduling</field>
         <field name="project_id" ref="project_project_4"/>
         <field name="stage_id" ref="project_task_type_31"/>
@@ -279,7 +279,7 @@
         <field name="color">10</field>
         <field name="recurring_task" eval="True"/>
     </record>
-    <record id="project_task_80" model="project.task" context="{'mail_auto_subscribe_no_notify': True}">
+    <record id="project_task_80" model="project.task">
         <field name="name">Content Calendar Development</field>
         <field name="project_id" ref="project_project_4"/>
         <field name="stage_id" ref="project_task_type_31"/>
@@ -288,7 +288,7 @@
         <field name="color">1</field>
         <field name="recurring_task" eval="True"/>
     </record>
-    <record id="project_task_22" model="project.task" context="{'mail_auto_subscribe_no_notify': True}">
+    <record id="project_task_22" model="project.task">
         <field name="name">Final Revisions</field>
         <field name="description"><![CDATA[<div data-oe-version="1.1">Implementation of final adjustments based on client feedback.</div><div><br></div>]]></field>
         <field name="project_id" ref="project_project_3"/>
@@ -297,7 +297,7 @@
         <field name="user_ids" eval="[(6, 0, [ref('base_industry_data.res_users_7')])]"/>
         <field name="color">1</field>
     </record>
-    <record id="project_task_19" model="project.task" context="{'mail_auto_subscribe_no_notify': True}">
+    <record id="project_task_19" model="project.task">
         <field name="name">Develop Brand Guidelines Document</field>
         <field name="description"><![CDATA[<div data-oe-version="1.1">Comprehensive guide detailing proper usage of all brand elements for consistent application.</div><div><br></div>]]></field>
         <field name="project_id" ref="project_project_3"/>
@@ -308,7 +308,7 @@
         <field name="user_ids" eval="[(6, 0, [ref('base_industry_data.res_users_7')])]"/>
         <field name="color">6</field>
     </record>
-    <record id="project_task_20" model="project.task" context="{'mail_auto_subscribe_no_notify': True}">
+    <record id="project_task_20" model="project.task">
         <field name="name">Export Final Files in Multiple Formats</field>
         <field name="description"><![CDATA[<div data-oe-version="1.1">Preparation of all design assets in various file formats (AI, EPS, JPG, PNG) for different use cases.</div><div><br></div>]]></field>
         <field name="project_id" ref="project_project_3"/>
@@ -317,7 +317,7 @@
         <field name="user_ids" eval="[(6, 0, [ref('base_industry_data.res_users_7')])]"/>
         <field name="color">3</field>
     </record>
-    <record id="project_task_18" model="project.task" context="{'mail_auto_subscribe_no_notify': True}">
+    <record id="project_task_18" model="project.task">
         <field name="name">Create Social Media Templates</field>
         <field name="description"><![CDATA[<div data-oe-version="1.1">Design of customized templates for consistent branding across social media platforms.</div><div><br></div><div><br></div>]]></field>
         <field name="project_id" ref="project_project_3"/>
@@ -326,7 +326,7 @@
         <field name="user_ids" eval="[(6, 0, [ref('base_industry_data.res_users_7')])]"/>
         <field name="color">5</field>
     </record>
-    <record id="project_task_17" model="project.task" context="{'mail_auto_subscribe_no_notify': True}">
+    <record id="project_task_17" model="project.task">
         <field name="name">Design Letterhead &amp; Stationery</field>
         <field name="description"><![CDATA[<div data-oe-version="1.1">Development of letterhead, envelopes, and stationery applying the new brand identity.</div><div><br></div>]]></field>
         <field name="project_id" ref="project_project_3"/>
@@ -335,7 +335,7 @@
         <field name="user_ids" eval="[(6, 0, [ref('base_industry_data.res_users_7')])]"/>
         <field name="color">5</field>
     </record>
-    <record id="project_task_16" model="project.task" context="{'mail_auto_subscribe_no_notify': True}">
+    <record id="project_task_16" model="project.task">
         <field name="name">Design Business Cards</field>
         <field name="description"><![CDATA[<div data-oe-version="1.1">Creation of business card designs applying the new brand identity.</div><div><br></div>]]></field>
         <field name="project_id" ref="project_project_3"/>
@@ -344,7 +344,7 @@
         <field name="user_ids" eval="[(6, 0, [ref('base_industry_data.res_users_7')])]"/>
         <field name="color">5</field>
     </record>
-    <record id="project_task_10" model="project.task" context="{'mail_auto_subscribe_no_notify': True}">
+    <record id="project_task_10" model="project.task">
         <field name="name">Create Brand Messaging Framework</field>
         <field name="description"><![CDATA[<div data-oe-version="1.1">Development of tone of voice, key messages, and communication guidelines.</div>]]></field>
         <field name="project_id" ref="project_project_3"/>
@@ -354,7 +354,7 @@
         <field name="user_ids" eval="[(6, 0, [ref('base_industry_data.res_users_7')])]"/>
         <field name="color">3</field>
     </record>
-    <record id="project_task_9" model="project.task" context="{'mail_auto_subscribe_no_notify': True}">
+    <record id="project_task_9" model="project.task">
         <field name="name">Develop Brand Positioning</field>
         <field name="description"><![CDATA[<div data-oe-version="1.1">Creation of unique market positioning that differentiates from competitors and resonates with target audience.</div>]]></field>
         <field name="project_id" ref="project_project_3"/>
@@ -362,7 +362,7 @@
         <field name="tag_ids" eval="[(6, 0, [ref('project_tags_9')])]"/>
         <field name="color">3</field>
     </record>
-    <record id="project_task_7" model="project.task" context="{'mail_auto_subscribe_no_notify': True}">
+    <record id="project_task_7" model="project.task">
         <field name="name">Competitive Analysis</field>
         <field name="description"><![CDATA[<div data-oe-version="1.1">Review of competitors' branding strategies to identify differentiation opportunities.</div>]]></field>
         <field name="project_id" ref="project_project_3"/>
@@ -371,7 +371,7 @@
         <field name="user_ids" eval="[(6, 0, [ref('base_industry_data.res_users_7')])]"/>
         <field name="color">11</field>
     </record>
-    <record id="project_task_6" model="project.task" context="{'mail_auto_subscribe_no_notify': True}">
+    <record id="project_task_6" model="project.task">
         <field name="name">Market Research</field>
         <field name="description"><![CDATA[<div data-oe-version="1.1">Analysis of industry trends, target audience preferences, and market positioning opportunities.</div>]]></field>
         <field name="project_id" ref="project_project_3"/>
@@ -380,7 +380,7 @@
         <field name="user_ids" eval="[(6, 0, [ref('base_industry_data.res_users_7')])]"/>
         <field name="color">11</field>
     </record>
-    <record id="project_task_5" model="project.task" context="{'mail_auto_subscribe_no_notify': True}">
+    <record id="project_task_5" model="project.task">
         <field name="name">Brand Audit &amp; Analysis</field>
         <field name="description"><![CDATA[<div data-oe-version="1.1">Evaluation of current brand assets, positioning, and performance to identify strengths and opportunities.</div>]]></field>
         <field name="project_id" ref="project_project_3"/>
@@ -389,7 +389,7 @@
         <field name="user_ids" eval="[(6, 0, [ref('base_industry_data.res_users_7')])]"/>
         <field name="color">11</field>
     </record>
-    <record id="project_task_4" model="project.task" context="{'mail_auto_subscribe_no_notify': True}">
+    <record id="project_task_4" model="project.task">
         <field name="name">Initial Client Consultation</field>
         <field name="description"><![CDATA[<div data-oe-version="1.1">Kickoff meeting to understand client's vision, goals, and expectations for the rebranding initiative.</div>]]></field>
         <field name="project_id" ref="project_project_3"/>

--- a/marketing_agency/demo/sale_order.xml
+++ b/marketing_agency/demo/sale_order.xml
@@ -1,75 +1,75 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
-    <record id="sale_order_15" model="sale.order" context="{'mail_auto_subscribe_no_notify': True}">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
+    <record id="sale_order_15" model="sale.order">
         <field name="partner_id" ref="base_industry_data.res_partner_21"/>
         <field name="sale_order_template_id" ref="sale_order_template_2"/>
         <field name="user_id" ref="base.user_admin"/>
     </record>
-    <record id="sale_order_13" model="sale.order" context="{'mail_auto_subscribe_no_notify': True}">
+    <record id="sale_order_13" model="sale.order">
         <field name="partner_id" ref="base_industry_data.res_partner_31"/>
         <field name="sale_order_template_id" ref="sale_order_template_4"/>
         <field name="user_id" ref="base.user_admin"/>
     </record>
-    <record id="sale_order_12" model="sale.order" context="{'mail_auto_subscribe_no_notify': True}">
+    <record id="sale_order_12" model="sale.order">
         <field name="partner_id" ref="base_industry_data.res_partner_27"/>
         <field name="sale_order_template_id" ref="sale_order_template_4"/>
         <field name="user_id" ref="base.user_admin"/>
         <field name="plan_id" ref="sale_subscription.subscription_plan_year"/>
     </record>
-    <record id="sale_order_9" model="sale.order" context="{'mail_auto_subscribe_no_notify': True}">
+    <record id="sale_order_9" model="sale.order">
         <field name="partner_id" ref="base_industry_data.res_partner_21"/>
         <field name="user_id" ref="base.user_admin"/>
         <field name="plan_id" ref="sale_subscription.subscription_plan_year"/>
     </record>
-    <record id="sale_order_6" model="sale.order" context="{'mail_auto_subscribe_no_notify': True}">
+    <record id="sale_order_6" model="sale.order">
         <field name="partner_id" ref="base_industry_data.res_partner_34"/>
         <field name="sale_order_template_id" ref="sale_order_template_3"/>
         <field name="user_id" ref="base.user_admin"/>
         <field name="plan_id" ref="sale_subscription.subscription_plan_year"/>
     </record>
-    <record id="sale_order_4" model="sale.order" context="{'mail_auto_subscribe_no_notify': True}">
+    <record id="sale_order_4" model="sale.order">
         <field name="partner_id" ref="base_industry_data.res_partner_34"/>
         <field name="sale_order_template_id" ref="sale_order_template_3"/>
         <field name="user_id" ref="base.user_admin"/>
         <field name="plan_id" ref="sale_subscription.subscription_plan_month"/>
     </record>
-    <record id="sale_order_3" model="sale.order" context="{'mail_auto_subscribe_no_notify': True}">
+    <record id="sale_order_3" model="sale.order">
         <field name="partner_id" ref="base_industry_data.res_partner_22"/>
         <field name="sale_order_template_id" ref="sale_order_template_3"/>
         <field name="user_id" ref="base.user_admin"/>
         <field name="plan_id" ref="sale_subscription.subscription_plan_month"/>
     </record>
-    <record id="sale_order_2" model="sale.order" context="{'mail_auto_subscribe_no_notify': True}">
+    <record id="sale_order_2" model="sale.order">
         <field name="partner_id" ref="base_industry_data.res_partner_24"/>
         <field name="sale_order_template_id" ref="sale_order_template_1"/>
         <field name="user_id" ref="base.user_admin"/>
         <field name="tag_ids" eval="[(6, 0, [ref('crm_tag_8'), ref('crm_tag_10')])]"/>
         <field name="opportunity_id" ref="crm_lead_4"/>
     </record>
-    <record id="sale_order_11" model="sale.order" context="{'mail_auto_subscribe_no_notify': True}">
+    <record id="sale_order_11" model="sale.order">
         <field name="partner_id" ref="base_industry_data.res_partner_35"/>
         <field name="user_id" ref="base.user_admin"/>
         <field name="plan_id" ref="sale_subscription.subscription_plan_year"/>
     </record>
-    <record id="sale_order_10" model="sale.order" context="{'mail_auto_subscribe_no_notify': True}">
+    <record id="sale_order_10" model="sale.order">
         <field name="partner_id" ref="base_industry_data.res_partner_28"/>
         <field name="user_id" ref="base.user_admin"/>
         <field name="opportunity_id" ref="crm_lead_3"/>
         <field name="state" eval="'sent'"/>
         <field name="tag_ids" eval="[(6, 0, [ref('crm_tag_2'), ref('crm_tag_16')])]"/>
     </record>
-    <record id="sale_order_8" model="sale.order" context="{'mail_auto_subscribe_no_notify': True}">
+    <record id="sale_order_8" model="sale.order">
         <field name="partner_id" ref="base_industry_data.res_partner_23"/>
         <field name="user_id" ref="base.user_admin"/>
         <field name="plan_id" ref="sale_subscription.subscription_plan_year"/>
         <field name="state">cancel</field>
     </record>
-    <record id="sale_order_7" model="sale.order" context="{'mail_auto_subscribe_no_notify': True}">
+    <record id="sale_order_7" model="sale.order">
         <field name="partner_id" ref="base_industry_data.res_partner_31"/>
         <field name="user_id" ref="base.user_admin"/>
         <field name="sale_order_template_id" ref="sale_order_template_1"/>
     </record>
-    <record id="sale_order_5" model="sale.order" context="{'mail_auto_subscribe_no_notify': True}">
+    <record id="sale_order_5" model="sale.order">
         <field name="partner_id" ref="base_industry_data.res_partner_25"/>
         <field name="user_id" ref="base.user_admin"/>
         <field name="opportunity_id" ref="crm_lead_7"/>

--- a/marketing_agency/demo/sale_order_confirm.xml
+++ b/marketing_agency/demo/sale_order_confirm.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True, 'mail_notrack': True, 'mail_activity_quick_update': True}">
     <function model="sale.order" name="action_confirm" eval="[[ref('sale_order_15'),ref('sale_order_13'),ref('sale_order_12'),ref('sale_order_9'),ref('sale_order_6'),ref('sale_order_4'),ref('sale_order_3'),ref('sale_order_2')]]"/>
     <function name="_create_invoices" model="sale.order" eval="[[ref('sale_order_12'),ref('sale_order_9'),ref('sale_order_6'),ref('sale_order_4'),ref('sale_order_3')]]"/>
     <function model="project.project" name="write">
@@ -194,48 +194,48 @@
         <value model="project.task" search="[('sale_order_id', '=', ref('sale_order_13')), ('tag_ids', 'in', [ref('project_tags_33')])]"/>
         <value eval="{'stage_id': ref('project_task_type_32'), 'state': '03_approved'}"/>
     </function>
-    <record id="mail_activity_19" model="mail.activity" context="{'mail_activity_quick_update': True}">
+    <record id="mail_activity_19" model="mail.activity">
         <field name="res_model_id" ref="project.model_project_task"/>
         <field name="res_id" model="project.task" search="[('sale_line_id', '=', ref('sale_order_line_55')), ('tag_ids', 'in', [ref('project_tags_26')])]"/>
         <field name="activity_type_id" ref="mail.mail_activity_data_todo"/>
         <field name="date_deadline" eval="(DateTime.today() + relativedelta(days=7)).strftime('%Y-%m-%d %H:%M')"/>
         <field name="user_id" ref="base.user_admin"/>
     </record>
-    <record id="mail_activity_9" model="mail.activity" context="{'mail_activity_quick_update': True}">
+    <record id="mail_activity_9" model="mail.activity">
         <field name="res_model_id" ref="project.model_project_task"/>
         <field name="res_id" model="project.task" search="[('sale_line_id', '=', ref('sale_order_line_5')), ('tag_ids', 'in', [ref('project_tags_25')])]"/>
         <field name="activity_type_id" ref="mail.mail_activity_data_call"/>
         <field name="date_deadline" eval="(DateTime.today() + relativedelta(days=11)).strftime('%Y-%m-%d %H:%M')"/>
         <field name="user_id" ref="base.user_admin"/>
     </record>
-    <record id="mail_activity_13" model="mail.activity" context="{'mail_activity_quick_update': True}">
+    <record id="mail_activity_13" model="mail.activity">
         <field name="res_model_id" ref="project.model_project_task"/>
         <field name="res_id" model="project.task" search="[('sale_line_id', '=', ref('sale_order_line_5')), ('tag_ids', 'in', [ref('project_tags_9')]), ('user_ids', 'in', [ref('base.user_admin')])]"/>
         <field name="activity_type_id" ref="mail.mail_activity_data_call"/>
         <field name="user_id" ref="base.user_admin"/>
     </record>
-    <record id="mail_activity_20" model="mail.activity" context="{'mail_activity_quick_update': True}">
+    <record id="mail_activity_20" model="mail.activity">
         <field name="res_model_id" ref="project.model_project_task"/>
         <field name="res_id" model="project.task" search="[('sale_line_id', '=', ref('sale_order_line_55')), ('tag_ids', 'in', [ref('project_tags_10')]), ('user_ids', 'in', [ref('base.user_admin')])]"/>
         <field name="activity_type_id" ref="mail.mail_activity_data_call"/>
         <field name="date_deadline" eval="(DateTime.today() + relativedelta(days=-7)).strftime('%Y-%m-%d %H:%M')"/>
         <field name="user_id" ref="base.user_admin"/>
     </record>
-    <record id="mail_activity_10" model="mail.activity" context="{'mail_activity_quick_update': True}">
+    <record id="mail_activity_10" model="mail.activity">
         <field name="res_model_id" ref="project.model_project_task"/>
         <field name="res_id" model="project.task" search="[('sale_line_id', '=', ref('sale_order_line_5')), ('tag_ids', 'in', [ref('project_tags_14')])]"/>
         <field name="activity_type_id" ref="mail.mail_activity_data_todo"/>
         <field name="date_deadline" eval="(DateTime.today() + relativedelta(days=-8)).strftime('%Y-%m-%d %H:%M')"/>
         <field name="user_id" ref="base.user_admin"/>
     </record>
-    <record id="mail_activity_12" model="mail.activity" context="{'mail_activity_quick_update': True}">
+    <record id="mail_activity_12" model="mail.activity">
         <field name="res_model_id" ref="project.model_project_task"/>
         <field name="res_id" model="project.task" search="[('sale_line_id', '=', ref('sale_order_line_5')), ('tag_ids', 'in', [ref('project_tags_14')])]"/>
         <field name="activity_type_id" ref="mail.mail_activity_data_call"/>
         <field name="date_deadline" eval="(DateTime.today()).strftime('%Y-%m-%d %H:%M')"/>
         <field name="user_id" ref="base.user_admin"/>
     </record>
-    <record id="mail_activity_11" model="mail.activity" context="{'mail_activity_quick_update': True}">
+    <record id="mail_activity_11" model="mail.activity">
         <field name="res_model_id" ref="project.model_project_task"/>
         <field name="res_id" model="project.task" search="[('sale_line_id', '=', ref('sale_order_line_5')), ('tag_ids', 'in', [ref('project_tags_24')])]"/>
         <field name="activity_type_id" ref="mail.mail_activity_data_email"/>

--- a/marketing_agency/demo/sale_order_line.xml
+++ b/marketing_agency/demo/sale_order_line.xml
@@ -105,6 +105,7 @@
     <record id="sale_order_line_22" model="sale.order.line">
         <field name="order_id" ref="sale_order_6"/>
         <field name="product_id" ref="product_product_10"/>
+        <field name="product_uom_qty">8.0</field>
     </record>
     <record id="sale_order_line_23" model="sale.order.line">
         <field name="order_id" ref="sale_order_6"/>

--- a/members_club/demo/crm_lead.xml
+++ b/members_club/demo/crm_lead.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
   <record id="crm_lead_1" model="crm.lead">
     <field name="partner_id" ref="base_industry_data.res_partner_26"/>
     <field name="name">Coporate Membership Fifth</field>

--- a/members_club/demo/event_event.xml
+++ b/members_club/demo/event_event.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
     <record id="event_event_1" model="event.event">
         <field name="cover_properties"><![CDATA[{"background-image":"url('/members_club/static/src/binary/ir_attachment/1195-speaker.jpg')","background_color_class":"o_cc3 o_cc","opacity":"0.2","resize_class":"o_half_screen_height o_record_has_cover"}]]></field>
         <field name="name">Fireside Chat with Isla Kendrew</field>

--- a/members_club/demo/sale_order.xml
+++ b/members_club/demo/sale_order.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
   <record id="sale_order_20" model="sale.order">
     <field name="partner_id" ref="base_industry_data.res_partner_29"/>
     <field name="user_id" ref="base.user_admin"/>

--- a/members_club/demo/sale_order_confirm.xml
+++ b/members_club/demo/sale_order_confirm.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True, 'mail_notrack': True}">
   <function model="sale.order" name="action_confirm">
     <value eval="[ref('sale_order_20'),ref('sale_order_19'),ref('sale_order_6'),ref('sale_order_5'),ref('sale_order_4'),ref('sale_order_3'),ref('sale_order_2')]"/>
   </function>

--- a/mental_therapy/__manifest__.py
+++ b/mental_therapy/__manifest__.py
@@ -27,7 +27,6 @@
         'demo/res_partner.xml',
         'demo/crm_lead.xml',
         'demo/calendar_event.xml',
-        'demo/res_users.xml',
         'demo/account_move.xml',
         'demo/account_move_line.xml',
         'demo/account_move_post.xml',

--- a/mental_therapy/demo/calendar_event.xml
+++ b/mental_therapy/demo/calendar_event.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
-  <record id="calendar_event_2" model="calendar.event" context="{'no_mail_to_attendees': True}">
+<odoo noupdate="1" context="{'no_mail_to_attendees': True}">
+  <record id="calendar_event_2" model="calendar.event">
     <field name="name">Olivia Ramirez - Therapy Session Booking</field>
     <field name="location">Mental Therapy, 1160, Belgium</field>
     <field name="appointment_type_id" ref="appointment_type_1"/>
@@ -19,7 +19,7 @@
     <field name="appointment_invite_id" ref="appointment_invite_therapy_session"/>
     <field name="opportunity_id" ref="crm_lead_13"/>
   </record>
-  <record id="calendar_event_3" model="calendar.event" context="{'no_mail_to_attendees': True}">
+  <record id="calendar_event_3" model="calendar.event">
     <field name="partner_ids" eval="[(6, 0, [ref('res_partner_15'), ref('base.partner_admin')])]"/>
     <field name="name">Therapy Session</field>
     <field name="duration">1.0</field>

--- a/mental_therapy/demo/res_users.xml
+++ b/mental_therapy/demo/res_users.xml
@@ -1,6 +1,0 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
-    <record id="base.user_admin" model="res.users" forcecreate="0">
-        <field name="notification_type">inbox</field>
-    </record>
-</odoo>

--- a/metal_fabricator/demo/sale_order.xml
+++ b/metal_fabricator/demo/sale_order.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
   <record id="sale_order_1" model="sale.order">
     <field name="partner_id" ref="base_industry_data.res_partner_30"/>
     <field name="sale_order_template_id" ref="sale_order_template_1"/>

--- a/metal_fabricator/demo/sale_order_confirm.xml
+++ b/metal_fabricator/demo/sale_order_confirm.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
   <function model="sale.order" name="action_confirm" eval="[[ref('sale_order_2'), ref('sale_order_1')]]"/>
 
   <record id="sale_advance_payment_inv_1" model="sale.advance.payment.inv">

--- a/micro_brewery/demo/crm_lead.xml
+++ b/micro_brewery/demo/crm_lead.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
     <record id="crm_lead_1" model="crm.lead">
         <field name="name">The Tipsy Teapot's opportunity</field>
         <field name="user_id" ref="base.user_admin"/>

--- a/micro_brewery/demo/purchase_order.xml
+++ b/micro_brewery/demo/purchase_order.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
     <record id="purchase_order_1" model="purchase.order">
         <field name="partner_id" ref="res_partner_8"/>
         <field name="user_id" ref="base.user_admin"/>

--- a/micro_brewery/demo/sale_order.xml
+++ b/micro_brewery/demo/sale_order.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
     <record id="sale_order_1" model="sale.order">
         <field name="partner_id" ref="res_partner_17"/>
         <field name="opportunity_id" ref="crm_lead_8"/>

--- a/museum/__manifest__.py
+++ b/museum/__manifest__.py
@@ -41,7 +41,6 @@
         'data/hr_job.xml',
     ],
     'demo': [
-        'demo/res_users.xml',
         'demo/event_event.xml',
         'demo/event_question.xml',
         'demo/event_slot.xml',

--- a/museum/demo/event_event.xml
+++ b/museum/demo/event_event.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
     <record id="event_event_4" model="event.event">
         <field name="name">Museum entry</field>
         <field name="cover_properties"><![CDATA[{"background-image":"url('/web/image/museum.ir_attachment_1595')","background_color_class":"o_cc3 o_cc","opacity":"0.4","resize_class":"o_half_screen_height o_record_has_cover"}]]></field>

--- a/museum/demo/res_users.xml
+++ b/museum/demo/res_users.xml
@@ -1,6 +1,0 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
-    <record id="base.user_admin" model="res.users" forcecreate="0">
-        <field name="notification_type">inbox</field>
-    </record>
-</odoo>

--- a/museum/demo/sale_order.xml
+++ b/museum/demo/sale_order.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
     <record id="sale_order_1" model="sale.order">
         <field name="partner_id" ref="res_partner_11" />
         <field name="user_id" ref="base.user_admin" />

--- a/night_clubs/demo/event_event.xml
+++ b/night_clubs/demo/event_event.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
     <record id="event_event_1" model="event.event">
         <field name="cover_properties">
             <![CDATA[{"background-image":"url('/web/image/night_clubs.ir_attachment_1138')","resize_class":"cover_auto o_record_has_cover","text_align_class":"","opacity":"0.4","background_color_class":"o_cc o_cc3"}]]>

--- a/night_clubs/demo/purchase_order.xml
+++ b/night_clubs/demo/purchase_order.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
     <record id="purchase_order_2" model="purchase.order">
         <field name="user_id" ref="base.user_admin"/>
         <field name="partner_id" ref="res_partner_28" />

--- a/night_clubs/demo/sale_order.xml
+++ b/night_clubs/demo/sale_order.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
     <record id="sale_order_1" model="sale.order">
         <field name="partner_id" ref="base.partner_admin" />
         <field name="user_id" ref="base.user_admin" />

--- a/non_profit_organization/demo/crm_lead.xml
+++ b/non_profit_organization/demo/crm_lead.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
     <record id="crm_lead_10" model="crm.lead">
         <field name="partner_id" ref="res_partner_29"/>
         <field name="name">Théo Mercier's opportunity</field>

--- a/non_profit_organization/demo/event_event.xml
+++ b/non_profit_organization/demo/event_event.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
     <record id="event_event_1" model="event.event">
         <field name="name">Clean River Day</field>
         <field name="stage_id" ref="event.event_stage_new"/>

--- a/non_profit_organization/demo/mail_activity.xml
+++ b/non_profit_organization/demo/mail_activity.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_activity_quick_update': True}">
     <record id="mail_activity_1" model="mail.activity">
         <field name="res_model_id" ref="project.model_project_task"/>
         <field name="date_deadline" eval="DateTime.today() + relativedelta(days=1)"/>

--- a/non_profit_organization/demo/mailing_mailing.xml
+++ b/non_profit_organization/demo/mailing_mailing.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
     <record id="mailing_mailing_1" model="mailing.mailing">
         <field name="subject">Partnership Update: Join Us on Our Upcoming Community Projects 🌍</field>
         <field name="user_id" ref="base.user_admin"/>

--- a/non_profit_organization/demo/project_project.xml
+++ b/non_profit_organization/demo/project_project.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
     <record id="project_project_1" model="project.project">
         <field name="name">Stop Child Labor Now</field>
         <field name="type_ids"

--- a/non_profit_organization/demo/project_task.xml
+++ b/non_profit_organization/demo/project_task.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
     <record id="project_task_1" model="project.task">
         <field name="name">Define campaign objectives &amp; partners</field>
         <field name="tag_ids" eval="[(6, 0, [ref('project_tags_4')])]"/>

--- a/non_profit_organization/demo/res_partner.xml
+++ b/non_profit_organization/demo/res_partner.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
     <record id="res_partner_13" model="res.partner">
         <field name="image_1920" type="base64"
             file="non_profit_organization/static/src/binary/res_partner/13-image_1920"/>

--- a/non_profit_organization/demo/sale_order.xml
+++ b/non_profit_organization/demo/sale_order.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
     <record id="sale_order_6" model="sale.order">
         <field name="partner_id" ref="res_partner_19"/>
         <field name="prepayment_percent">1.0</field>

--- a/non_profit_organization/demo/sale_order_confirm.xml
+++ b/non_profit_organization/demo/sale_order_confirm.xml
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True, 'mail_notrack': True}">
     <function model="sale.order" name="action_confirm" eval="[[ref('sale_order_6'),ref('sale_order_5'),ref('sale_order_2'),ref('sale_order_1')]]"/>
 </odoo>

--- a/non_profit_organization/demo/survey_survey.xml
+++ b/non_profit_organization/demo/survey_survey.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
     <record id="survey_survey_1" model="survey.survey">
         <field name="survey_type">survey</field>
         <field name="title">Your Feedback Matters – [Event Name] Evaluation</field>

--- a/odoo_partner/__manifest__.py
+++ b/odoo_partner/__manifest__.py
@@ -36,7 +36,6 @@
         'data/knowledge_tour.xml',
     ],
     'demo': [
-        'demo/res_users.xml',
         'demo/res_partner.xml',
         'demo/appointment_type.xml',
         'demo/crm_lead.xml',

--- a/odoo_partner/demo/crm_lead.xml
+++ b/odoo_partner/demo/crm_lead.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
     <record id="crm_lead_10" model="crm.lead">
         <field name="user_id" ref="base.user_admin"/>
         <field name="name">Business Intelligence Dashboard Creation</field>

--- a/odoo_partner/demo/mail_activity.xml
+++ b/odoo_partner/demo/mail_activity.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_activity_quick_update': True}">
     <record id="mail_activity_4" model="mail.activity">
         <field name="res_model_id" ref="crm.model_crm_lead"/>
         <field name="date_deadline" eval="(DateTime.today() + relativedelta(days=3)).strftime('%Y-%m-%d %H:%M')"/>

--- a/odoo_partner/demo/project_project.xml
+++ b/odoo_partner/demo/project_project.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
     <function model="ir.model.data" name="_update_xmlids">
         <value model="base" eval="[{
             'xml_id': 'odoo_partner.project_project_1',

--- a/odoo_partner/demo/res_partner.xml
+++ b/odoo_partner/demo/res_partner.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
     <record id="res_partner_27" model="res.partner">
         <field name="name">Apex Enterprises</field>
         <field name="image_1920" type="base64" file="odoo_partner/static/src/binary/res_partner/27-image_1920"/>

--- a/odoo_partner/demo/res_users.xml
+++ b/odoo_partner/demo/res_users.xml
@@ -1,6 +1,0 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
-    <record id="base.user_admin" model="res.users" forcecreate="0">
-        <field name="notification_type">inbox</field>
-    </record>
-</odoo>

--- a/odoo_partner/demo/sale_order.xml
+++ b/odoo_partner/demo/sale_order.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
     <record id="sale_order_11" model="sale.order">
         <field name="user_id" ref="base.user_admin"/>
         <field name="partner_id" ref="res_partner_27"/>

--- a/outdoor_activities/__manifest__.py
+++ b/outdoor_activities/__manifest__.py
@@ -25,7 +25,6 @@
         'data/mail_message.xml',
     ],
     'demo': [
-        'demo/res_users.xml',
         'demo/res_partner.xml',
         'demo/appointment_type.xml',
         'demo/website_theme_apply.xml',

--- a/outdoor_activities/demo/calender_event.xml
+++ b/outdoor_activities/demo/calender_event.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
-    <record id="calendar_event_1" model="calendar.event" context="{'no_mail_to_attendees': True}">
+<odoo noupdate="1" context="{'no_mail_to_attendees': True}">
+    <record id="calendar_event_1" model="calendar.event">
         <field name="name">Advanced Cave Dive</field>
         <field name="appointment_type_id" ref="appointment_type_2" />
         <field

--- a/outdoor_activities/demo/crm_lead.xml
+++ b/outdoor_activities/demo/crm_lead.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
     <record id="crm_lead_6" model="crm.lead">
         <field name="partner_id" ref="res_partner_68" />
         <field name="name">Special Request</field>

--- a/outdoor_activities/demo/event_event.xml
+++ b/outdoor_activities/demo/event_event.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
     <record id="event_event_1" model="event.event">
         <field name="cover_properties"><![CDATA[{"background-image":"url(/web/image/outdoor_activities.ir_attachment_1168)","background_color_class":"o_cc3 o_cc"}]]></field>
         <field name="name">Open Water Certification Course - April</field>

--- a/outdoor_activities/demo/res_users.xml
+++ b/outdoor_activities/demo/res_users.xml
@@ -1,6 +1,0 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
-    <record id="base.user_admin" model="res.users" forcecreate="0">
-        <field name="notification_type">inbox</field>
-    </record>
-</odoo>

--- a/outdoor_activities/demo/sale_order.xml
+++ b/outdoor_activities/demo/sale_order.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
     <record id="sale_order_2" model="sale.order">
         <field name="partner_id" ref="res_partner_68" />
         <field name="user_id" ref="base.user_admin" />

--- a/personal_trainer/__manifest__.py
+++ b/personal_trainer/__manifest__.py
@@ -27,7 +27,6 @@
         'data/knowledge_tour.xml',
     ],
     'demo': [
-        'demo/res_users.xml',
         'demo/res_partner.xml',
         'demo/crm_lead.xml',
         'demo/calendar_event.xml',

--- a/personal_trainer/demo/calendar_event.xml
+++ b/personal_trainer/demo/calendar_event.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
-    <record id="calendar_event_1" model="calendar.event" context="{'no_mail_to_attendees': True}">
+<odoo noupdate="1" context="{'no_mail_to_attendees': True}">
+    <record id="calendar_event_1" model="calendar.event">
         <field name="name">John Smith - 60-min Personal Training Session Booking</field>
         <field name="start_date" eval="DateTime.today().date()"/>
         <field name="appointment_type_id" ref="appointment_type_1"/>
@@ -19,7 +19,7 @@
             </ul>
         ]]></field>
     </record>
-    <record id="calendar_event_2" model="calendar.event" context="{'no_mail_to_attendees': True}">
+    <record id="calendar_event_2" model="calendar.event">
         <field name="name">Lena Martinez - 60-min Personal Training Session Booking</field>
         <field name="appointment_type_id" ref="appointment_type_1"/>
         <field name="appointment_booker_id" ref="base.partner_admin"/>
@@ -38,7 +38,7 @@
             </ul>
         ]]></field>
     </record>
-    <record id="calendar_event_3" model="calendar.event" context="{'no_mail_to_attendees': True}">
+    <record id="calendar_event_3" model="calendar.event">
         <field name="name">Clayton Smouth - 90-min Sport-Specific Coaching Booking</field>
         <field name="start_date" eval="DateTime.today().date()"/>
         <field name="appointment_type_id" ref="appointment_type_3"/>

--- a/personal_trainer/demo/crm_lead.xml
+++ b/personal_trainer/demo/crm_lead.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
   <record id="crm_lead_1" model="crm.lead">
     <field name="name">12-week Transformation Program</field>
     <field name="partner_id" ref="res_partner_13"/>

--- a/personal_trainer/demo/res_partner.xml
+++ b/personal_trainer/demo/res_partner.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
     <record id="res_partner_13" model="res.partner">
         <field name="name">John Smith</field>
         <field name="image_1920" type="base64" file="personal_trainer/static/src/binary/res_partner/13-image_1920"/>

--- a/personal_trainer/demo/res_users.xml
+++ b/personal_trainer/demo/res_users.xml
@@ -1,6 +1,0 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
-    <record id="base.user_admin" model="res.users" forcecreate="0">
-        <field name="notification_type">inbox</field>
-    </record>
-</odoo>

--- a/personal_trainer/demo/sale_order.xml
+++ b/personal_trainer/demo/sale_order.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
     <record id="sale_order_1" model="sale.order">
         <field name="partner_id" ref="res_partner_13"/>
         <field name="user_id" ref="base.user_admin"/>

--- a/personal_trainer/demo/sale_order_confirm.xml
+++ b/personal_trainer/demo/sale_order_confirm.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
     <function model="sale.order" name="action_confirm">
         <value eval="[ref('sale_order_1')]"/>
     </function>

--- a/pharmacy_retail/__manifest__.py
+++ b/pharmacy_retail/__manifest__.py
@@ -45,7 +45,6 @@
         'data/knowledge_tour.xml',
     ],
     'demo': [
-        'demo/res_users.xml',
         'demo/res_partner.xml',
         'demo/stock_lot.xml',
         'demo/product_supplierinfo.xml',

--- a/pharmacy_retail/demo/purchase_order.xml
+++ b/pharmacy_retail/demo/purchase_order.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
     <record id="purchase_order_1" model="purchase.order">
         <field name="partner_id" ref="res_partner_11"/>
         <field name="user_id" ref="base.user_admin"/>

--- a/pharmacy_retail/demo/res_users.xml
+++ b/pharmacy_retail/demo/res_users.xml
@@ -1,6 +1,0 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
-    <record id="base.user_admin" model="res.users" forcecreate="0">
-        <field name="notification_type">inbox</field>
-    </record>
-</odoo>

--- a/pharmacy_retail/demo/sale_order.xml
+++ b/pharmacy_retail/demo/sale_order.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
     <record id="sale_order_1" model="sale.order">
         <field name="partner_id" ref="res_partner_17"/>
         <field name="pricelist_id" ref="product_pricelist_2"/>

--- a/pharmacy_retail/demo/sale_order_post.xml
+++ b/pharmacy_retail/demo/sale_order_post.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
     <function name="action_confirm" model="sale.order">
         <value eval="[
             ref('sale_order_1'),

--- a/photography/__manifest__.py
+++ b/photography/__manifest__.py
@@ -33,7 +33,6 @@
         'data/website_theme_apply.xml',
     ],
     'demo': [
-        'demo/res_users.xml',
         'demo/res_partner.xml',
         'demo/crm_lead.xml',
         'demo/appointment_data.xml',

--- a/photography/demo/appointment.xml
+++ b/photography/demo/appointment.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
-    <record id="appointment_1" model="calendar.event" context="{'no_mail_to_attendees': True}">
+<odoo noupdate="1" context="{'no_mail_to_attendees': True}">
+    <record id="appointment_1" model="calendar.event">
         <field name="name">Studio Session - Cat pics! 😻</field>
         <field name="start"
             eval="(DateTime.now() + relativedelta(days=3)).strftime('%Y-%m-%d 10:00:00')" />

--- a/photography/demo/crm_lead.xml
+++ b/photography/demo/crm_lead.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
     <record id="crm_lead_1" model="crm.lead">
         <field name="create_date" eval="DateTime.now() - relativedelta(days=8)" />
         <field name="type">opportunity</field>

--- a/photography/demo/res_users.xml
+++ b/photography/demo/res_users.xml
@@ -1,6 +1,0 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
-    <record id="base.user_admin" model="res.users" forcecreate="0">
-        <field name="notification_type">inbox</field>
-    </record>
-</odoo>

--- a/photography/demo/sale_order.xml
+++ b/photography/demo/sale_order.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
 
     <record id="order_1" model="sale.order">
         <field name="partner_id" ref="partner_regina" />

--- a/physical_therapy/__manifest__.py
+++ b/physical_therapy/__manifest__.py
@@ -27,7 +27,6 @@
         'demo/res_partner.xml',
         'demo/crm_lead.xml',
         'demo/calendar_event.xml',
-        'demo/res_users.xml',
         'demo/account_move.xml',
         'demo/account_move_line.xml',
         'demo/account_move_post.xml',

--- a/physical_therapy/demo/calendar_event.xml
+++ b/physical_therapy/demo/calendar_event.xml
@@ -1,12 +1,12 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
-  <record id="calendar_event_278" model="calendar.event" context="{'no_mail_to_attendees': True}">
+<odoo noupdate="1" context="{'no_mail_to_attendees': True}">
+  <record id="calendar_event_278" model="calendar.event">
     <field name="name">John Smith</field>
     <field name="duration">1.0</field>
     <field name="recurrency" eval="True"/>
     <field name="follow_recurrence" eval="True"/>
   </record>
-  <record id="calendar_event_2" model="calendar.event" context="{'no_mail_to_attendees': True}">
+  <record id="calendar_event_2" model="calendar.event">
     <field name="name">Jacob Stein - Therapy Session Booking</field>
     <field name="location">Physical Therapy, 1160, Belgium</field>
     <field name="appointment_type_id" ref="appointment_type_1"/>
@@ -25,7 +25,7 @@
     <field name="appointment_invite_id" ref="appointment_invite_wellness_session"/>
     <field name="opportunity_id" ref="crm_lead_10"/>
   </record>
-  <record id="calendar_event_1" model="calendar.event" context="{'no_mail_to_attendees': True}">
+  <record id="calendar_event_1" model="calendar.event">
     <field name="name">Elise Smith - Therapy Session Booking</field>
     <field name="location">Physical Therapy, 1160, Belgium</field>
     <field name="appointment_type_id" ref="appointment_type_1"/>

--- a/physical_therapy/demo/res_users.xml
+++ b/physical_therapy/demo/res_users.xml
@@ -1,6 +1,0 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
-    <record id="base.user_admin" model="res.users" forcecreate="0">
-        <field name="notification_type">inbox</field>
-    </record>
-</odoo>

--- a/product_conversion/__manifest__.py
+++ b/product_conversion/__manifest__.py
@@ -15,9 +15,6 @@
         'data/ir_ui_view.xml',
         'data/base_automation.xml',
     ],
-    'demo': [
-        'demo/res_users.xml',
-    ],
     'assets': {
         'web.assets_backend': [
             'product_conversion/static/src/js/barcode_picking_model.js',

--- a/product_conversion/demo/res_users.xml
+++ b/product_conversion/demo/res_users.xml
@@ -1,6 +1,0 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
-    <record id="base.user_admin" model="res.users" forcecreate="0">
-        <field name="notification_type">inbox</field>
-    </record>
-</odoo>

--- a/real_estate/demo/calendar_event.xml
+++ b/real_estate/demo/calendar_event.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
-    <record id="calendar_event_2" model="calendar.event" context="{'no_mail_to_attendees': True}">
+<odoo noupdate="1" context="{'no_mail_to_attendees': True}">
+    <record id="calendar_event_2" model="calendar.event">
         <field name="name">Jessica Martinez - Amazing 5 bedrooms manor Booking</field>
         <field name="location">Rue du Laid Burniat 5, 1348 Ottignies-Louvain-la-Neuve, Belgium</field>
         <field name="start" model="appointment.type" eval="pytz.timezone(obj().env['appointment.type'].search([('name', '=', 'Amazing 5 bedrooms manor')], limit=1).appointment_tz or 'Europe/Brussels').localize(DateTime.today().date() + relativedelta(weekday=4, hour=14)).astimezone(pytz.UTC).replace(tzinfo=None)"/>
@@ -10,7 +10,7 @@
         <field name="partner_ids" eval="[(6, 0, [ref('base_industry_data.res_partner_25'), ref('base.partner_admin')])]"/>
         <field name="appointment_type_id" model="appointment.type" search="[('name', '=', 'Amazing 5 bedrooms manor')]"/>
     </record>
-    <record id="calendar_event_1" model="calendar.event" context="{'no_mail_to_attendees': True}">
+    <record id="calendar_event_1" model="calendar.event">
         <field name="name">Jessica Martinez - Amazing 5 bedrooms manor in Grand-Rosière Booking</field>
         <field name="location">Rue de la haie 3, 1315 Incourt, Belgium</field>
         <field name="user_id" ref="base.user_admin"/>
@@ -20,7 +20,7 @@
         <field name="partner_ids" eval="[(6, 0, [ref('base.partner_admin')])]"/>
         <field name="appointment_type_id" model="appointment.type" search="[('name', '=', 'Amazing 5 bedrooms manor')]"/>
     </record>
-    <record id="calendar_event_3" model="calendar.event" context="{'no_mail_to_attendees': True}">
+    <record id="calendar_event_3" model="calendar.event">
         <field name="name">Casey Admin - Old farm to renovate Booking</field>
         <field name="user_id" ref="base_industry_data.res_users_7"/>
         <field name="location">Roderveldlaan 3, 2600 Antwerpen, Belgium</field>

--- a/real_estate/demo/crm_lead.xml
+++ b/real_estate/demo/crm_lead.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
     <record id="crm_lead_16" model="crm.lead">
         <field name="name">I love this manor</field>
         <field name="partner_id" ref="base_industry_data.res_partner_24"/>

--- a/real_estate/demo/mail_activity.xml
+++ b/real_estate/demo/mail_activity.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_activity_quick_update': True}">
     <record id="mail_activity_2" model="mail.activity">
         <field name="res_model_id" ref="crm.model_crm_lead"/>
         <field name="res_id" ref="crm_lead_5"/>

--- a/real_estate/demo/sale_order.xml
+++ b/real_estate/demo/sale_order.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
     <record id="sale_order_6" model="sale.order">
         <field name="partner_id" ref="base_industry_data.res_partner_21"/>
         <field name="user_id" ref="base.user_admin"/>

--- a/shoe_maker/demo/sale_order.xml
+++ b/shoe_maker/demo/sale_order.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
     <record id="sale_order_1" model="sale.order">
         <field name="partner_id" ref="base_industry_data.res_partner_26"/>
         <field name="user_id" ref="base.user_admin"/>

--- a/software_reseller/__manifest__.py
+++ b/software_reseller/__manifest__.py
@@ -38,7 +38,6 @@
         'data/mail_message.xml',
     ],
     'demo': [
-        'demo/res_users.xml',
         'demo/hr_department.xml',
         'demo/res_partner.xml',
         'demo/hr_employee.xml',

--- a/software_reseller/demo/purchase_order.xml
+++ b/software_reseller/demo/purchase_order.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
   <record id="purchase_order_4" model="purchase.order">
     <field name="partner_id" ref="base_industry_data.res_partner_35"/>
     <field name="user_id" ref="base.user_admin"/>

--- a/software_reseller/demo/res_users.xml
+++ b/software_reseller/demo/res_users.xml
@@ -1,6 +1,0 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
-    <record id="base.user_admin" model="res.users" forcecreate="0">
-        <field name="notification_type">inbox</field>
-    </record>
-</odoo>

--- a/software_reseller/demo/sale_order.xml
+++ b/software_reseller/demo/sale_order.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
   <record id="sale_order_4" model="sale.order">
     <field name="partner_id" ref="base_industry_data.res_partner_26"/>
     <field name="user_id" ref="base.user_admin"/>

--- a/software_reseller/demo/sale_order_confirm.xml
+++ b/software_reseller/demo/sale_order_confirm.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True, 'mail_notrack': True}">
     <function model="sale.order" name="write">
         <value eval="[ref('sale_order_4')]" />
         <value eval="{'date_order': DateTime.today() - relativedelta(years=1)}" />

--- a/solar_installation/__manifest__.py
+++ b/solar_installation/__manifest__.py
@@ -55,7 +55,6 @@
         'data/knowledge_tour.xml',
     ],
     'demo': [
-        'demo/res_users.xml',
         'demo/res_partner.xml',
         'demo/crm_tag.xml',
         'demo/crm_lead.xml',

--- a/solar_installation/demo/crm_lead.xml
+++ b/solar_installation/demo/crm_lead.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
     <record id="crm_lead_1" model="crm.lead">
         <field name="name">Need to install 3 kW solar system</field>
         <field name="partner_id" ref="res_partner_10"/>

--- a/solar_installation/demo/helpdesk_ticket.xml
+++ b/solar_installation/demo/helpdesk_ticket.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
-    <record id="helpdesk_ticket_7" model="helpdesk.ticket" context="{'mail_notrack': True}">
+<odoo noupdate="1" context="{'mail_notrack': True}">
+    <record id="helpdesk_ticket_7" model="helpdesk.ticket">
         <field name="name">Raj Sharma's Ticket</field>
         <field name="stage_id" ref="helpdesk.stage_solved"/>
         <field name="answered_customer_message_count">1</field>
@@ -27,7 +27,7 @@
         </field>
         <field name="close_date" eval="datetime.now()"/>
     </record>
-    <record id="helpdesk_ticket_8" model="helpdesk.ticket" context="{'mail_notrack': True}">
+    <record id="helpdesk_ticket_8" model="helpdesk.ticket">
         <field name="name">Mehul Vyas's Ticket</field>
         <field name="stage_id" ref="helpdesk.stage_new"/>
         <field name="product_id" ref="product_product_10"/>
@@ -52,7 +52,7 @@
         ]]>
         </field>
     </record>
-    <record id="helpdesk_ticket_9" model="helpdesk.ticket" context="{'mail_notrack': True}">
+    <record id="helpdesk_ticket_9" model="helpdesk.ticket">
         <field name="name">Website Visitor #177's Ticket</field>
         <field name="stage_id" ref="helpdesk.stage_new"/>
         <field name="ticket_ref">09</field>
@@ -79,7 +79,7 @@
         ]]>
         </field>
     </record>
-    <record id="helpdesk_ticket_10" model="helpdesk.ticket" context="{'mail_notrack': True}">
+    <record id="helpdesk_ticket_10" model="helpdesk.ticket">
         <field name="name">Website Visitor #178's Ticket</field>
         <field name="stage_id" ref="helpdesk.stage_new"/>
         <field name="ticket_ref">10</field>
@@ -106,7 +106,7 @@
         ]]>
         </field>
     </record>
-    <record id="helpdesk_ticket_11" model="helpdesk.ticket" context="{'mail_notrack': True}">
+    <record id="helpdesk_ticket_11" model="helpdesk.ticket">
         <field name="name">Website Visitor #200's Ticket</field>
         <field name="stage_id" ref="helpdesk.stage_in_progress"/>
         <field name="product_id" ref="product_product_10"/>

--- a/solar_installation/demo/purchase_order.xml
+++ b/solar_installation/demo/purchase_order.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
     <record id="purchase_order_1" model="purchase.order">
         <field name="partner_id" ref="res_partner_15"/>
         <field name="user_id" ref="base.user_admin"/>

--- a/solar_installation/demo/res_users.xml
+++ b/solar_installation/demo/res_users.xml
@@ -1,6 +1,0 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
-    <record id="base.user_admin" model="res.users" forcecreate="0">
-        <field name="notification_type">inbox</field>
-    </record>
-</odoo>

--- a/solar_installation/demo/sale_order.xml
+++ b/solar_installation/demo/sale_order.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
     <record id="sale_order_20" model="sale.order">
         <field name="partner_id" ref="res_partner_23"/>
         <field name="sale_order_template_id" ref="sale_order_template_3"/>

--- a/solar_installation/demo/sale_order_post.xml
+++ b/solar_installation/demo/sale_order_post.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
     <function name="action_confirm" model="sale.order">
         <value eval="[
             ref('sale_order_20'),

--- a/spa_resort/demo/calendar_event.xml
+++ b/spa_resort/demo/calendar_event.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
-  <record id="calendar_event_1" model="calendar.event" context="{'no_mail_to_attendees': True}">
+<odoo noupdate="1" context="{'no_mail_to_attendees': True, 'mail_notrack': True}">
+  <record id="calendar_event_1" model="calendar.event">
     <field name="name">Juliette VDH - Deep Tissue Massage Booking</field>
     <field name="user_id" ref="base.user_admin"/>
     <field name="location">Thermes &amp; Spa, Belgium</field>
@@ -17,7 +17,7 @@
     <field name="appointment_status">booked</field>
     <field name="appointment_booker_id" ref="res_partner_9"/>
   </record>
-  <record id="calendar_event_2" model="calendar.event" context="{'no_mail_to_attendees': True}">
+  <record id="calendar_event_2" model="calendar.event">
     <field name="name">Juliette VDH - Golden Age Retreat (65+) Booking</field>
     <field name="user_id" ref="base.user_admin"/>
     <field name="location">MyCompany, Rue des Bourlottes 9, 1367 Ramillies, Belgium</field>
@@ -33,7 +33,7 @@
     <field name="appointment_status">booked</field>
     <field name="appointment_booker_id" ref="res_partner_9"/>
   </record>
-  <record id="calendar_event_3" model="calendar.event" context="{'no_mail_to_attendees': True}">
+  <record id="calendar_event_3" model="calendar.event">
     <field name="name">Juliette VDH - Student Wellness Break Booking</field>
     <field name="user_id" ref="base.user_admin"/>
     <field name="location">MyCompany, Rue des Bourlottes 9, 1367 Ramillies, Belgium</field>
@@ -49,7 +49,7 @@
     <field name="appointment_status">booked</field>
     <field name="appointment_booker_id" ref="res_partner_9"/>
   </record>
-  <record id="calendar_event_4" model="calendar.event" context="{'no_mail_to_attendees': True}">
+  <record id="calendar_event_4" model="calendar.event">
     <field name="name">Martin Test - Student Wellness Break Booking</field>
     <field name="user_id" ref="base.user_admin"/>
     <field name="location">MyCompany, Rue des Bourlottes 9, 1367 Ramillies, Belgium</field>

--- a/spa_resort/demo/sale_order.xml
+++ b/spa_resort/demo/sale_order.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
   <record id="sale_order_1" model="sale.order">
     <field name="partner_id" ref="res_partner_9"/>
     <field name="user_id" ref="base.user_admin"/>

--- a/spa_resort/demo/sale_order_confirm.xml
+++ b/spa_resort/demo/sale_order_confirm.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
   <!--Update sale order stages-->
   <function model="sale.order" name="action_confirm" eval="[[ref('sale_order_10'),ref('sale_order_8'),ref('sale_order_7'),ref('sale_order_1')]]"/>
 

--- a/sport_events/__manifest__.py
+++ b/sport_events/__manifest__.py
@@ -44,7 +44,6 @@
         'data/knowledge_article_favorite.xml',
     ],
     'demo': [
-        'demo/res_users.xml',
         'demo/survey_survey.xml',
         'demo/website_view.xml',
         'demo/survey_question.xml',

--- a/sport_events/demo/crm_lead.xml
+++ b/sport_events/demo/crm_lead.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
   <record id="crm_lead_4" model="crm.lead">
     <field name="partner_id" ref="res_partner_24"/>
     <field name="name">Decathlon Belgium's opportunity</field>

--- a/sport_events/demo/event_event.xml
+++ b/sport_events/demo/event_event.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
   <record id="event_event_2" model="event.event">
     <field name="cover_properties"><![CDATA[{"background-image": "url(/web/image/sport_events.ir_attachment_1314)", "resize_class": "cover_auto", "opacity": "0.4", "background_color_class": "o_cc o_cc3"}]]></field>
     <field name="is_published" eval="True"/>

--- a/sport_events/demo/mail_activity.xml
+++ b/sport_events/demo/mail_activity.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_activity_quick_update': True}">
   <record id="mail_activity_1" model="mail.activity">
     <field name="res_model_id" ref="crm.model_crm_lead"/>
     <field name="res_id" ref="crm_lead_1"/>

--- a/sport_events/demo/purchase_order.xml
+++ b/sport_events/demo/purchase_order.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
   <record id="purchase_order_2" model="purchase.order">
     <field name="partner_id" ref="res_partner_11"/>
     <field name="user_id" ref="base.user_admin"/>

--- a/sport_events/demo/res_partner.xml
+++ b/sport_events/demo/res_partner.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
   <record id="res_partner_11" model="res.partner">
     <field name="image_1920" type="base64" file="sport_events/static/src/binary/res_partner/11-image_1920"/>
     <field name="name">AlpineGear</field>

--- a/sport_events/demo/res_users.xml
+++ b/sport_events/demo/res_users.xml
@@ -1,6 +1,0 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
-    <record id="base.user_admin" model="res.users" forcecreate="0">
-        <field name="notification_type">inbox</field>
-    </record>
-</odoo>

--- a/sport_events/demo/sale_order.xml
+++ b/sport_events/demo/sale_order.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
   <record id="sale_order_5" model="sale.order">
     <field name="partner_id" ref="res_partner_30"/>
     <field name="user_id" ref="base.user_admin"/>

--- a/sport_events/demo/survey_survey.xml
+++ b/sport_events/demo/survey_survey.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
   <record id="survey_survey_1" model="survey.survey">
     <field name="title">Your Experience Around the Course </field>
     <field name="description"><![CDATA[<div>We’d love your feedback on the area around the racecourse — from scenery and accessibility to nearby attractions and facilities. Your input helps us improve the experience for future participants and promote local tourism.</div>]]></field>

--- a/sports_club/__manifest__.py
+++ b/sports_club/__manifest__.py
@@ -38,7 +38,6 @@
         'data/knowledge_tour.xml',
     ],
     'demo': [
-        'demo/res_users.xml',
         'demo/res_partner.xml',
         'demo/hr_employee.xml',
         'demo/crm_team.xml',

--- a/sports_club/demo/calendar_event.xml
+++ b/sports_club/demo/calendar_event.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
-    <record id="calendar_event_1" model="calendar.event" context="{'no_mail_to_attendees': True}">
+<odoo noupdate="1" context="{'no_mail_to_attendees': True}">
+    <record id="calendar_event_1" model="calendar.event">
         <field name="name">John Doe - Sport Court Booking</field>
         <field name="appointment_type_id" ref="appointment_type_1" />
         <field name="start" model="appointment.type" eval="pytz.timezone(obj().env.ref('sports_club.appointment_type_1').appointment_tz).localize(
@@ -10,7 +10,7 @@
                 DateTime.today().date() + relativedelta(days=1, hours=13)
             ).astimezone(pytz.UTC).replace(tzinfo=None)"/>
     </record>
-    <record id="calendar_event_2" model="calendar.event" context="{'no_mail_to_attendees': True}">
+    <record id="calendar_event_2" model="calendar.event">
         <field name="name">Joel Willis - Sport Court Booking</field>
         <field name="appointment_type_id" ref="appointment_type_1" />
         <field name="start" model="appointment.type" eval="pytz.timezone(obj().env.ref('sports_club.appointment_type_1').appointment_tz).localize(
@@ -20,7 +20,7 @@
                 DateTime.today().date() + relativedelta(hours=17)
             ).astimezone(pytz.UTC).replace(tzinfo=None)"/>
     </record>
-    <record id="calendar_event_3" model="calendar.event" context="{'no_mail_to_attendees': True}">
+    <record id="calendar_event_3" model="calendar.event">
         <field name="name">John Doe - Sport Court Booking</field>
         <field name="appointment_type_id" ref="appointment_type_2" />
         <field name="start" model="appointment.type" eval="pytz.timezone(obj().env.ref('sports_club.appointment_type_2').appointment_tz).localize(
@@ -30,7 +30,7 @@
                 DateTime.today().date() + relativedelta(hours=10)
             ).astimezone(pytz.UTC).replace(tzinfo=None)"/>
     </record>
-    <record id="calendar_event_4" model="calendar.event" context="{'no_mail_to_attendees': True}">
+    <record id="calendar_event_4" model="calendar.event">
         <field name="name">Joel Willis - Sport Court Booking</field>
         <field name="appointment_type_id" ref="appointment_type_1" />
         <field name="start" model="appointment.type" eval="pytz.timezone(obj().env.ref('sports_club.appointment_type_1').appointment_tz).localize(
@@ -40,7 +40,7 @@
                 DateTime.today().date() + relativedelta(days=2, hours=13)
             ).astimezone(pytz.UTC).replace(tzinfo=None)"/>
     </record>
-    <record id="calendar_event_5" model="calendar.event" context="{'no_mail_to_attendees': True}">
+    <record id="calendar_event_5" model="calendar.event">
         <field name="name">John Doe - Sport Court Booking</field>
         <field name="appointment_type_id" ref="appointment_type_1" />
         <field name="start" model="appointment.type" eval="pytz.timezone(obj().env.ref('sports_club.appointment_type_1').appointment_tz).localize(
@@ -50,7 +50,7 @@
                 DateTime.today().date() + relativedelta(hours=19)
             ).astimezone(pytz.UTC).replace(tzinfo=None)"/>
     </record>
-    <record id="calendar_event_6" model="calendar.event" context="{'no_mail_to_attendees': True}">
+    <record id="calendar_event_6" model="calendar.event">
         <field name="name">Joel Willis - Friday Night Free Play</field>
         <field name="appointment_type_id" ref="appointment_type_2" />
         <field name="start" model="appointment.type" eval="pytz.timezone(obj().env.ref('sports_club.appointment_type_2').appointment_tz).localize(
@@ -60,7 +60,7 @@
                 DateTime.today().date() + relativedelta(days=4, hours=10)
             ).astimezone(pytz.UTC).replace(tzinfo=None)"/>
     </record>
-    <record id="calendar_event_7" model="calendar.event" context="{'no_mail_to_attendees': True}">
+    <record id="calendar_event_7" model="calendar.event">
         <field name="name">Joel Willis - Sport Court Booking</field>
         <field name="appointment_type_id" ref="appointment_type_1" />
         <field name="start" model="appointment.type" eval="pytz.timezone(obj().env.ref('sports_club.appointment_type_1').appointment_tz).localize(
@@ -70,7 +70,7 @@
                 DateTime.today().date() + relativedelta(hours=21)
             ).astimezone(pytz.UTC).replace(tzinfo=None)"/>
     </record>
-    <record id="calendar_event_8" model="calendar.event" context="{'no_mail_to_attendees': True}">
+    <record id="calendar_event_8" model="calendar.event">
         <field name="name">John Doe - Friday Night Free Play</field>
         <field name="appointment_type_id" ref="appointment_type_2" />
         <field name="start" model="appointment.type" eval="pytz.timezone(obj().env.ref('sports_club.appointment_type_2').appointment_tz).localize(

--- a/sports_club/demo/crm_lead.xml
+++ b/sports_club/demo/crm_lead.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
     <record id="crm_lead_1" model="crm.lead">
         <field name="name">Hello</field>
         <field name="team_id" ref="sales_team.team_sales_department"/>

--- a/sports_club/demo/res_users.xml
+++ b/sports_club/demo/res_users.xml
@@ -1,6 +1,0 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
-    <record id="base.user_admin" model="res.users" forcecreate="0">
-        <field name="notification_type">inbox</field>
-    </record>
-</odoo>

--- a/sports_club/demo/sale_order.xml
+++ b/sports_club/demo/sale_order.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
     <record id="sale_order_1" model="sale.order">
         <field name="carrier_id" ref="website_sale_collect.carrier_pick_up_in_store"/>
         <field name="website_id" ref="website.default_website"/>

--- a/student_organization/demo/event_event.xml
+++ b/student_organization/demo/event_event.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
   <record id="event_event_2" model="event.event">
     <field name="cover_properties"><![CDATA[{"background-image":"url(/web/image/student_organization.ir_attachment_1446)","background_color_class":"o_cc3 o_cc","background_color_style":"","opacity":"0.4","resize_class":"o_half_screen_height o_record_has_cover","text_align_class":""}]]></field>
     <field name="name" eval="'Student Organization Gala %s' % datetime.now().year" />

--- a/student_organization/demo/purchase_order.xml
+++ b/student_organization/demo/purchase_order.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
   <record id="purchase_order_2" model="purchase.order">
     <field name="partner_id" ref="base_industry_data.res_partner_24"/>
     <field name="reminder_date_before_receipt">1</field>

--- a/student_organization/demo/sale_order.xml
+++ b/student_organization/demo/sale_order.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
   <record id="sale_order_3" model="sale.order">
     <field name="partner_id" ref="base_industry_data.res_partner_27"/>
     <field name="user_id" ref="base.user_admin"/>

--- a/summer_camps/demo/crm_lead.xml
+++ b/summer_camps/demo/crm_lead.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
   <record id="crm_lead_1" model="crm.lead">
     <field name="name">Discount for siblings</field>
     <field name="user_id" ref="base.user_admin"/>

--- a/summer_camps/demo/event_event.xml
+++ b/summer_camps/demo/event_event.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
   <record id="event_event_1" model="event.event">
     <field name="cover_properties"><![CDATA[{"background-image":"url(\"/web/image/summer_camps.ir_attachment_1093\")","resize_class":"cover_auto o_record_has_cover","text_align_class":"","opacity":"0.4","background_color_class":"o_cc o_cc3","background_color_style":""}]]></field>
     <field name="name">🏕️ Adventure Summer Camp</field>

--- a/summer_camps/demo/sale_order.xml
+++ b/summer_camps/demo/sale_order.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
   <record id="sale_order_1" model="sale.order">
     <field name="partner_id" ref="res_partner_11"/>
     <field name="user_id" ref="base.user_admin"/>

--- a/surveyor/__manifest__.py
+++ b/surveyor/__manifest__.py
@@ -35,7 +35,6 @@
         'data/knowledge_tour.xml',
     ],
     'demo': [
-        'demo/res_users.xml',
         'demo/res_partner.xml',
         'demo/crm_stage.xml',
         'demo/crm_lead.xml',

--- a/surveyor/demo/crm_lead.xml
+++ b/surveyor/demo/crm_lead.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True, 'mail_activity_quick_update': True}">
     <record id="crm_lead_1" model="crm.lead">
         <field name="name">Quotation request</field>
         <field name="partner_id" ref="res_partner_8"/>

--- a/surveyor/demo/res_users.xml
+++ b/surveyor/demo/res_users.xml
@@ -1,6 +1,0 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
-    <record id="base.user_admin" model="res.users" forcecreate="0">
-        <field name="notification_type">inbox</field>
-    </record>
-</odoo>

--- a/surveyor/demo/sale_order.xml
+++ b/surveyor/demo/sale_order.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
 
     <record id="sale_order_8" model="sale.order">
         <field name="opportunity_id" ref="crm_lead_1"/>

--- a/takeaway_restaurant/demo/purchase_order.xml
+++ b/takeaway_restaurant/demo/purchase_order.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
     <record id="purchase_order_2" model="purchase.order">
         <field name="partner_id" ref="res_partner_9"/>
         <field name="user_id" ref="base.user_admin"/>

--- a/tattoo_shop/demo/calendar_event.xml
+++ b/tattoo_shop/demo/calendar_event.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
-  <record id="calendar_event_2" model="calendar.event" context="{'no_mail_to_attendees': True}">
+<odoo noupdate="1" context="{'no_mail_to_attendees': True}">
+  <record id="calendar_event_2" model="calendar.event">
     <field name="name">Discuss Piercing choice</field>
     <field name="appointment_type_id" ref="appointment_type_2"/>
     <field name="start" model="appointment.type" eval="pytz.timezone(obj().env.ref('tattoo_shop.appointment_type_2').appointment_tz).localize(
@@ -12,8 +12,7 @@
     <field name="res_id" ref="crm_lead_6"/>
     <field name="res_model_id" ref="crm.model_crm_lead"/>
   </record>
-
-  <record id="calendar_event_1" model="calendar.event" context="{'no_mail_to_attendees': True}">
+  <record id="calendar_event_1" model="calendar.event">
     <field name="name">Jonathan - Piercing Booking</field>
     <field name="appointment_type_id" ref="appointment_type_2"/>
     <field name="start" model="appointment.type" eval="pytz.timezone(obj().env.ref('tattoo_shop.appointment_type_2').appointment_tz).localize(

--- a/tattoo_shop/demo/crm_lead.xml
+++ b/tattoo_shop/demo/crm_lead.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True, 'mail_activity_quick_update': True}">
   <record id="crm_lead_8" model="crm.lead">
     <field name="partner_id" ref="base_industry_data.res_partner_23"/>
     <field name="name">Large Tattoo - Logo</field>

--- a/tattoo_shop/demo/sale_order.xml
+++ b/tattoo_shop/demo/sale_order.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
-    <record id="sale_order_1" model="sale.order">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
+  <record id="sale_order_1" model="sale.order">
     <field name="medium_id" ref="utm.utm_medium_website"/>
     <field name="partner_id" ref="base.partner_admin"/>
     <field name="user_id" ref="base.user_admin"/>

--- a/team_sports_club/demo/calendar_event.xml
+++ b/team_sports_club/demo/calendar_event.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
-  <record id="calendar_event_4" model="calendar.event" context="{'no_mail_to_attendees': True}">
+<odoo noupdate="1" context="{'no_mail_to_attendees': True}">
+  <record id="calendar_event_4" model="calendar.event">
     <field name="name">Training P2 Booking</field>
     <field name="user_id" ref="base.user_admin"/>
     <field name="location">Football Club Industry, Rue d'Odoo 345, 1348 Louvain-la-Neuve, Belgium</field>
@@ -12,7 +12,7 @@
     <field name="appointment_booker_id" ref="base.partner_admin"/>
     <field name="appointment_type_id" ref="appointment_type_1"/>
   </record>
-  <record id="calendar_event_3" model="calendar.event" context="{'no_mail_to_attendees': True}">
+  <record id="calendar_event_3" model="calendar.event">
     <field name="name">Training P2 Booking</field>
     <field name="user_id" ref="base.user_admin"/>
     <field name="location">Football Club Industry, Rue d'Odoo 345, 1348 Louvain-la-Neuve, Belgium</field>
@@ -24,7 +24,7 @@
     <field name="appointment_booker_id" ref="base.partner_admin"/>
     <field name="appointment_type_id" ref="appointment_type_1"/>
   </record>
-  <record id="calendar_event_2" model="calendar.event" context="{'no_mail_to_attendees': True}">
+  <record id="calendar_event_2" model="calendar.event">
     <field name="name">Match P2 - Away Odoo P2</field>
     <field name="user_id" ref="base.user_admin"/>
     <field name="duration">2.25</field>

--- a/team_sports_club/demo/crm_lead.xml
+++ b/team_sports_club/demo/crm_lead.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
   <record id="crm_lead_5" model="crm.lead">
     <field name="partner_id" ref="base_industry_data.res_partner_24"/>
     <field name="name">Youth Academy Sponsor</field>

--- a/team_sports_club/demo/event_event.xml
+++ b/team_sports_club/demo/event_event.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
   <record id="event_event_1" model="event.event">
     <field name="cover_properties"><![CDATA[{"background-image":"url(\"/web/image/team_sports_club.ir_attachment_1007\")","resize_class":"o_half_screen_height o_record_has_cover","text_align_class":"","opacity":"0","background_color_class":"o_cc o_cc3","background_color_style":""}]]></field>
     <field name="is_published" eval="True"/>

--- a/team_sports_club/demo/res_partner.xml
+++ b/team_sports_club/demo/res_partner.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
 <record id="res_partner_197" model="res.partner">
     <field name="name">Adrien Côté</field>
     <field name="is_company" eval="True"/>

--- a/team_sports_club/demo/sale_order.xml
+++ b/team_sports_club/demo/sale_order.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
   <record id="sale_order_23" model="sale.order">
     <field name="partner_id" ref="res_partner_13"/>
     <field name="pricelist_id" ref="product_pricelist_9"/>

--- a/tests/test_generic/tests/test_industry_mail_behavior.py
+++ b/tests/test_generic/tests/test_industry_mail_behavior.py
@@ -2,28 +2,91 @@
 
 import logging
 
+
 from odoo.tests import tagged
 from .industry_case import IndustryCase
 
 _logger = logging.getLogger(__name__)
 
 
+RECORD_CONTEXT_MODELS_DICT = {
+    'calendar.event': ['no_mail_to_attendees', 'mail_notrack'],
+    'crm.lead': ['mail_auto_subscribe_no_notify'],
+    'event.event': ['mail_auto_subscribe_no_notify'],
+    'helpdesk.ticket': ['mail_notrack', 'mail_auto_subscribe_no_notify'],
+    'hr.applicant': ['mail_notrack'],
+    'hr.job': ['mail_auto_subscribe_no_notify'],
+    'mail.activity': ['mail_activity_quick_update'],
+    'mailing.mailing': ['mail_auto_subscribe_no_notify'],
+    'maintenance.request': ['mail_auto_subscribe_no_notify', 'mail_activity_quick_update'],
+    'mrp.eco': ['mail_auto_subscribe_no_notify'],
+    'pos.session': ['mail_auto_subscribe_no_notify'],
+    'project.project': ['mail_auto_subscribe_no_notify'],
+    'project.task': ['mail_auto_subscribe_no_notify'],
+    'purchase.order': ['mail_auto_subscribe_no_notify'],
+    'quality.check': ['mail_auto_subscribe_no_notify'],
+    'res.partner': ['mail_auto_subscribe_no_notify'],
+    'sale.order': ['mail_auto_subscribe_no_notify'],
+    'slide.channel': ['mail_auto_subscribe_no_notify'],
+    'stock.picking': ['mail_auto_subscribe_no_notify'],
+    'survey.survey': ['mail_auto_subscribe_no_notify'],
+}
+
+EXCEPTION_MODELS = [
+    'hr.expense',
+    'hr.leave',
+]
+
+
 @tagged('post_install', '-at_install')
 class IndustryMailBehaviorTestCase(IndustryCase):
-    def test_user_notification_type(self):
-        if not self.env['ir.module.module'].search_count([('demo', '=', True)], limit=1):
-            return
-        for user in self.env['res.users'].search([('group_ids', 'in', [self.env.ref('base.group_user').id, self.env.ref('base.group_system').id]), ('notification_type', '!=', 'inbox')]):
-            _logger.warning("Notification type should remain 'inbox' for all users, not the case for %s (%d).", user.name, user.id)
 
-    def test_mail_generated(self):
-        if self.env['ir.module.module'].search_count([('demo', '=', True)], limit=1):
-            return
+    def test_generic_mail_message_generated(self):
+        mails = self.env['mail.mail']._read_group([('model', '!=', False), ('model', 'not in', EXCEPTION_MODELS), ('state', '!=', 'outgoing')], ['res_id', 'model'])
 
-        mails = self.env['mail.mail'].search([('model', '!=', False), ('model', '!=', 'hr.expense')])
-        if mails:
-            models = list(set(mails.mapped('model')))
-            _logger.warning(
-                "Mails are generated from models: %s — use correct context to prevent mail pollution.",
-                ', '.join(models)
-            )
+        result = {}
+        for res_id, res_model in mails:
+            record = self.env[res_model].browse(res_id)
+            if not record:
+                continue
+            all_activities = getattr(record, 'activity_ids', False) or self.env['mail.activity']
+
+            ext_ids = record._get_external_ids()
+            if not any(ext_ids.values()):
+                continue
+            for ext_id in next(iter(ext_ids.values())):
+                ctx_set = result.setdefault(ext_id, set())
+                if (ctxs := RECORD_CONTEXT_MODELS_DICT.get(res_model)):
+                    ctx_set.update(ctxs)
+
+                if all_activities:
+                    for activity in all_activities:
+                        activity_external_ids = activity._get_external_ids().get(activity.id, [])
+                        if not activity_external_ids:
+                            ctx_set.add('mail_activity_quick_update')
+                        else:
+                            for activity_ext_id in activity_external_ids:
+                                result.setdefault(activity_ext_id, set()).add('mail_activity_quick_update')
+
+                if getattr(record, 'calendar_event_ids', False):
+                    for event in record.calendar_event_ids:
+                        event_external_ids = event._get_external_ids().get(event.id, [])
+                        if not event_external_ids:
+                            ctx_set.add('mail_activity_quick_update')
+                        else:
+                            for event_ext_id in event_external_ids:
+                                result.setdefault(event_ext_id, set()).add('mail_activity_quick_update')
+
+        for ext_ids, context in result.items():
+            if context:
+                _logger.warning(
+                    "Messages and mails are generated from record '%s' — use context '%s' to prevent message and mail pollution.",
+                    ext_ids,
+                    ', '.join(context)
+                )
+            else:
+                _logger.warning(
+                    "Messages and mails are generated from record '%s', but no context is defined. "
+                    "This case is not yet covered — please review and handle this scenario to prevent potential message and mail pollution.",
+                    ext_ids,
+                )

--- a/tests/test_generic/tests/test_xml.py
+++ b/tests/test_generic/tests/test_xml.py
@@ -94,21 +94,11 @@ ESCAPE_STUDIO_TEST = [
     'construction',
 ]
 
-SKIP_CONTEXT_DICT_FOR_DEMO = {
-    'crm.lead': 'mail_auto_subscribe_no_notify',
-    'event.event': 'mail_auto_subscribe_no_notify',
-    'hr.job': 'mail_auto_subscribe_no_notify',
-    'mailing.mailing': 'mail_auto_subscribe_no_notify',
-    'project.project': 'mail_auto_subscribe_no_notify',
-    'project.task': 'mail_auto_subscribe_no_notify',
-    'stock.picking': 'skip_sms',
+FUNCTION_CONTEXT_DICT_WITHOUT_USER = {
+    'sale.advance.payment.inv': 'create_invoices',
+    'sale.order': '_create_invoices',
 }
-CONTEXT_MODELS_DICT = {
-    'calendar.event': 'no_mail_to_attendees',
-    'helpdesk.ticket': 'mail_notrack',
-    'hr.applicant': 'mail_notrack',
-    **SKIP_CONTEXT_DICT_FOR_DEMO
-}
+
 RISKY_FIELDS = {
     "domain",
     "context",
@@ -205,7 +195,7 @@ class TestEnv(IndustryCase):
                 self._check_dates_are_relative(tree, file_name)
                 self._check_static_values_in_inputs(tree, file_name)
                 self._check_res_config_setting(tree)
-                self._check_context_to_stop_mail_sending(tree, file_name, module)
+                self._check_context_to_stop_mail_sending(tree, file_name)
                 self._check_text_based_xpath(tree, file_name)
                 self._check_portal_login_is_email(tree, file_name)
                 if root.split('/')[-1] == 'data':
@@ -680,31 +670,64 @@ class TestEnv(IndustryCase):
                         line,
                     )
 
-    def _check_context_to_stop_mail_sending(self, root, file_name, module):
+    def _check_context_to_stop_mail_sending(self, root, file_name):
+
+        def log_warning(expected_context):
+            _logger.warning(
+                "Context should be used in file '%s' for model '%s' to prevent mail pollution when using %s function. "
+                "Expected context: '%s'. Found context: %s",
+                file_name,
+                model_name,
+                func_name,
+                ', '.join(expected_context),
+                function.get('context') or 'None'
+            )
         for record in root.xpath("//record"):
             model_name = record.get('model')
-            if not model_name or model_name not in CONTEXT_MODELS_DICT:
+            if model_name != 'slide.channel':
                 continue
-            record_context = record.get('context') or ''
-            expected_context = CONTEXT_MODELS_DICT.get(model_name)
-            if model_name in SKIP_CONTEXT_DICT_FOR_DEMO:
-                record_xml_id = record.get('id') if "." in record.get('id') else module + '.' + record.get('id')
-                recordset = self.env.ref(record_xml_id) if record_xml_id else False
-                if recordset:
-                    user = getattr(recordset, 'user_id', False)
-                    if not user or user.notification_type == 'inbox':
-                        continue
+            for user_field in record.xpath(".//field[@name='user_id']"):
+                user_id = user_field.get('eval') or user_field.get('ref')
+                if user_id and user_id != 'False':
+                    _logger.warning(
+                        "Remove or set user_id to False in file '%s' for model '%s' to prevent mail pollution.",
+                        file_name,
+                        model_name
+                    )
 
-            context_dict = ast.literal_eval(record_context) if record_context else {}
-            if expected_context not in context_dict:
-                _logger.warning(
-                    "Context should be used in file '%s' for model '%s' to prevent mail pollution. "
-                    "Expected context: '%s'. Found context: %s",
-                    file_name,
-                    model_name,
-                    expected_context,
-                    record_context or 'None'
+        for function in root.xpath("//function"):
+            func_name = function.get('name')
+            model_name = function.get('model')
+            raw_context = function.get('context', '{}')
+            try:
+                context_dict = ast.literal_eval(raw_context)
+                context_dict.update(ast.literal_eval(root.get('context', '{}')))
+            except (ValueError, SyntaxError):
+                context_dict = {}
+            if model_name == 'sale.order' and func_name == 'action_confirm':
+                SaleOrder = self.env['sale.order']
+                has_subscription = ('is_subscription' in SaleOrder._fields
+                    and SaleOrder.search_count([('is_subscription', '=', True)]) > 0
                 )
+                if has_subscription:
+                    expected_context = ['mail_auto_subscribe_no_notify', 'mail_notrack']
+                    if not all(context in context_dict for context in expected_context):
+                        log_warning(expected_context)
+
+            if model_name in FUNCTION_CONTEXT_DICT_WITHOUT_USER and func_name == FUNCTION_CONTEXT_DICT_WITHOUT_USER.get(model_name):
+                expected_context = ['mail_auto_subscribe_no_notify']
+                if not all(context in context_dict for context in expected_context):
+                    log_warning(expected_context)
+
+            if func_name == 'write':
+                for value in function.xpath(".//value"):
+                    write_value = value.get('eval')
+                    if not write_value or ('user_id' not in write_value and 'user_ids' not in write_value):
+                        continue
+                    expected_context = ['mail_auto_subscribe_no_notify']
+                    if not all(context in context_dict for context in expected_context):
+                        log_warning(expected_context)
+                        break
 
     def _check_text_based_xpath(self, root, file_name):
         TEXT_XPATH_PATTERN = re.compile(r"text\(")

--- a/textile_manufacturing/demo/crm_lead.xml
+++ b/textile_manufacturing/demo/crm_lead.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
   <record id="crm_lead_3" model="crm.lead">
     <field name="name">Corporate T-shirt</field>
     <field name="user_id" ref="base.user_admin"/>

--- a/textile_manufacturing/demo/mail_activity.xml
+++ b/textile_manufacturing/demo/mail_activity.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_activity_quick_update': True}">
     <record id="mail_activity_3" model="mail.activity">
         <field name="res_model_id" ref="project.model_project_task"/>
         <field name="date_deadline" eval="(DateTime.today() - relativedelta(days=2)).strftime('%Y-%m-%d %H:%M')"/>

--- a/textile_manufacturing/demo/project_project.xml
+++ b/textile_manufacturing/demo/project_project.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
   <record id="project_project_2" model="project.project">
     <field name="task_properties_definition" eval="[{'name': 'knowledge_article_html', 'type': 'html', 'string': 'Knowledge Article', 'default': '&lt;p data-oe-version=&quot;2.0&quot;&gt;&lt;a target=&quot;_blank&quot; class=&quot;btn btn-sm o_knowledge_article_link&quot; href=&quot;/knowledge/article/%s&quot; data-res_id=&quot;%s&quot;&gt;📄 Client Full design&lt;/a&gt;&lt;/p&gt;' %(ref('knowledge_article_37'), ref('knowledge_article_37')), 'view_in_cards': False}]"/>
   </record>

--- a/textile_manufacturing/demo/project_task.xml
+++ b/textile_manufacturing/demo/project_task.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo auto_sequence="1" noupdate="1">
+<odoo auto_sequence="1" noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
   <record id="project_task_33" model="project.task">
     <field name="name">Validate Raw Material</field>
     <field name="project_id" ref="project_project_6"/>

--- a/textile_manufacturing/demo/purchase_order.xml
+++ b/textile_manufacturing/demo/purchase_order.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
   <record id="purchase_order_3" model="purchase.order">
     <field name="partner_id" ref="base_industry_data.res_partner_32"/>
     <field name="user_id" ref="base.user_admin"/>

--- a/textile_manufacturing/demo/sale_order.xml
+++ b/textile_manufacturing/demo/sale_order.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
   <record id="sale_order_2" model="sale.order">
     <field name="partner_id" ref="base_industry_data.res_partner_27"/>
     <field name="user_id" ref="base.user_admin"/>

--- a/theater/demo/crm_lead.xml
+++ b/theater/demo/crm_lead.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
   <record id="crm_lead_6" model="crm.lead">
     <field name="name">Annual Membership + Merchandise Partnership</field>
     <field name="stage_id" ref="crm.stage_lead1"/>

--- a/theater/demo/event_event.xml
+++ b/theater/demo/event_event.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
   <record id="event_event_1" model="event.event">
     <field name="cover_properties"><![CDATA[{"background-image": "url(/web/image/theater.ir_attachment_1122)", "resize_class": "cover_auto o_record_has_cover", "text_align_class": "", "opacity": "0", "background_color_class": "o_cc o_cc3", "background_color_style": ""}]]></field>
     <field name="name">Shadows of Verona</field>

--- a/theater/demo/mail_activity.xml
+++ b/theater/demo/mail_activity.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_activity_quick_update': True}">
   <record id="mail_activity_2" model="mail.activity">
     <field name="res_model_id" ref="crm.model_crm_lead"/>
     <field name="res_id" ref="crm_lead_3"/>

--- a/theater/demo/sale_order.xml
+++ b/theater/demo/sale_order.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
   <record id="sale_order_10" model="sale.order">
     <field name="partner_id" ref="base_industry_data.res_partner_22"/>
     <field name="user_id" ref="base.user_admin"/>

--- a/toy_store/__manifest__.py
+++ b/toy_store/__manifest__.py
@@ -33,7 +33,6 @@
         'data/knowledge_tour.xml',
     ],
     'demo': [
-        'demo/res_users.xml',
         'demo/res_partner.xml',
         'demo/hr_employee.xml',
         'demo/product_template.xml',

--- a/toy_store/demo/purchase_order.xml
+++ b/toy_store/demo/purchase_order.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
     <record id="purchase_order_1" model="purchase.order">
         <field name="partner_id" ref="res_partner_13"/>
         <field name="user_id" ref="base.user_admin"/>

--- a/toy_store/demo/res_users.xml
+++ b/toy_store/demo/res_users.xml
@@ -1,6 +1,0 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
-    <record id="base.user_admin" model="res.users" forcecreate="0">
-        <field name="notification_type">inbox</field>
-    </record>
-</odoo>

--- a/usage_based_maintenance/__manifest__.py
+++ b/usage_based_maintenance/__manifest__.py
@@ -22,9 +22,6 @@
         'data/ir_default.xml',
         'data/base_automation.xml',
     ],
-    'demo': [
-        'demo/res_users.xml',
-    ],
     'license': 'OEEL-1',
     'images': ['images/main.png'],
     'website': "https://www.odoo.com/all-industries",

--- a/usage_based_maintenance/demo/res_users.xml
+++ b/usage_based_maintenance/demo/res_users.xml
@@ -1,6 +1,0 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
-    <record id="base.user_admin" model="res.users" forcecreate="0">
-        <field name="notification_type">inbox</field>
-    </record>
-</odoo>

--- a/veterinary_clinic/demo/calendar_event.xml
+++ b/veterinary_clinic/demo/calendar_event.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
-  <record id="calendar_event_10" model="calendar.event" context="{'no_mail_to_attendees': True}">
+<odoo noupdate="1" context="{'no_mail_to_attendees': True}">
+  <record id="calendar_event_10" model="calendar.event">
     <field name="name">Booking - Vanya</field>
     <field name="start" model="appointment.type" eval="pytz.timezone(obj().env.ref('veterinary_clinic.appointment_type_1').appointment_tz).localize(
                 DateTime.today().date() + relativedelta(days=2, hours=13, minutes=30)
@@ -12,7 +12,7 @@
     <field name="appointment_booker_id" ref="base.partner_admin"/>
     <field name="x_new_pet_field" eval="[(6, 0, [ref('x_pets_9')])]"/>
   </record>
-  <record id="calendar_event_1" model="calendar.event" context="{'no_mail_to_attendees': True}">
+  <record id="calendar_event_1" model="calendar.event">
     <field name="name">Robert Wilson - Consultation - Checkup Booking</field>
     <field name="user_id" ref="base.user_admin"/>
     <field name="location">MyCompany, Rue des Bourlottes 9, 1367 Ramillies, Belgium</field>
@@ -29,7 +29,7 @@
     <field name="appointment_status">booked</field>
     <field name="appointment_booker_id" ref="res_partner_76"/>
   </record>
-  <record id="calendar_event_2" model="calendar.event" context="{'no_mail_to_attendees': True}">
+  <record id="calendar_event_2" model="calendar.event">
     <field name="name">Robert Wilson - Consultation - Checkup Booking</field>
     <field name="user_id" ref="base.user_admin"/>
     <field name="location">MyCompany, Rue des Bourlottes 9, 1367 Ramillies, Belgium</field>
@@ -47,7 +47,7 @@
     <field name="appointment_booker_id" ref="res_partner_76"/>
     <field name="x_new_pet_field" eval="[(6, 0, [ref('x_pets_5')])]"/>
   </record>
-  <record id="calendar_event_5" model="calendar.event" context="{'no_mail_to_attendees': True}">
+  <record id="calendar_event_5" model="calendar.event">
     <field name="name">walk in customer name</field>
     <field name="user_id" ref="base.user_admin"/>
     <field name="start" model="appointment.type" eval="pytz.timezone(obj().env.ref('veterinary_clinic.appointment_type_1').appointment_tz).localize(
@@ -60,7 +60,7 @@
     <field name="partner_ids" eval="[(6, 0, [ref('base.partner_admin')])]"/>
     <field name="x_new_pet_field" eval="[(6, 0, [ref('x_pets_2')])]"/>
   </record>
-  <record id="calendar_event_4" model="calendar.event" context="{'no_mail_to_attendees': True}">
+  <record id="calendar_event_4" model="calendar.event">
     <field name="name">John Smith, Lucie</field>
     <field name="description"><![CDATA[<div data-oe-version="1.0">Regular checkup</div><div><br></div>]]></field>
     <field name="user_id" ref="base.user_admin"/>
@@ -74,7 +74,7 @@
     <field name="partner_ids" eval="[(6, 0, [ref('base_industry_data.res_partner_26'), ref('base.partner_admin')])]"/>
     <field name="x_new_pet_field" eval="[(6, 0, [ref('x_pets_2')])]"/>
   </record>
-  <record id="calendar_event_3" model="calendar.event" context="{'no_mail_to_attendees': True}">
+  <record id="calendar_event_3" model="calendar.event">
     <field name="name">Emily Johnson - Consultation - Checkup Booking</field>
     <field name="user_id" ref="base.user_admin"/>
     <field name="location">MyCompany, Rue des Bourlottes 9, 1367 Ramillies, Belgium</field>

--- a/veterinary_clinic/demo/crm_lead.xml
+++ b/veterinary_clinic/demo/crm_lead.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
   <record id="crm_lead_5" model="crm.lead">
     <field name="partner_id" ref="base_industry_data.res_partner_26"/>
     <field name="name">John Smith's opportunity</field>

--- a/veterinary_clinic/demo/sale_order.xml
+++ b/veterinary_clinic/demo/sale_order.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
   <record id="sale_order_15" model="sale.order">
     <field name="partner_id" ref="base_industry_data.res_partner_26"/>
     <field name="user_id" ref="base.user_admin"/>

--- a/vineyard/__manifest__.py
+++ b/vineyard/__manifest__.py
@@ -43,7 +43,6 @@
         'data/knowledge_article_favorite.xml',
     ],
     'demo': [
-        'demo/res_users.xml',
         'demo/product_product.xml',
         'demo/appointment_type.xml',
         'demo/crm_tag.xml',

--- a/vineyard/demo/crm_lead.xml
+++ b/vineyard/demo/crm_lead.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
   <record id="crm_lead_1" model="crm.lead">
     <field name="name">Metropolitan Cabernet Sauvignon Supply</field>
     <field name="team_id" ref="sales_team.team_sales_department"/>

--- a/vineyard/demo/mrp_eco.xml
+++ b/vineyard/demo/mrp_eco.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
   <record id="mrp_eco_1" model="mrp.eco">
     <field name="name">Trial 1</field>
     <field name="user_id" ref="base.user_admin"/>

--- a/vineyard/demo/project_project.xml
+++ b/vineyard/demo/project_project.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
   <record id="industry_fsm.fsm_project" model="project.project" forcecreate="1">
     <field name="name">Field Service</field>
     <field name="user_id" ref="base.user_admin"/>

--- a/vineyard/demo/project_task.xml
+++ b/vineyard/demo/project_task.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
   <record id="project_task_8" model="project.task">
     <field name="name">Harvest Parcel 2</field>
     <field name="project_id" ref="industry_fsm.fsm_project"/>

--- a/vineyard/demo/purchase_order.xml
+++ b/vineyard/demo/purchase_order.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
   <record id="purchase_order_1" model="purchase.order">
     <field name="partner_id" ref="base_industry_data.res_partner_26"/>
     <field name="user_id" ref="base.user_admin"/>

--- a/vineyard/demo/res_users.xml
+++ b/vineyard/demo/res_users.xml
@@ -1,6 +1,0 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
-    <record id="base.user_admin" model="res.users" forcecreate="0">
-        <field name="notification_type">inbox</field>
-    </record>
-</odoo>

--- a/vineyard/demo/sale_order.xml
+++ b/vineyard/demo/sale_order.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
   <record id="sale_order_3" model="sale.order">
     <field name="partner_id" ref="base_industry_data.res_partner_25"/>
     <field name="user_id" ref="base.user_admin"/>

--- a/vineyard/demo/stock_picking.xml
+++ b/vineyard/demo/stock_picking.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
   <record id="stock_picking_28" model="stock.picking">
     <field name="picking_type_id" ref="stock_picking_type_27"/>
     <field name="scheduled_date" eval="datetime.today().date() + relativedelta(years=-1)"/>

--- a/wedding_planner/demo/calendar_event.xml
+++ b/wedding_planner/demo/calendar_event.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
-  <record id="calendar_event_1" model="calendar.event" context="{'no_mail_to_attendees': True}">
+<odoo noupdate="1" context="{'no_mail_to_attendees': True}">
+  <record id="calendar_event_1" model="calendar.event">
     <field name="name">Jessica Martinez's Marriage - Consultation meeting</field>
     <field name="duration">1.25</field>
     <field name="res_id" ref="crm_lead_2"/>
@@ -8,7 +8,7 @@
     <field name="partner_ids" eval="[(6, 0, [ref('base_industry_data.res_partner_25'), ref('base.partner_admin')])]"/>
     <field name="opportunity_id" ref="crm_lead_2"/>
   </record>
-  <record id="calendar_event_2" model="calendar.event" context="{'no_mail_to_attendees': True}">
+  <record id="calendar_event_2" model="calendar.event">
     <field name="name">Meeting with customer to confirm vendors</field>
     <field name="duration">2.5</field>
     <field name="res_id" ref="crm_lead_3"/>

--- a/wedding_planner/demo/crm_lead.xml
+++ b/wedding_planner/demo/crm_lead.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True, 'mail_activity_quick_update': True}">
   <record id="crm_lead_2" model="crm.lead">
     <field name="name">Jessica Martinez's Marriage</field>
     <field name="partner_id" ref="base_industry_data.res_partner_25"/>

--- a/wedding_planner/demo/project_project.xml
+++ b/wedding_planner/demo/project_project.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
   <record id="project_project_2" model="project.project">
     <field name="name">S00003 - Wedding Planning (Full Service)</field>
     <field name="user_id" ref="base.user_admin"/>

--- a/wedding_planner/demo/purchase_order.xml
+++ b/wedding_planner/demo/purchase_order.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
   <record id="purchase_order_10" model="purchase.order">
     <field name="partner_id" ref="res_partner_37"/>
     <field name="user_id" ref="base.user_admin"/>

--- a/wedding_planner/demo/sale_order.xml
+++ b/wedding_planner/demo/sale_order.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
-   <record id="sale_order_2" model="sale.order">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
+  <record id="sale_order_2" model="sale.order">
     <field name="partner_id" ref="base_industry_data.res_partner_27"/>
     <field name="sale_order_template_id" ref="sale_order_template_1"/>
     <field name="user_id" ref="base.user_admin"/>

--- a/wellness_practitioner/__manifest__.py
+++ b/wellness_practitioner/__manifest__.py
@@ -20,7 +20,6 @@
         'data/knowledge_tour.xml',
     ],
     'demo': [
-        'demo/res_users.xml',
         'demo/res_partner.xml',
         'demo/crm_lead.xml',
     ],

--- a/wellness_practitioner/demo/crm_lead.xml
+++ b/wellness_practitioner/demo/crm_lead.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
     <record id="crm_lead_3" model="crm.lead">
         <field name="partner_id" ref="res_partner_15"/>
         <field name="name">Lower Back Pain Relief</field>

--- a/wellness_practitioner/demo/res_users.xml
+++ b/wellness_practitioner/demo/res_users.xml
@@ -1,6 +1,0 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
-    <record id="base.user_admin" model="res.users" forcecreate="0">
-        <field name="notification_type">inbox</field>
-    </record>
-</odoo>

--- a/wine_merchant/demo/calendar_event.xml
+++ b/wine_merchant/demo/calendar_event.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
-  <record id="calendar_event_1" model="calendar.event" context="{'no_mail_to_attendees': True}">
+<odoo noupdate="1" context="{'no_mail_to_attendees': True, 'mail_activity_quick_update': True}">
+  <record id="calendar_event_1" model="calendar.event">
     <field name="name">Meeting at clients</field>
     <field name="description"><![CDATA[<br>Feedback: <p>Nice meeting <br>Client will buy more</p>]]></field>
     <field name="user_id" ref="base.user_admin"/>

--- a/wine_merchant/demo/crm_lead.xml
+++ b/wine_merchant/demo/crm_lead.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
   <record id="crm_lead_6" model="crm.lead">
     <field name="name">The wine cellar bar's opportunity</field>
     <field name="partner_id" ref="base_industry_data.res_partner_32"/>

--- a/wine_merchant/demo/event_event.xml
+++ b/wine_merchant/demo/event_event.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
     <record id="event_event_1" model="event.event">
         <field name="name">Wine Tasting - Bordeaux</field>
         <field name="cover_properties"><![CDATA[{"background-image":"url(/web/image/wine_merchant.ir_attachment_1161)","background_color_class":"o_cc3 o_cc","opacity":"0.4","resize_class":"o_half_screen_height o_record_has_cover"}]]></field>

--- a/wine_merchant/demo/mail_activity.xml
+++ b/wine_merchant/demo/mail_activity.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_activity_quick_update': True}">
   <record id="mail_activity_6" model="mail.activity">
     <field name="res_model_id" ref="point_of_sale.model_pos_session"/>
     <field name="res_id" ref="pos_session_1"/>

--- a/wine_merchant/demo/pos_session.xml
+++ b/wine_merchant/demo/pos_session.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
   <record id="pos_session_1" model="pos.session">
     <field name="config_id" ref="pos_config_1"/>
     <field name="user_id" ref="base.user_admin"/>

--- a/wine_merchant/demo/purchase_order.xml
+++ b/wine_merchant/demo/purchase_order.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
   <record id="purchase_order_1" model="purchase.order">
     <field name="partner_id" ref="base_industry_data.res_partner_34"/>
     <field name="user_id" ref="base.user_admin"/>

--- a/wine_merchant/demo/sale_order.xml
+++ b/wine_merchant/demo/sale_order.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
   <record id="sale_order_4" model="sale.order">
     <field name="partner_id" ref="base_industry_data.res_partner_34"/>
     <field name="pricelist_id" ref="product_pricelist_2"/>

--- a/yoga_pilates/demo/event_event.xml
+++ b/yoga_pilates/demo/event_event.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
     <record id="event_event_1" model="event.event">
         <field name="name">Energize &amp; Restore</field>
         <field name="cover_properties"><![CDATA[{"background-image":"url(/web/image/yoga_pilates.ir_attachment_1619)","background_color_class":"o_cc3 o_cc","opacity":"0.4","resize_class":"o_half_screen_height o_record_has_cover"}]]></field>

--- a/yoga_pilates/demo/sale_order.xml
+++ b/yoga_pilates/demo/sale_order.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
   <record id="sale_order_13" model="sale.order">
     <field name="partner_id" ref="base_industry_data.res_partner_25"/>
     <field name="user_id" ref="base.user_admin"/>

--- a/yoga_pilates/demo/sale_order_confirm.xml
+++ b/yoga_pilates/demo/sale_order_confirm.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True, 'mail_notrack': True}">
   <!--Update sale order stages-->
   <function model="sale.order" name="action_confirm" eval="[[ref('sale_order_12'),ref('sale_order_13')]]"/>
 </odoo>

--- a/yoga_pilates/demo/survey_survey.xml
+++ b/yoga_pilates/demo/survey_survey.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
   <record id="survey_survey_1" model="survey.survey">
     <field name="title">Yoga Class: Satisfaction Survey</field>
     <field name="survey_type">survey</field>


### PR DESCRIPTION
- Remove res_users.xml forcing notification_type='inbox' so modules generate
mails again.
- Read generated mails via _read_group and browse related records.
- Inspect linked mail.activity and handle upsell activities separately:
   - Identify upsell activities from note content.
   - Ignore upsell activities without external IDs when their count matches
     generated mails.
   - Process remaining activities to detect missing contexts.
- Suggest required contexts to prevent message/mail pollution.
- Log warnings with external IDs and recommended contexts.
- Add validation on XML <function> nodes to ensure required mail-prevention
contexts are set.
- Introduce helper log_warning to standardize missing-context warnings.
- Add specific checks:
   - slide.channel: ensure publish_template_id is set to False.
   - sale.order.action_confirm: require mail_auto_subscribe_no_notify and
      mail_notrack when subscription SO is present.
   - Functions defined in FUNCTION_CONTEXT_DICT_WITHOUT_USER:
      enforce mail_auto_subscribe_no_notify.
    - write calls updating user_id / user_ids: require
      mail_auto_subscribe_no_notify to prevent unwanted followers/mails.
- Safely parse function context using literal_eval with fallback handling.

`Context Used`

- mail_auto_subscribe_no_notify: Prevents notifications that are normally sent
when users are automatically added as followers. By default this is False,
meaning notifications are sent — enable it to stay silent.
- mail_activity_quick_update: When creating activities for other users, this
avoids sending them a notification about the new activity.
- mail_notrack: During create or write, disables field change tracking so no
automatic “value changed” messages are posted.
- no_mail_to_attendees: Stops email notifications from being sent to event attendees.

Task ID: 5262306