### PR TITLE
[IMP] construction_developer: versatile work items pricing

### DIFF
--- a/construction_developer/__manifest__.py
+++ b/construction_developer/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Construction Developer',
-    'version': '1.9',
+    'version': '1.10',
     'category': 'Construction',
     'depends': [
         'base_industry_data',

--- a/construction_developer/data/base_automation.xml
+++ b/construction_developer/data/base_automation.xml
@@ -63,6 +63,32 @@
         <field name="name">Construction: Work Item - On save and unit cost/price change</field>
         <field name="trigger_field_ids" eval="[(6, 0, [ref('x_unit_cost_field_x_work_item'), ref('x_unit_price_field_x_work_item')])]"/>
     </record>
+    <record id="base_automation_product_product_on_write_unit_cost_price_change" model="base.automation">
+        <field name="model_id" ref="product.model_product_product" />
+        <field name="action_server_ids"
+            eval="[(6, 0, [ref('server_action_update_related_work_item_lines')])]" />
+        <field name="trigger">on_create_or_write</field>
+        <field name="name">Construction: Work Item - On save and cost/price change</field>
+        <field name="trigger_field_ids" eval="[(6, 0, [ref('product.field_product_product__lst_price'), ref('product.field_product_product__standard_price')])]"/>
+    </record>
+    <record id="base_automation_work_item_on_write_unit_price_when_margin_fixed" model="base.automation">
+        <field name="model_id" ref="x_work_item_model" />
+        <field name="action_server_ids"
+            eval="[(6, 0, [ref('server_action_update_margin_if_margin_fixed')])]" />
+        <field name="trigger">on_create_or_write</field>
+        <field name="filter_domain">[("x_is_margin_fixed", "=", True)]</field>
+        <field name="name">Construction: Work Item - On save and unit price change</field>
+        <field name="trigger_field_ids" eval="[(6, 0, [ref('x_unit_price_field_x_work_item')])]"/>
+    </record>
+    <record id="base_automation_work_item_on_write_unit_margin_or_cost_when_margin_fixed" model="base.automation">
+        <field name="model_id" ref="x_work_item_model" />
+        <field name="action_server_ids"
+            eval="[(6, 0, [ref('server_action_update_price_if_margin_fixed')])]" />
+        <field name="trigger">on_create_or_write</field>
+        <field name="filter_domain">[("x_is_margin_fixed", "=", True)]</field>
+        <field name="name">Construction: Work Item - On save and unit margin or cost change</field>
+        <field name="trigger_field_ids" eval="[(6, 0, [ref('x_unit_margin_field_x_work_item'), ref('x_unit_cost_field_x_work_item')])]"/>
+    </record>
     <record id="base_automation_work_item_on_write" model="base.automation">
         <field name="model_id" ref="x_work_item_model" />
         <field name="action_server_ids"
@@ -86,6 +112,15 @@
         <field name="trigger">on_create_or_write</field>
         <field name="filter_domain">[('x_is_template', '!=', False), ('x_product_id', '=', False)]</field>
         <field name="name">Construction: Work Item - On save of work item template without product</field>
+    </record>
+    <record id="base_automation_on_write_wi_margin_fixed_to_false" model="base.automation">
+        <field name="model_id" ref="x_work_item_model" />
+        <field name="action_server_ids"
+            eval="[(6, 0, [ref('server_action_recompute_price_with_components_prices')])]" />
+        <field name="trigger">on_create_or_write</field>
+        <field name="name">Construction: Work Item - On Margin Fixed write to False</field>
+        <field name="trigger_field_ids" eval="[(6, 0, [ref('x_is_margin_fixed_field_x_work_item')])]"/>
+        <field name="filter_domain">[('x_is_margin_fixed', '=', False)]</field>
     </record>
     <!-- 
     this is needed to set a default stage based on the project's

--- a/construction_developer/data/ir_actions_act_window.xml
+++ b/construction_developer/data/ir_actions_act_window.xml
@@ -13,6 +13,20 @@
         <field name="res_model">x_work_item</field>
         <field name="context">{'search_default_x_active': True}</field>
     </record>
+    <record id="action_window_see_work_items_from_product_template" model="ir.actions.act_window">
+        <field name="name">Work Items</field>
+        <field name="domain">[('x_is_template', '=', True), ('x_work_item_line_ids.x_product_id.product_tmpl_id', '=', active_id)]</field>
+        <field name="res_model">x_work_item</field>
+        <field name="view_mode">list,form</field>
+        <field name="context">{'search_default_x_active': True}</field>
+    </record>
+    <record id="action_window_see_work_items_from_product_product" model="ir.actions.act_window">
+        <field name="name">Work Items</field>
+        <field name="domain">[('x_is_template', '=', True), ('x_work_item_line_ids.x_product_id', '=', active_id)]</field>
+        <field name="res_model">x_work_item</field>
+        <field name="view_mode">list,form</field>
+        <field name="context">{'search_default_x_active': True}</field>
+    </record>
     <record id="action_window_add_work_item" model="ir.actions.act_window">
         <field name="name">Add Work Item</field>
         <field name="domain">[('x_active', '=', True),('x_is_template', '=', True)]</field>

--- a/construction_developer/data/ir_actions_server.xml
+++ b/construction_developer/data/ir_actions_server.xml
@@ -124,6 +124,16 @@ record.write({'x_name': record.x_product_id.name})
 record.write({'x_unit_price': record.x_product_id.list_price, 'x_unit_cost': record.x_product_id.standard_price})
 ]]></field>
     </record>
+    <record id="server_action_update_related_work_item_lines" model="ir.actions.server">
+        <field name="name">Construction: Work Item - Update related wi lines on product cost/price change</field>
+        <field name="model_id" ref="product.model_product_product"/>
+        <field name="state">code</field>
+        <field name="code"><![CDATA[
+wil = env['x_work_item_line'].search([('x_product_id', 'in', records.ids), ('x_work_item_id.x_is_template', '=', True)])
+for product in records:
+    wil.filtered(lambda line: line.x_product_id == product).write({'x_unit_price': product.list_price, 'x_unit_cost': product.standard_price})
+]]></field>
+    </record>
     <record id="server_action_update_product_cost" model="ir.actions.server">
         <field name="name">Construction: Work Item - Update product cost</field>
         <field name="model_id" ref="x_work_item_model"/>
@@ -144,16 +154,44 @@ record.write({'x_unit_price': record.x_product_id.list_price, 'x_unit_cost': rec
         <field name="evaluation_type">equation</field>
         <field name="value"><![CDATA[record.x_unit_price]]></field>
     </record>
+    <record id="server_action_update_margin_if_margin_fixed" model="ir.actions.server">
+        <field name="name">Construction: Work Item - Update margin on price change if margin is fixed</field>
+        <field name="model_id" ref="x_work_item_model" />
+        <field name="state">code</field>
+        <field name="code"><![CDATA[
+for wi in records:
+    wi['x_unit_margin'] = (wi.x_unit_price - wi.x_unit_cost) / wi.x_unit_cost if wi.x_unit_cost > 0 else False
+]]></field>
+    </record>
+    <record id="server_action_update_price_if_margin_fixed" model="ir.actions.server">
+        <field name="name">Construction: Work Item - Update price on margin/cost change if margin is fixed</field>
+        <field name="model_id" ref="x_work_item_model" />
+        <field name="state">code</field>
+        <field name="code"><![CDATA[
+for wi in records:
+    wi['x_unit_price'] = wi.x_unit_cost * (1 + wi.x_unit_margin)
+]]></field>
+    </record>
+    <record id="server_action_recompute_price_with_components_prices" model="ir.actions.server">
+        <field name="name">Construction: Work Item - Recompute price</field>
+        <field name="model_id" ref="x_work_item_model" />
+        <field name="state">code</field>
+        <field name="code"><![CDATA[
+for wi in records:
+    wi['x_unit_price'] = sum(line.x_unit_price * line.x_quantity for line in wi.x_work_item_line_ids)
+]]></field>
+    </record>
     <record id="server_action_set_work_item_as_template" model="ir.actions.server">
         <field name="name">Construction: Work Item - Set as template</field>
         <field name="model_id" ref="x_work_item_model" />
         <field name="state">code</field>
         <field name="code"><![CDATA[
-record.copy(default={'x_sale_order_line_id': False, 'x_is_template': True, 'x_targeted_so_id': False})
+for wi in records:
+    wi.copy(default={'x_sale_order_line_id': False, 'x_is_template': True, 'x_targeted_so_id': False})
 action = {
     'type': 'ir.actions.client',
     'tag': 'display_notification',
-    'params': {'message': record.x_name + " template saved.", 'type': 'success'},
+    'params': {'message': ', '.join(wi.x_name for wi in records) + " template saved.", 'type': 'success'},
 }
 ]]></field>
     </record>

--- a/construction_developer/data/ir_model_fields.xml
+++ b/construction_developer/data/ir_model_fields.xml
@@ -322,7 +322,7 @@ for record in self:
     record['x_unit_cost'] = sum(line.x_unit_cost * line.x_quantity for line in record.x_work_item_line_ids)
 ]]></field>
         <field name="ttype">monetary</field>
-        <field name="depends">x_work_item_line_ids</field>
+        <field name="depends">x_work_item_line_ids.x_unit_cost,x_work_item_line_ids.x_quantity</field>
         <field name="field_description">Unit Cost</field>
         <field name="model_id" ref="x_work_item_model"/>
         <field name="readonly" eval="True"/>
@@ -332,27 +332,32 @@ for record in self:
         <field name="name">x_unit_price</field>
         <field name="compute"><![CDATA[
 for record in self:
-    record['x_unit_price'] = sum(line.x_unit_price * line.x_quantity for line in record.x_work_item_line_ids)
+    if not record.x_is_margin_fixed:
+        record['x_unit_price'] = sum(line.x_unit_price * line.x_quantity for line in record.x_work_item_line_ids)
 ]]></field>
         <field name="ttype">monetary</field>
-        <field name="depends">x_work_item_line_ids</field>
+        <field name="depends">x_work_item_line_ids.x_unit_price,x_work_item_line_ids.x_quantity</field>
         <field name="field_description">Unit Price</field>
         <field name="model_id" ref="x_work_item_model"/>
-        <field name="readonly" eval="True"/>
         <field name="currency_field">x_currency_id</field>
     </record>
     <record id="x_unit_margin_field_x_work_item" model="ir.model.fields">
         <field name="name">x_unit_margin</field>
         <field name="compute"><![CDATA[
 for record in self:
-    record['x_unit_margin'] = (record.x_unit_price - record.x_unit_cost) / record.x_unit_price if record.x_unit_price > 0 else False
+    if not record.x_is_margin_fixed:
+        record['x_unit_margin'] = (record.x_unit_price - record.x_unit_cost) / record.x_unit_cost if record.x_unit_cost > 0 else False
 ]]></field>
         <field name="ttype">float</field>
         <field name="depends">x_unit_price,x_unit_cost</field>
         <field name="field_description">Unit Margin</field>
         <field name="model_id" ref="x_work_item_model"/>
-        <field name="readonly" eval="True"/>
-        <field name="store" eval="False"/>
+    </record>
+    <record id="x_is_margin_fixed_field_x_work_item" model="ir.model.fields">
+        <field name="name">x_is_margin_fixed</field>
+        <field name="ttype">boolean</field>
+        <field name="field_description">Fixed</field>
+        <field name="model_id" ref="x_work_item_model"/>
     </record>
 
     <record id="x_line_work_item_id_field_sale_order_line" model="ir.model.fields">
@@ -377,6 +382,32 @@ for record in self:
         <field name="readonly" eval="True"/>
         <field name="relation">x_work_item</field>
         <field name="store" eval="False"/>
+    </record>
+    <record id="x_x_product_template_x_work_items_count_field_product_template" model="ir.model.fields">
+        <field name="compute"><![CDATA[
+for record in self:
+    record['x_x_product_template_x_work_items_count'] = record.env['x_work_item'].search_count([('x_is_template', '=', True), ('x_work_item_line_ids.x_product_id.product_tmpl_id', '=', record.id)])
+]]>    </field>
+        <field name="ttype">integer</field>
+        <field name="field_description">Template Work items count</field>
+        <field name="model_id" ref="product.model_product_template"/>
+        <field name="name">x_x_product_template_x_work_items_count</field>
+        <field name="selectable" eval="False"/>
+        <field name="store" eval="False"/>
+        <field name="readonly" eval="True"/>
+    </record>
+    <record id="x_x_product_product_x_work_items_count_field_product_product" model="ir.model.fields">
+        <field name="compute"><![CDATA[
+for record in self:
+    record['x_x_product_product_x_work_items_count'] = record.env['x_work_item'].search_count([('x_is_template', '=', True), ('x_work_item_line_ids.x_product_id', '=', record.id)])
+]]>    </field>
+        <field name="ttype">integer</field>
+        <field name="field_description">Product Work items count</field>
+        <field name="model_id" ref="product.model_product_product"/>
+        <field name="name">x_x_product_product_x_work_items_count</field>
+        <field name="selectable" eval="False"/>
+        <field name="store" eval="False"/>
+        <field name="readonly" eval="True"/>
     </record>
     <record id="x_product_wi_template_id_field_x_work_item" model="ir.model.fields">
         <field name="ttype">many2one</field>

--- a/construction_developer/data/ir_ui_view.xml
+++ b/construction_developer/data/ir_ui_view.xml
@@ -79,7 +79,7 @@
             <xpath expr="//notebook//page[@name='order_lines']//list//field[@name='tax_ids']" position="attributes">
                 <attribute name="width">150px</attribute>
             </xpath>
-            <xpath expr="//notebook//page[@name='other_information']//field[@name='invoice_status']" position="after">
+            <xpath expr="//notebook//page[@name='other_information']//field[@name='team_id']" position="after">
                 <field name="x_so_contract_type" readonly="state == 'sale'"/>
             </xpath>
             <xpath expr="//notebook//page[@name='order_lines']//list//field[@name='tax_ids']" position="after">
@@ -150,16 +150,22 @@
                     <group>
                         <field name="x_product_id" force_save="1" readonly="not x_is_template" invisible="x_targeted_so_id" context="{'default_type': 'service'}"/>
                         <field name="x_reference" readonly="id and not x_is_template"/>
-                        <label for="x_unit_id"/>
-                        <div class="d-flex" name="unit_quantity">
-                            <field name="x_unit_id" class="oe_inline" string="Unit" force_save="1" options="{'no_open': True}" placeholder="m²" invisible="not x_product_id"/>
-                            <field name="x_unit_custom_id" class="oe_inline" string="Unit" force_save="1" options="{'no_open': True}" placeholder="m²" invisible="x_product_id" required="not x_product_id"/>
-                        </div>
+                        <field name="x_unit_id" force_save="1" options="{'no_open': True}" placeholder="m²" invisible="not x_product_id"/>
+                        <field name="x_unit_custom_id" string="Unit" force_save="1" options="{'no_open': True}" placeholder="m²" invisible="x_product_id" required="not x_product_id"/>
                     </group>
                     <group>
                         <field name="x_unit_cost" widget="monetary" force_save="1" readonly="True"/>
-                        <field name="x_unit_price" widget="monetary" force_save="1" readonly="True"/>
-                        <field name="x_unit_margin" widget="percentage" force_save="1" readonly="True"/>
+                        <label for="x_unit_price"/>
+                        <div class="o_row">
+                            <field name="x_unit_price" class="oe_inline mw-50" widget="monetary" force_save="1" readonly="not x_is_margin_fixed"/>
+                            <button type="action" class="btn btn-secondary oe_inline" name="%(server_action_recompute_price_with_components_prices)d" invisible="not x_is_margin_fixed" string="Recompute" help="Recomputes the unit price based on components"/>
+                        </div>
+                        <label for="x_unit_margin"/>
+                        <div class="o_row">
+                            <field name="x_unit_margin" widget="percentage" class="oe_inline mw-50" force_save="1" readonly="not x_is_margin_fixed"/>
+                            <label for="x_is_margin_fixed"/>
+                            <field name="x_is_margin_fixed" class="oe_inline" force_save="1" help="When set, unit price is computed based on unit margin"/>
+                        </div>
                     </group>
                 </group>
                 <notebook>
@@ -282,6 +288,21 @@
         <field name="active" eval="True"/>
         <field name="type">form</field>
         <field name="arch" type="xml">
+            <button name="action_view_sales" position="after">
+                <button
+                    class="oe_stat_button"
+                    name="%(action_window_see_work_items_from_product_template)d"
+                    type="action" icon="fa-magic"
+                    invisible="x_x_product_template_x_work_items_count == 0"
+                >
+                    <div class="o_field_widget o_stat_info">
+                        <span class="o_stat_value d-flex gap-1">
+                            <field name="x_x_product_template_x_work_items_count" widget="statinfo" nolabel="1" class="oe_inline"/>
+                        </span>
+                        <span class="o_stat_text">Work Items</span>
+                    </div>
+                </button>
+            </button>
             <xpath expr="//form/sheet/*[1]" position="before">
                 <div class="alert alert-warning text-center o_form_header" invisible="x_uom_matches_category" role="alert">
                     <a class="close" data-bs-dismiss="alert" href="#">x</a>
@@ -294,6 +315,33 @@
                 </div>
             </xpath>
         </field>
+    </record>
+
+    <record id="product_product_form_view_extension" model="ir.ui.view">
+        <field name="arch" type="xml">
+            <button name="action_view_sales" position="after">
+                <button
+                    class="oe_stat_button"
+                    name="%(action_window_see_work_items_from_product_product)d"
+                    type="action" icon="fa-magic"
+                    invisible="x_x_product_product_x_work_items_count == 0"
+                >
+                    <div class="o_field_widget o_stat_info">
+                        <span class="o_stat_value d-flex gap-1">
+                            <field name="x_x_product_product_x_work_items_count" widget="statinfo" nolabel="1" class="oe_inline"/>
+                        </span>
+                        <span class="o_stat_text">Work Items</span>
+                    </div>
+                </button>
+            </button>
+        </field>
+        <field name="inherit_id" ref="sale.product_form_view_sale_order_button"/>
+        <field name="mode">extension</field>
+        <field name="model">product.product</field>
+        <field name="name">product.product.form.inherit.view</field>
+        <field name="priority">1600</field>
+        <field name="type">form</field>
+        <field name="active" eval="True"/>
     </record>
 
 <!-- remark -->

--- a/tests/test_construction_developer/tests/__init__.py
+++ b/tests/test_construction_developer/tests/__init__.py
@@ -2,3 +2,4 @@
 
 from . import test_cost_nature_analysis_report
 from . import test_cost_nature_analysis_report_tour
+from . import test_action_server

--- a/tests/test_construction_developer/tests/test_action_server.py
+++ b/tests/test_construction_developer/tests/test_action_server.py
@@ -1,0 +1,88 @@
+from odoo.tests.common import TransactionCase
+from odoo.tests import Form, tagged
+
+
+@tagged('post_install', '-at_install')
+class ActionServerTestCase(TransactionCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.partner_1 = cls.env['res.partner'].create({'name': 'Test Partner 1'})
+        cls.test_product = cls.env['product.product'].create({'name': 'Test Product'})
+        cls.uom_1 = cls.env['uom.uom'].create({'name': 'Unit of Measure 1', 'rounding': 0.01})
+        cls.test_template_work_item = cls.env['x_work_item'].create({
+            'x_is_template': True,
+            'x_product_id': cls.test_product.id,
+            'x_name': cls.test_product.name,
+        })
+
+    def test_create_work_item_for_sale_order(self):
+        test_sale_order_1 = self.env['sale.order'].create({
+            'partner_id': self.partner_1.id,
+        })
+        new_work_item = self.env['x_work_item'].create({
+            'x_is_template': False,
+            'x_name': "Test work item on sol",
+            'x_targeted_so_id': test_sale_order_1.id,
+            'x_unit_custom_id': self.uom_1.id,
+        })
+        self.assertTrue(new_work_item.x_product_id, "A new product should be created and assigned to this work item after creating it")
+        self.assertEqual(new_work_item.x_unit_id.id, self.uom_1.id, "The unit in work item should be the one assigned to the temporary field when creating the work item")
+
+    def test_keeping_last_wi_template_created(self):
+        self.assertTrue(self.test_template_work_item.x_active, "The work item template should be active after being created")
+        self.assertEqual(self.test_product.x_work_item_template_id.id, self.test_template_work_item.id, "The work item template registered on the product should be the last template created")
+        self.test_template_work_item_2 = self.env['x_work_item'].create({
+            'x_is_template': True,
+            'x_product_id': self.test_product.id,
+            'x_name': self.test_product.name,
+        })
+        self.assertFalse(self.test_template_work_item.x_active, "The old work item template should be inactive after the new one is created")
+        self.assertTrue(self.test_template_work_item_2.x_active, "The new work item template should be active after being created")
+        self.test_product._invalidate_cache()
+        self.assertEqual(self.test_product.x_work_item_template_id.id, self.test_template_work_item_2.id, "The work item template registered on the product should be the last template created")
+
+    def test_wi_prices_correctly_computed(self):
+        component_product_1 = self.env['product.product'].create({
+            'name': 'Component Product 1',
+            'lst_price': 15,
+            'standard_price': 7.5,
+        })
+        component_product_2 = self.env['product.product'].create({
+            'name': 'Component Product 2',
+            'lst_price': 40,
+            'standard_price': 20,
+        })
+        wi_form = Form(self.test_template_work_item)
+        with wi_form.x_work_item_line_ids.new() as wi_line:
+            wi_line.x_product_id = component_product_1
+            wi_line.x_quantity = 4
+        with wi_form.x_work_item_line_ids.new() as wi_line:
+            wi_line.x_product_id = component_product_2
+        wi_form.save()
+        test_template_work_item_lines = self.test_template_work_item.x_work_item_line_ids
+        self.assertEqual(test_template_work_item_lines[0].x_unit_cost, 7.5, "Assignation error: The first work item line should have a cost of 7.5")
+        self.assertEqual(test_template_work_item_lines[0].x_unit_price, 15.0, "Assignation error: The first work item line should have a price of 15.0")
+        self.assertEqual(test_template_work_item_lines[1].x_unit_cost, 20.0, "Assignation error: The second work item line should have a cost of 20.0")
+        self.assertEqual(test_template_work_item_lines[1].x_unit_price, 40.0, "Assignation error: The second work item line should have a price of 40.0")
+        self.assertEqual(self.test_template_work_item.x_unit_cost, 50.0, "The cost of work item is not computed correctly: it should be the sum of the product of components costs by quantity")
+        self.assertEqual(self.test_template_work_item.x_unit_price, 100.0, "The price of work item is not computed correctly: it should be the sum of the product of components prices by quantity")
+        self.assertEqual(self.test_template_work_item.x_unit_margin, 1.0, "The margin of work item is not computed correctly: it should be equal to 1.0 at this point")
+        test_template_work_item_lines[0].x_unit_cost = 20
+        self.assertEqual(self.test_template_work_item.x_unit_cost, 100.0, "The cost of work item is not recomputed correctly when the cost of a component changes")
+        self.assertEqual(self.test_template_work_item.x_unit_price, 100.0, "The price of work item changes when the cost of a component changes but it should not happen")
+        self.assertEqual(self.test_template_work_item.x_unit_margin, 0.0, "The margin of work item is not correct after the cost of a component changes: it should be recomputed to represent the new value")
+        test_template_work_item_lines[1].x_unit_price = 240
+        self.assertEqual(self.test_template_work_item.x_unit_cost, 100.0, "The cost of work item changes after the price of a component changes while it should not happen")
+        self.assertEqual(self.test_template_work_item.x_unit_price, 300.0, "The price of work item is not recomputed correctly when the price of a component changes")
+        self.assertEqual(self.test_template_work_item.x_unit_margin, 2.0, "The margin of work item is not correct after the price of a component changes: it should be recomputed to represent the new value")
+        self.test_template_work_item.x_is_margin_fixed = True
+        self.test_template_work_item.x_unit_price = 200
+        self.assertEqual(self.test_template_work_item.x_unit_margin, 1.0, "When margin is fixed, the margin should be recomputed if we change manually the price of work item")
+        self.test_template_work_item.x_unit_margin = 0.5
+        self.assertEqual(self.test_template_work_item.x_unit_price, 150.0, "When margin is fixed, the price should be recomputed if we change manually the margin of work item")
+        test_template_work_item_lines[1].x_unit_cost = 10
+        self.assertEqual(self.test_template_work_item.x_unit_margin, 0.5, "When margin is fixed, the margin of work item should stay the same when the cost of a component changes")
+        self.assertEqual(self.test_template_work_item.x_unit_cost, 90.0, "When margin is fixed, the cost of work item should be recomputed when the cost of a component changes")
+        self.assertEqual(self.test_template_work_item.x_unit_price, 135.0, "When margin is fixed, the price of work item should be recomputed when the cost of a component changes")


### PR DESCRIPTION
Improves the work item model with the possibility to manage prices manually.
Before this PR, every work item had their cost and price defined as the sum of their components costs and prices.
Now, this works as before but we can check the fixed checkbox next to the margin to enable an alternative behavior:
Input manually a fixed margin or a fixed price. This margin is kept and impacts the price when the cost of components changes.

A second commit in this pr adds some tests for the construction module: 
- Test the creation of a work item related to a sale order, see if the product is created behind.
- Test that there is a single work item template at the same time for a product
- Test the cost, price and margin of a work item whenever components changes or work item values are changed directly

Task-5262058