### PR TITLE
[IMP] real_estate: rely on standard prevent_sale instead of custom CTA override

### DIFF
--- a/real_estate/__manifest__.py
+++ b/real_estate/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Real Estate Agency',
-    'version': '1.5',
+    'version': '1.6',
     'category': 'Services',
     'author': 'Odoo S.A.',
     'depends': [
@@ -59,6 +59,7 @@
         'data/website_menu.xml',
         'data/website_theme_apply.xml',
         'data/uninstall_hook.xml',
+        'data/website.xml',
     ],
     'demo': [
         'demo/product_attribute_value.xml',

--- a/real_estate/data/website.xml
+++ b/real_estate/data/website.xml
@@ -1,0 +1,9 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<odoo noupdate="1">
+    <record id="website.default_website" model="website" forcecreate="1">
+        <field name="name">Real Estate Agency</field>
+        <field name="prevent_sale">True</field>
+        <field name="prevent_sale_for">specific_categories</field>
+        <field name="prevent_sale_for_categories" eval="[(4, ref('real_estate.product_public_category_1')), (4, ref('real_estate.product_public_category_2'))]"/>
+    </record>
+</odoo>

--- a/real_estate/data/website_page.xml
+++ b/real_estate/data/website_page.xml
@@ -12,4 +12,10 @@
     <field name="is_published" eval="True"/>
     <field name="url">/contactus</field>
   </record>
+  <record id="website_page_8" model="website.page">
+    <field name="view_id" ref="information_request"/>
+    <field name="website_id" ref="website.default_website"/>
+    <field name="is_published" eval="True"/>
+    <field name="url">/information-request</field>
+  </record>
 </odoo>

--- a/real_estate/data/website_theme_apply.xml
+++ b/real_estate/data/website_theme_apply.xml
@@ -22,8 +22,8 @@
         <value model="ir.ui.view" eval="{'arch': obj().env.ref('real_estate.contactus').arch.replace( 'value=&quot;*salesteam*&quot;', 'value=&quot;%s&quot;' % str( (team := obj().env.ref('sales_team.team_sales_department', raise_if_not_found=False) or obj().env['crm.team'].search([], limit=1) ) and team.id or 0))}"/>
     </function>
     <function model="ir.ui.view" name="write">
-        <value model="ir.ui.view" eval="obj().env.ref('real_estate.ir_ui_view_3249').id"/>
-        <value model="ir.ui.view" eval="{'arch': obj().env.ref('real_estate.ir_ui_view_3249').arch.replace(
+        <value model="ir.ui.view" eval="obj().env.ref('real_estate.information_request').id"/>
+        <value model="ir.ui.view" eval="{'arch': obj().env.ref('real_estate.information_request').arch.replace(
             '*VIP_customer_tag*', str(obj().env.ref('real_estate.crm_team_4').id))
         }"/>
     </function>

--- a/real_estate/data/website_view.xml
+++ b/real_estate/data/website_view.xml
@@ -100,7 +100,7 @@
                                 <span class="s_website_form_label_content">Subject</span>
                                 <span class="s_website_form_mark">          *</span>
                               </label>
-                              <input class="form-control s_website_form_input" type="text" name="name" required="" placeholder="" id="oy7pg7e0vg6c" data-fill-with="undefined"/>
+                              <input class="form-control s_website_form_input" type="text" name="name" id="oy7pg7e0vg6c" data-fill-with="undefined"/>
                             </div>
                             <div data-name="Field" class="s_website_form_field mb-3 col-12 s_website_form_required" data-type="text" data-translated-name="Field">
                               <label class="s_website_form_label" style="width: 250px;" for="o5mtutqkqd9a">
@@ -182,7 +182,7 @@
                             <span class="s_website_form_label_content">Your Name</span>
                             <span class="s_website_form_mark"> *</span>
                           </label>
-                          <input class="form-control s_website_form_input" type="text" name="name" required="" placeholder="" id="opv6ikrbw8i" data-fill-with="name"/>
+                          <input class="form-control s_website_form_input" type="text" name="name" id="opv6ikrbw8i" data-fill-with="name"/>
                         </div>
                         <div data-name="Field" class="s_website_form_field mb-3 col-12 s_website_form_required" data-type="email" data-translated-name="Field">
                           <label class="s_website_form_label" style="width: 500px;" for="o36rnwjacmkt">
@@ -288,124 +288,114 @@
       </t>
     </field>
   </record>
-    <template inherit_id='website_sale.cta_wrapper' id="product" name="rename of add to cart">
-        <xpath expr="//button[@name='add_to_cart']" position="replace">
-            <button
-                name="add_to_cart"
-                id="interested_in_this_property"
-                data-action="add_to_cart"
-                t-attf-class="btn btn-primary flex-grow-1"
-                data-animation-selector=".o_wsale_product_images"
-                t-att-data-product-category-id="product.public_categ_ids.ids and product.public_categ_ids.ids[0]"
-                t-attf-onclick="event.preventDefault(); event.stopImmediatePropagation(); location.href='#Interested-in-this-property';"
-                t-att-data-product-id="product_variant.id"
-                t-att-data-product-template-id="product.id"
-                t-att-data-product-type="product.type"
-                t-att-data-show-quantity="is_view_active('website_sale.product_quantity')"
-            >
-                <i class="fa fa-envelope me-2"/> Contact us
-            </button>
-        </xpath>
-    </template>
-    <template inherit_id='website_sale.product_quantity' id="quantity" name="remove quantity selector">
-      <xpath expr="//div[@id='add_to_cart_wrap']//a[@name='remove_one']" position="replace"></xpath>
-      <xpath expr="//div[@id='add_to_cart_wrap']//input[@name='add_qty']" position="replace"></xpath>
-      <xpath expr="//div[@id='add_to_cart_wrap']//a[hasclass('js_add_cart_json')]" position="replace"></xpath>
-    </template>
-  <record id="ir_ui_view_3249" model="ir.ui.view">
+  <record id="real_estate_cta_contact_us_href_inherit" model="ir.ui.view">
+    <field name="name">real.estate.cta.contact.us.href.inherit</field>
+    <field name="key">real_estate.cta_contact_us_href</field>
+    <field name="active" eval="True"/>
+    <field name="type">qweb</field>
+    <field name="inherit_id" ref="website_sale.cta_wrapper"/>
+    <field name="website_id" ref="website.default_website"/>
     <field name="arch" type="xml">
-      <data>
-        <xpath expr="//*[hasclass('oe_structure')][@id='oe_structure_website_sale_product_2']" position="replace">
-          <div class="oe_structure oe_empty oe_structure_not_nearest mt16" id="oe_structure_website_sale_product_2" data-editor-message="DROP BUILDING BLOCKS HERE TO MAKE THEM AVAILABLE ACROSS ALL PRODUCTS">
-            <section class="s_title_form o_cc o_cc2 pt64 o_colored_level pb56" data-snippet="s_title_form" data-name="Title - Form" id="Interested-in-this-property" data-anchor="true">
-              <div class="o_container_small">
-                <h2 class="text-center">Interested in this property?</h2>
-                <p class="text-center lead">Get in touch with your customers to provide them with better service. You can modify the form fields to gather more precise information.</p>
-                <section class="s_website_form pt16 pb16" data-vcss="001" data-snippet="s_website_form" data-name="Form">
-                  <div class="container-fluid">
-                    <form action="/website/form/" method="post" enctype="multipart/form-data" class="o_mark_required" data-mark="*" data-pre-fill="true" data-model_name="crm.lead" data-success-mode="redirect" data-success-page="/contactus-thank-you">
-                      <div class="s_website_form_rows row s_col_no_bgcolor">
-                        <div data-name="Field" class="s_website_form_field mb-3 col-12 s_website_form_required" data-type="char" data-translated-name="Field">
-                          <label class="s_website_form_label" style="width: 200px" for="owyz4lqydmnd">
-                            <span class="s_website_form_label_content">Your Name</span>
-                            <span class="s_website_form_mark">      *</span>
-                          </label>
-                          <input class="form-control s_website_form_input" type="text" name="contact_name" required="1" placeholder="" id="owyz4lqydmnd" data-fill-with="name"/>
-                        </div>
-                        <div data-name="Field" class="s_website_form_field mb-3 col-12" data-type="tel" data-translated-name="Field">
-                          <label class="s_website_form_label" style="width: 200px" for="osp0at6i4gxn">
-                            <span class="s_website_form_label_content">Phone Number</span>
-                          </label>
-                          <input class="form-control s_website_form_input" type="tel" name="phone" placeholder="" id="osp0at6i4gxn" data-fill-with="phone"/>
-                        </div>
-                        <div data-name="Field" class="s_website_form_field mb-3 col-12 s_website_form_required" data-type="email" data-translated-name="Field">
-                          <label class="s_website_form_label" style="width: 200px" for="otrdrv4m744">
-                            <span class="s_website_form_label_content">Your Email</span>
-                            <span class="s_website_form_mark">      *</span>
-                          </label>
-                          <input class="form-control s_website_form_input" type="email" name="email_from" required="1" placeholder="" id="otrdrv4m744" data-fill-with="email"/>
-                        </div>
-                        <div data-name="Field" class="s_website_form_field mb-3 col-12 s_website_form_field_hidden" data-type="char" data-translated-name="Field">
-                          <label class="s_website_form_label" style="width: 200px" for="otpj9zeau4p">
-                            <span class="s_website_form_label_content">Your Company</span>
-                            <span class="s_website_form_mark">        *</span>
-                          </label>
-                          <input class="form-control s_website_form_input" type="text" name="partner_name" placeholder="" id="otpj9zeau4p" data-fill-with="commercial_company_name"/>
-                        </div>
-                        <div data-name="Field" class="s_website_form_field mb-3 col-12 s_website_form_model_required" data-type="char" data-translated-name="Field">
-                          <label class="s_website_form_label" style="width: 200px" for="otw2ya2767a">
-                            <span class="s_website_form_label_content">Subject</span>
-                            <span class="s_website_form_mark">    *</span>
-                          </label>
-                          <input class="form-control s_website_form_input" type="text" name="name" required="" placeholder="" id="otw2ya2767a" data-fill-with="undefined"/>
-                        </div>
-                        <div hidden="true" data-name="Field" class="s_website_form_field mb-3 col-12" data-type="many2one" data-translated-name="Field">
-                          <label class="s_website_form_label" style="width: 200px" for="oy78fiy08x2q">
-                            <span class="s_website_form_label_content">Product</span>
-                          </label>
-                          <select class="form-select s_website_form_input" name="x_interested_in_id" id="oy78fiy08x2q">
-                            <option id="oy78fiy08x2q0" t-att-value="product.id" selected="selected">Default product</option>
-                          </select>
-                        </div>
-                        <div data-name="Field" class="s_website_form_field mb-3 col-12 s_website_form_required" data-type="text" data-translated-name="Field">
-                          <label class="s_website_form_label" style="width: 200px" for="oycerkkna0l9">
-                            <span class="s_website_form_label_content">Your Question</span>
-                            <span class="s_website_form_mark">      *</span>
-                          </label>
-                          <textarea class="form-control s_website_form_input" name="description" required="1" placeholder="" id="oycerkkna0l9" rows="3"/>
-                        </div>
-                        <div data-name="Field" class="s_website_form_field mb-3 col-12 s_website_form_dnone">
-                          <div class="row s_col_no_resize s_col_no_bgcolor">
-                            <label class="col-form-label col-sm-auto s_website_form_label" style="width: 200px">
-                              <span class="s_website_form_label_content"/>
-                            </label>
-                            <div class="col-sm">
-                              <input type="hidden" class="form-control s_website_form_input" name="team_id" value="*VIP_customer_tag*"/>
-                            </div>
-                          </div>
-                        </div>
-                        <div class="mb-0 py-2 col-12 s_website_form_submit text-center s_website_form_no_submit_label" data-name="Submit Button">
-                          <div style="width: 200px;" class="s_website_form_label"/>
-                          <span id="s_website_form_result"/>
-                          <a href="#" role="button" class="btn btn-primary s_website_form_send">Submit</a>
-                        </div>
-                      </div>
-                    </form>
-                  </div>
-                </section>
-              </div>
-            </section>
-          </div>
-        </xpath>
-      </data>
+      <xpath expr="//div[@id='contact_us_wrapper']/a" position="replace">
+        <a t-attf-href="/information-request?product_id=#{product.id}"
+          class="btn btn-primary flex-grow-1 w-100">
+          Contact Us
+        </a>
+      </xpath>
     </field>
-    <field name="inherit_id" ref="website_sale.product"/>
-    <field name="key">website_sale.product_oe_structure_website_sale_product_2</field>
-    <field name="mode">extension</field>
-    <field name="name">Interest form</field>
+  </record>
+  <record id="information_request" model="ir.ui.view">
+    <field name="name">Information Request</field>
+    <field name="key">real_estate.information_request</field>
     <field name="active" eval="True"/>
     <field name="type">qweb</field>
     <field name="website_id" ref="website.default_website"/>
+    <field name="arch" type="xml">
+      <t name="Information Request" t-name="website.information_request">
+        <t t-call="website.layout" logged_partner="request.env['website.visitor']._get_visitor_from_request().partner_id">
+          <t t-set="contactus_form_values" t-value="{ 'name': request.params.get('subject', ''),             'x_interested_in_id':request.params.get('product_id'),             }"/>
+          <span class="hidden" data-for="contactus_form" t-att-data-values="contactus_form_values"/>
+          <div id="wrap" class="oe_structure oe_empty">
+              <section class="s_title_form o_cc o_cc2 pt64 o_colored_level pb56" data-snippet="s_title_form" data-name="Title - Form" id="Interested-in-this-property" data-anchor="true">
+                <div class="o_container_small">
+                  <h2 class="text-center">Interested in this property?</h2>
+                  <p class="text-center lead">Get in touch with your customers to provide them with better service. You can modify the form fields to gather more precise information.</p>
+                  <section class="s_website_form pt16 pb16" data-vcss="001" data-snippet="s_website_form" data-name="Form">
+                    <div class="container-fluid">
+                      <form id="contactus_form" action="/website/form/" method="post" enctype="multipart/form-data" class="o_mark_required" data-mark="*" data-pre-fill="true" data-model_name="crm.lead" data-success-mode="redirect" data-success-page="/contactus-thank-you">
+                        <div class="s_website_form_rows row s_col_no_bgcolor">
+                          <div data-name="Field" class="s_website_form_field mb-3 col-12 s_website_form_required" data-type="char" data-translated-name="Field">
+                            <label class="s_website_form_label" style="width: 200px" for="owyz4lqydmnd">
+                              <span class="s_website_form_label_content">Your Name</span>
+                              <span class="s_website_form_mark">      *</span>
+                            </label>
+                            <input class="form-control s_website_form_input" type="text" name="contact_name" required="1" placeholder="" id="owyz4lqydmnd" data-fill-with="name"/>
+                          </div>
+                          <div data-name="Field" class="s_website_form_field mb-3 col-12" data-type="tel" data-translated-name="Field">
+                            <label class="s_website_form_label" style="width: 200px" for="osp0at6i4gxn">
+                              <span class="s_website_form_label_content">Phone Number</span>
+                            </label>
+                            <input class="form-control s_website_form_input" type="tel" name="phone" placeholder="" id="osp0at6i4gxn" data-fill-with="phone"/>
+                          </div>
+                          <div data-name="Field" class="s_website_form_field mb-3 col-12 s_website_form_required" data-type="email" data-translated-name="Field">
+                            <label class="s_website_form_label" style="width: 200px" for="otrdrv4m744">
+                              <span class="s_website_form_label_content">Your Email</span>
+                              <span class="s_website_form_mark">      *</span>
+                            </label>
+                            <input class="form-control s_website_form_input" type="email" name="email_from" required="1" placeholder="" id="otrdrv4m744" data-fill-with="email"/>
+                          </div>
+                          <div data-name="Field" class="s_website_form_field mb-3 col-12 s_website_form_field_hidden" data-type="char" data-translated-name="Field">
+                            <label class="s_website_form_label" style="width: 200px" for="otpj9zeau4p">
+                              <span class="s_website_form_label_content">Your Company</span>
+                              <span class="s_website_form_mark">        *</span>
+                            </label>
+                            <input class="form-control s_website_form_input" type="text" name="partner_name" placeholder="" id="otpj9zeau4p" data-fill-with="commercial_company_name"/>
+                          </div>
+                          <div data-name="Field" class="s_website_form_field mb-3 col-12 s_website_form_model_required" data-type="char" data-translated-name="Field">
+                            <label class="s_website_form_label" style="width: 200px" for="otw2ya2767a">
+                              <span class="s_website_form_label_content">Subject</span>
+                              <span class="s_website_form_mark">    *</span>
+                            </label>
+                            <input class="form-control s_website_form_input" type="text" name="name" id="otw2ya2767a" data-fill-with="name"/>
+                          </div>
+                          <div data-name="Field" class="s_website_form_field_hidden mb-3 col-12" data-type="char" data-translated-name="Field">
+                            <label class="s_website_form_label" style="width: 200px" for="oy78fiy08x2q">
+                              <span class="s_website_form_label_content">Product</span>
+                            </label>
+                            <input class="form-control s_website_form_input" type="text" name="x_interested_in_id" required="1" id="oy78fiy08x2q" data-fill-with="x_interested_in_id"/>
+                          </div>
+                          <div data-name="Field" class="s_website_form_field mb-3 col-12 s_website_form_required" data-type="text" data-translated-name="Field">
+                            <label class="s_website_form_label" style="width: 200px" for="oycerkkna0l9">
+                              <span class="s_website_form_label_content">Your Question</span>
+                              <span class="s_website_form_mark">      *</span>
+                            </label>
+                            <textarea class="form-control s_website_form_input" name="description" required="1" placeholder="" id="oycerkkna0l9" rows="3"/>
+                          </div>
+                          <div data-name="Field" class="s_website_form_field mb-3 col-12 s_website_form_dnone">
+                            <div class="row s_col_no_resize s_col_no_bgcolor">
+                              <label class="col-form-label col-sm-auto s_website_form_label" style="width: 200px">
+                                <span class="s_website_form_label_content"/>
+                              </label>
+                              <div class="col-sm">
+                                <input type="hidden" class="form-control s_website_form_input" name="team_id" value="*VIP_customer_tag*"/>
+                              </div>
+                            </div>
+                          </div>
+                          <div class="mb-0 py-2 col-12 s_website_form_submit text-center s_website_form_no_submit_label" data-name="Submit Button">
+                            <div style="width: 200px;" class="s_website_form_label"/>
+                            <span id="s_website_form_result"/>
+                            <a href="#" role="button" class="btn btn-primary s_website_form_send">Submit</a>
+                          </div>
+                        </div>
+                      </form>
+                    </div>
+                  </section>
+                </div>
+              </section>
+          </div>
+        </t>
+      </t>
+    </field>
   </record>
   <record id="ir_ui_view_3022" model="ir.ui.view">
     <field name="inherit_id" ref="website_sale.header_cart_link"/>

--- a/real_estate/demo/website.xml
+++ b/real_estate/demo/website.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-    <record id="website.default_website" model="website" forcecreate="1">
+    <record id="website.default_website" model="website" forcecreate="0">
         <field name="name">Real Estate Agency</field>
         <field name="configurator_done" eval="True"/>
         <field name="logo" type="base64" file="real_estate/static/description/icon.png"/>


### PR DESCRIPTION
The custom add-to-cart button override was removed and replaced by the standard website prevent_sale configuration for specific public product categories.

task - 5943972