### PR TITLE
[IMP] booking_engine, *: add stop sell boolean field to disable booking button

### DIFF
--- a/booking_engine/__manifest__.py
+++ b/booking_engine/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Booking Engine',
-    'version': '1.7',
+    'version': '1.8',
     'category': 'Hidden/Tools',
     'author': 'Odoo S.A.',
     'depends': [

--- a/booking_engine/data/ir_model_fields.xml
+++ b/booking_engine/data/ir_model_fields.xml
@@ -636,4 +636,11 @@ for record in self:
         <field name="store" eval="False"/>
         <field name="related">x_resource_id.x_occupancy_color</field>
     </record>
+    <record id="product_model_product_template_x_stop_sell" model="ir.model.fields">
+        <field name="ttype">boolean</field>
+        <field name="copied" eval="True"/>
+        <field name="field_description">Stop-Sell</field>
+        <field name="model_id" ref="product.model_product_template"/>
+        <field name="name">x_stop_sell</field>
+    </record>
 </odoo>

--- a/booking_engine/data/ir_ui_view.xml
+++ b/booking_engine/data/ir_ui_view.xml
@@ -823,4 +823,18 @@
         <field name="type">form</field>
         <field name="active" eval="True"/>
     </record>
+    <record id="product_template_form_view_booking_engine" model="ir.ui.view">
+        <field name="arch" type="xml">
+            <xpath expr="//group[@name='extra_info']/field[@name='is_published']" position="after">
+                <field name="x_stop_sell" widget="boolean_toggle"/>
+            </xpath>
+        </field>
+        <field name="inherit_id" ref="website_sale.product_template_form_view"/>
+        <field name="mode">extension</field>
+        <field name="model">product.template</field>
+        <field name="name">product.template.product.form.inherit.booking.engine</field>
+        <field name="priority">160</field>
+        <field name="type">form</field>
+        <field name="active" eval="True"/>
+    </record>
 </odoo>

--- a/booking_engine/data/website_view.xml
+++ b/booking_engine/data/website_view.xml
@@ -2,7 +2,8 @@
 <odoo>  
   <template id="custom_add_cart_name" inherit_id="website_sale.cta_wrapper">
     <xpath expr="//a[@id='add_to_cart']" position="replace">
-      <a id="add_to_cart" role="button" href="#" t-attf-class="btn btn-primary js_check_product a-submit flex-grow-1" t-att-data-show-quantity="is_view_active('website_sale.product_quantity')" data-animation-selector=".o_wsale_product_images" class="btn btn-primary js_check_product a-submit flex-grow-1"><i class="fa fa-shopping-cart me-2"/>&amp;nbsp;Book</a>
+      <a t-if="product.x_stop_sell" role="button" href="#" class="btn btn-secondary flex-grow-1 disabled" aria-disabled="true"><i class="fa fa-ban me-2"/>&amp;nbsp;Unavailable</a>
+      <a t-else="" id="add_to_cart" role="button" href="#" t-attf-class="btn btn-primary js_check_product a-submit flex-grow-1" t-att-data-show-quantity="is_view_active('website_sale.product_quantity')" data-animation-selector=".o_wsale_product_images" class="btn btn-primary js_check_product a-submit flex-grow-1"><i class="fa fa-shopping-cart me-2"/>&amp;nbsp;Book</a>
     </xpath>
   </template>
   <template id="custom_product_name" inherit_id="website_sale.products">

--- a/booking_engine/i18n/booking_engine.pot
+++ b/booking_engine/i18n/booking_engine.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 19.0+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-02-17 09:07+0000\n"
-"PO-Revision-Date: 2026-02-17 09:07+0000\n"
+"POT-Creation-Date: 2026-02-19 08:56+0000\n"
+"PO-Revision-Date: 2026-02-19 08:56+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -48,6 +48,11 @@ msgstr ""
 #. module: booking_engine
 #: model:product.attribute.value,name:booking_engine.product_attribute_guest4
 msgid "4 pers."
+msgstr ""
+
+#. module: booking_engine
+#: model_terms:ir.ui.view,arch_db:booking_engine.custom_add_cart_name
+msgid "<i class=\"fa fa-ban me-2\"/>&amp;nbsp;Unavailable"
 msgstr ""
 
 #. module: booking_engine
@@ -870,6 +875,11 @@ msgstr ""
 #: model:ir.actions.act_window,name:booking_engine.res_partner_stays_action
 #: model_terms:ir.ui.view,arch_db:booking_engine.res_partner_form_view
 msgid "Stays"
+msgstr ""
+
+#. module: booking_engine
+#: model:ir.model.fields,field_description:booking_engine.product_model_product_template_x_stop_sell
+msgid "Stop-Sell"
 msgstr ""
 
 #. module: booking_engine

--- a/campsite/data/knowledge_article.xml
+++ b/campsite/data/knowledge_article.xml
@@ -54,7 +54,21 @@
             <li>Once done, logged in as a portal user. </li>
             <li>Open a stay offer page from the website and scroll down to the Customer Reviews section.</li>
             <li>Adjust the number of stars, leave a comment and send it!</li>
-        </ul><p>
+        </ul>
+        <h4>Stop-sell switch</h4>
+        <p>Command your revenue with a single switch: our stay offer level Stop-Sell lets you instantly pause specific stay packages during emergencies or peak demand.</p>
+        <ul>
+            <li>Open one of your stay offers from the Campsite App.</li>
+            <li>Navigate to the Sales tab. </li>
+            <li>In the eCommerce section, activate the Stop-Sell switch to prevent any further booking to take place from your website.</li>
+        </ul>
+        <div class="o_editor_banner user-select-none o-contenteditable-false lh-1 d-flex align-items-center alert alert-success pb-0 pt-3" data-oe-role="status" contenteditable="false" role="status">
+            <i class="o_editor_banner_icon mb-3 fst-normal" data-oe-aria-label="Banner Success" aria-label="Banner Success">✅</i>
+            <div class="o_editor_banner_content o-contenteditable-true w-100 px-3" contenteditable="true">
+                <p>You can still sell yourself by creating new orders but prevent website visitors to make additional bookings.</p>
+            </div>
+        </div>
+        <p>
             <a href="https://www.odoo.com/documentation/latest/applications/websites/ecommerce.html" class="btn btn-secondary">🎓
                 eCommerce</a>
         </p><p>

--- a/campsite/i18n/campsite.pot
+++ b/campsite/i18n/campsite.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 19.0+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-02-17 05:29+0000\n"
-"PO-Revision-Date: 2026-02-17 05:29+0000\n"
+"POT-Creation-Date: 2026-02-26 05:55+0000\n"
+"PO-Revision-Date: 2026-02-26 05:55+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -27,23 +27,6 @@ msgstr ""
 msgid ""
 "<a class=\"mb-2 o_translate_inline btn btn-secondary\" href=\"/shop\">Book "
 "Your Stay Now</a>"
-msgstr ""
-
-#. module: campsite
-#: model_terms:ir.ui.view,arch_db:campsite.homepage
-msgid ""
-"<a t-att-href=\"'/shop/category/' + "
-"str(env.ref('campsite.product_public_category_10').id)\" "
-"class=\"o_translate_inline btn btn-secondary\">Find out more</a>"
-msgstr ""
-
-#. module: campsite
-#: model_terms:ir.ui.view,arch_db:campsite.homepage
-msgid ""
-"<a t-att-href=\"'/shop/category/' + "
-"str(env.ref('campsite.product_public_category_11').id)\" "
-"class=\"o_translate_inline btn btn-secondary\">Explore Our Pitches "
-"Options</a>"
 msgstr ""
 
 #. module: campsite
@@ -470,6 +453,14 @@ msgstr ""
 #. module: campsite
 #: model_terms:ir.ui.view,arch_db:campsite.welcome_article_body
 msgid ""
+"Command your revenue with a single switch: our stay offer level Stop-Sell "
+"lets you instantly pause specific stay packages during emergencies or peak "
+"demand."
+msgstr ""
+
+#. module: campsite
+#: model_terms:ir.ui.view,arch_db:campsite.welcome_article_body
+msgid ""
 "Create a new leave selecting the appropriate working schedule, the one from "
 "your stay resources."
 msgstr ""
@@ -574,6 +565,11 @@ msgid ""
 msgstr ""
 
 #. module: campsite
+#: model_terms:ir.ui.view,arch_db:campsite.homepage
+msgid "Explore Our Pitches Options"
+msgstr ""
+
+#. module: campsite
 #: model:product.template,name:campsite.product_template_9
 msgid "Fan"
 msgstr ""
@@ -583,6 +579,11 @@ msgstr ""
 msgid ""
 "Fantastic staff! Always available and ready to help, they provide amazing "
 "pitches and cabin! We loved the stay!"
+msgstr ""
+
+#. module: campsite
+#: model_terms:ir.ui.view,arch_db:campsite.homepage
+msgid "Find out more"
 msgstr ""
 
 #. module: campsite
@@ -708,6 +709,13 @@ msgstr ""
 #. module: campsite
 #: model_terms:ir.ui.view,arch_db:campsite.welcome_article_body
 msgid ""
+"In the eCommerce section, activate the Stop-Sell switch to prevent any "
+"further booking to take place from your website."
+msgstr ""
+
+#. module: campsite
+#: model_terms:ir.ui.view,arch_db:campsite.welcome_article_body
+msgid ""
 "It enables each place manager to adjust the stay offers with greater "
 "flexibility without impacting other places."
 msgstr ""
@@ -758,6 +766,11 @@ msgstr ""
 #. module: campsite
 #: model_terms:ir.ui.view,arch_db:campsite.welcome_article_body
 msgid "Managing your businesses"
+msgstr ""
+
+#. module: campsite
+#: model_terms:ir.ui.view,arch_db:campsite.welcome_article_body
+msgid "Navigate to the Sales tab."
 msgstr ""
 
 #. module: campsite
@@ -872,6 +885,11 @@ msgstr ""
 msgid ""
 "Open now, the Tasks from the accommodation app, House Keeping menu.<br/>This is\n"
 "                the daily list of house keeping tasks to be tackled."
+msgstr ""
+
+#. module: campsite
+#: model_terms:ir.ui.view,arch_db:campsite.welcome_article_body
+msgid "Open one of your stay offers from the Campsite App."
 msgstr ""
 
 #. module: campsite
@@ -1085,6 +1103,11 @@ msgid "Still from their Rental Order, open the Guests tab."
 msgstr ""
 
 #. module: campsite
+#: model_terms:ir.ui.view,arch_db:campsite.welcome_article_body
+msgid "Stop-sell switch"
+msgstr ""
+
+#. module: campsite
 #: model:product.template,name:campsite.product_template_5
 msgid "Tentalo"
 msgstr ""
@@ -1284,6 +1307,13 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:campsite.welcome_article_body
 msgid ""
 "You can as well select your company and in the Branches tab define branches."
+msgstr ""
+
+#. module: campsite
+#: model_terms:ir.ui.view,arch_db:campsite.welcome_article_body
+msgid ""
+"You can still sell yourself by creating new orders but prevent website "
+"visitors to make additional bookings."
 msgstr ""
 
 #. module: campsite

--- a/guest_house/data/knowledge_article.xml
+++ b/guest_house/data/knowledge_article.xml
@@ -89,6 +89,19 @@
             <li>Open a room page from the website and scroll down to the Customer Reviews section.</li>
             <li>Adjust the number of stars, leave a comment and send it!</li>
         </ul>
+        <h4>Stop-sell switch</h4>
+        <p>Command your revenue with a single switch: our stay offer level Stop-Sell lets you instantly pause specific stay packages during emergencies or peak demand.</p>
+        <ul>
+            <li>Open one of your stay offers from the Guest House App.</li>
+            <li>Navigate to the Sales tab. </li>
+            <li>In the eCommerce section, activate the Stop-Sell switch to prevent any further booking to take place from your website.</li>
+        </ul>
+        <div class="o_editor_banner user-select-none o-contenteditable-false lh-1 d-flex align-items-center alert alert-success pb-0 pt-3" data-oe-role="status" contenteditable="false" role="status">
+            <i class="o_editor_banner_icon mb-3 fst-normal" data-oe-aria-label="Banner Success" aria-label="Banner Success">✅</i>
+            <div class="o_editor_banner_content o-contenteditable-true w-100 px-3" contenteditable="true">
+                <p>You can still sell yourself by creating new orders but prevent website visitors to make additional bookings.</p>
+            </div>
+        </div>
         <p><a href="https://www.odoo.com/documentation/latest/applications/websites/ecommerce.html"
                 class="btn btn-secondary">🎓 eCommerce</a> </p>
         <p>

--- a/guest_house/i18n/guest_house.pot
+++ b/guest_house/i18n/guest_house.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 19.0+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-02-17 05:30+0000\n"
-"PO-Revision-Date: 2026-02-17 05:30+0000\n"
+"POT-Creation-Date: 2026-02-26 05:57+0000\n"
+"PO-Revision-Date: 2026-02-26 05:57+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -412,6 +412,14 @@ msgstr ""
 #. module: guest_house
 #: model_terms:ir.ui.view,arch_db:guest_house.welcome_article_body
 msgid ""
+"Command your revenue with a single switch: our stay offer level Stop-Sell "
+"lets you instantly pause specific stay packages during emergencies or peak "
+"demand."
+msgstr ""
+
+#. module: guest_house
+#: model_terms:ir.ui.view,arch_db:guest_house.welcome_article_body
+msgid ""
 "Create a new leave selecting the appropriate working schedule, the one from "
 "your stay resources."
 msgstr ""
@@ -616,6 +624,13 @@ msgstr ""
 #. module: guest_house
 #: model_terms:ir.ui.view,arch_db:guest_house.welcome_article_body
 msgid ""
+"In the eCommerce section, activate the Stop-Sell switch to prevent any "
+"further booking to take place from your website."
+msgstr ""
+
+#. module: guest_house
+#: model_terms:ir.ui.view,arch_db:guest_house.welcome_article_body
+msgid ""
 "It enables each place manager to adjust the stay offers with greater "
 "flexibility without impacting other places."
 msgstr ""
@@ -651,6 +666,11 @@ msgstr ""
 #. module: guest_house
 #: model_terms:ir.ui.view,arch_db:guest_house.welcome_article_body
 msgid "Managing your businesses"
+msgstr ""
+
+#. module: guest_house
+#: model_terms:ir.ui.view,arch_db:guest_house.welcome_article_body
+msgid "Navigate to the Sales tab."
 msgstr ""
 
 #. module: guest_house
@@ -750,6 +770,11 @@ msgstr ""
 msgid ""
 "Open now, the Tasks from the accommodation app, House Keeping menu.<br/>This is\n"
 "                the daily list of house keeping tasks to be tackled."
+msgstr ""
+
+#. module: guest_house
+#: model_terms:ir.ui.view,arch_db:guest_house.welcome_article_body
+msgid "Open one of your stay offers from the Guest House App."
 msgstr ""
 
 #. module: guest_house
@@ -965,6 +990,11 @@ msgid "Still from their Rental Order, open the Guests tab."
 msgstr ""
 
 #. module: guest_house
+#: model_terms:ir.ui.view,arch_db:guest_house.welcome_article_body
+msgid "Stop-sell switch"
+msgstr ""
+
+#. module: guest_house
 #: model:product.template,name:guest_house.product_template_15
 msgid "Studious Room (2 guests)"
 msgstr ""
@@ -1112,6 +1142,13 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:guest_house.welcome_article_body
 msgid ""
 "You can as well select your company and in the Branches tab define branches."
+msgstr ""
+
+#. module: guest_house
+#: model_terms:ir.ui.view,arch_db:guest_house.welcome_article_body
+msgid ""
+"You can still sell yourself by creating new orders but prevent website "
+"visitors to make additional bookings."
 msgstr ""
 
 #. module: guest_house

--- a/holiday_house/data/knowledge_article.xml
+++ b/holiday_house/data/knowledge_article.xml
@@ -78,6 +78,19 @@ Open your website home page in a private tab to do so.</li>
             <li>Open a house page from the website and scroll down to the Customer Reviews section.</li>
             <li>Adjust the number of stars, leave a comment and send it!</li>
         </ul>
+        <h4>Stop-sell switch</h4>
+        <p>Command your revenue with a single switch: our stay offer level Stop-Sell lets you instantly pause specific stay packages during emergencies or peak demand.</p>
+        <ul>
+            <li>Open one of your stay offers from the Holiday House App.</li>
+            <li>Navigate to the Sales tab. </li>
+            <li>In the eCommerce section, activate the Stop-Sell switch to prevent any further booking to take place from your website.</li>
+        </ul>
+        <div class="o_editor_banner user-select-none o-contenteditable-false lh-1 d-flex align-items-center alert alert-success pb-0 pt-3" data-oe-role="status" contenteditable="false" role="status">
+            <i class="o_editor_banner_icon mb-3 fst-normal" data-oe-aria-label="Banner Success" aria-label="Banner Success">✅</i>
+            <div class="o_editor_banner_content o-contenteditable-true w-100 px-3" contenteditable="true">
+                <p>You can still sell yourself by creating new orders but prevent website visitors to make additional bookings.</p>
+            </div>
+        </div>
         <p>
             <a class="btn btn-secondary" href="https://www.odoo.com/documentation/latest/applications/websites/ecommerce.html">🎓 eCommerce</a>
         </p>

--- a/holiday_house/i18n/holiday_house.pot
+++ b/holiday_house/i18n/holiday_house.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 19.0+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-02-17 05:31+0000\n"
-"PO-Revision-Date: 2026-02-17 05:31+0000\n"
+"POT-Creation-Date: 2026-02-26 05:59+0000\n"
+"PO-Revision-Date: 2026-02-26 05:59+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -419,6 +419,14 @@ msgstr ""
 #. module: holiday_house
 #: model_terms:ir.ui.view,arch_db:holiday_house.welcome_article_body
 msgid ""
+"Command your revenue with a single switch: our stay offer level Stop-Sell "
+"lets you instantly pause specific stay packages during emergencies or peak "
+"demand."
+msgstr ""
+
+#. module: holiday_house
+#: model_terms:ir.ui.view,arch_db:holiday_house.welcome_article_body
+msgid ""
 "Create a new leave selecting the appropriate working schedule, the one from "
 "your stay resources."
 msgstr ""
@@ -617,6 +625,13 @@ msgstr ""
 #. module: holiday_house
 #: model_terms:ir.ui.view,arch_db:holiday_house.welcome_article_body
 msgid ""
+"In the eCommerce section, activate the Stop-Sell switch to prevent any "
+"further booking to take place from your website."
+msgstr ""
+
+#. module: holiday_house
+#: model_terms:ir.ui.view,arch_db:holiday_house.welcome_article_body
+msgid ""
 "It enables each place manager to adjust the stay offers with greater "
 "flexibility without impacting other places."
 msgstr ""
@@ -656,6 +671,11 @@ msgstr ""
 #: model_terms:product.template,website_description:holiday_house.product_template_13
 #: model_terms:product.template,website_description:holiday_house.product_template_14
 msgid "Map"
+msgstr ""
+
+#. module: holiday_house
+#: model_terms:ir.ui.view,arch_db:holiday_house.welcome_article_body
+msgid "Navigate to the Sales tab."
 msgstr ""
 
 #. module: holiday_house
@@ -745,6 +765,11 @@ msgstr ""
 msgid ""
 "Open now, the Tasks from the accommodation app, House Keeping menu.<br/>This is\n"
 "                the daily list of house keeping tasks to be tackled."
+msgstr ""
+
+#. module: holiday_house
+#: model_terms:ir.ui.view,arch_db:holiday_house.welcome_article_body
+msgid "Open one of your stay offers from the Holiday House App."
 msgstr ""
 
 #. module: holiday_house
@@ -920,6 +945,11 @@ msgid "Still from their Rental Order, open the Guests tab."
 msgstr ""
 
 #. module: holiday_house
+#: model_terms:ir.ui.view,arch_db:holiday_house.welcome_article_body
+msgid "Stop-sell switch"
+msgstr ""
+
+#. module: holiday_house
 #: model_terms:product.template,description_ecommerce:holiday_house.product_template_14
 msgid ""
 "Suspended above the shoreline, this beach house offers sweeping views of the"
@@ -1053,6 +1083,13 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:holiday_house.welcome_article_body
 msgid ""
 "You can as well select your company and in the Branches tab define branches."
+msgstr ""
+
+#. module: holiday_house
+#: model_terms:ir.ui.view,arch_db:holiday_house.welcome_article_body
+msgid ""
+"You can still sell yourself by creating new orders but prevent website "
+"visitors to make additional bookings."
 msgstr ""
 
 #. module: holiday_house

--- a/hotel/data/knowledge_article.xml
+++ b/hotel/data/knowledge_article.xml
@@ -108,6 +108,19 @@
             <li>Open a room page from the website and scroll down to the Customer Reviews section.</li>
             <li>Adjust the number of stars, leave a comment and send it!</li>
         </ul>
+        <h4>Stop-sell switch</h4>
+        <p>Command your revenue with a single switch: our stay offer level Stop-Sell lets you instantly pause specific stay packages during emergencies or peak demand.</p>
+        <ul>
+            <li>Open one of your stay offers from the Hotel App.</li>
+            <li>Navigate to the Sales tab. </li>
+            <li>In the eCommerce section, activate the Stop-Sell switch to prevent any further booking to take place from your website.</li>
+        </ul>
+        <div class="o_editor_banner user-select-none o-contenteditable-false lh-1 d-flex align-items-center alert alert-success pb-0 pt-3" data-oe-role="status" contenteditable="false" role="status">
+            <i class="o_editor_banner_icon mb-3 fst-normal" data-oe-aria-label="Banner Success" aria-label="Banner Success">✅</i>
+            <div class="o_editor_banner_content o-contenteditable-true w-100 px-3" contenteditable="true">
+                <p>You can still sell yourself by creating new orders but prevent website visitors to make additional bookings.</p>
+            </div>
+        </div>
         <p>
             <a class="btn btn-secondary"
                 href="https://www.odoo.com/documentation/latest/applications/websites/ecommerce.html">🎓

--- a/hotel/i18n/hotel.pot
+++ b/hotel/i18n/hotel.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 19.0+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-02-17 05:32+0000\n"
-"PO-Revision-Date: 2026-02-17 05:32+0000\n"
+"POT-Creation-Date: 2026-02-26 05:59+0000\n"
+"PO-Revision-Date: 2026-02-26 05:59+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -587,6 +587,14 @@ msgid "Comfort and elegance in every room"
 msgstr ""
 
 #. module: hotel
+#: model_terms:ir.ui.view,arch_db:hotel.welcome_article_body
+msgid ""
+"Command your revenue with a single switch: our stay offer level Stop-Sell "
+"lets you instantly pause specific stay packages during emergencies or peak "
+"demand."
+msgstr ""
+
+#. module: hotel
 #: model_terms:ir.ui.view,arch_db:hotel.homepage
 msgid ""
 "Contemporary design with a touch of sophistication, ensuring a memorable "
@@ -836,6 +844,13 @@ msgid ""
 msgstr ""
 
 #. module: hotel
+#: model_terms:ir.ui.view,arch_db:hotel.welcome_article_body
+msgid ""
+"In the eCommerce section, activate the Stop-Sell switch to prevent any "
+"further booking to take place from your website."
+msgstr ""
+
+#. module: hotel
 #: model_terms:ir.ui.view,arch_db:hotel.homepage
 msgid "Indulge in Our Exquisite Accommodations"
 msgstr ""
@@ -873,6 +888,11 @@ msgstr ""
 #. module: hotel
 #: model_terms:ir.ui.view,arch_db:hotel.homepage
 msgid "Modern rooms equipped with all the amenities for a comfortable stay."
+msgstr ""
+
+#. module: hotel
+#: model_terms:ir.ui.view,arch_db:hotel.welcome_article_body
+msgid "Navigate to the Sales tab."
 msgstr ""
 
 #. module: hotel
@@ -974,6 +994,11 @@ msgstr ""
 msgid ""
 "Open now, the Tasks from the accommodation app, House Keeping menu.<br/>This is\n"
 "                the daily list of house keeping tasks to be tackled."
+msgstr ""
+
+#. module: hotel
+#: model_terms:ir.ui.view,arch_db:hotel.welcome_article_body
+msgid "Open one of your stay offers from the Hotel App."
 msgstr ""
 
 #. module: hotel
@@ -1164,6 +1189,11 @@ msgid "Still from their Rental Order, open the Guests tab."
 msgstr ""
 
 #. module: hotel
+#: model_terms:ir.ui.view,arch_db:hotel.welcome_article_body
+msgid "Stop-sell switch"
+msgstr ""
+
+#. module: hotel
 #: model_terms:ir.ui.view,arch_db:hotel.homepage
 msgid ""
 "Stylish and cozy rooms that provide a perfect retreat after a day of "
@@ -1327,6 +1357,13 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:hotel.welcome_article_body
 msgid ""
 "You can as well select your company and in the Branches tab define branches."
+msgstr ""
+
+#. module: hotel
+#: model_terms:ir.ui.view,arch_db:hotel.welcome_article_body
+msgid ""
+"You can still sell yourself by creating new orders but prevent website "
+"visitors to make additional bookings."
 msgstr ""
 
 #. module: hotel


### PR DESCRIPTION
```
* = [hotel, campsite, guest_house, holiday_house]
```
- This change introduces a new boolean field stop_sell on the product template to control product availability.
- The field is exposed in the product form view for backend users.
- When a product is marked as stop sell, the book button on the website is replaced with a disabled Unavailable state, preventing users from initiating a booking for unavailable products.
- Added a knowledge base note for the Stop-Sell switch in the Hotel, Campsite, Guest House, and Holiday House apps.

Task Id: 5502874