### PR TITLE
[IMP] booking_engine: add availabilities

### DIFF
--- a/booking_engine/__manifest__.py
+++ b/booking_engine/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Booking Engine',
-    'version': '1.8',
+    'version': '1.9',
     'category': 'Hidden/Tools',
     'author': 'Odoo S.A.',
     'depends': [
@@ -9,6 +9,7 @@
         'knowledge',
         'planning_hr_skills',
         'sale_project',
+        'web_gantt',
         'web_studio',
         'website_appointment',
         'website_sale_renting_planning',
@@ -19,6 +20,7 @@
         'data/ir_model.xml',
         'data/ir_model_access.xml',
         'data/ir_model_fields.xml',
+        'data/ir_default.xml',
         'data/project_project.xml',
         'data/account_tax.xml',
         'data/product_template.xml',
@@ -41,8 +43,17 @@
         'demo/website_menu.xml',
         'demo/payment_provider_demo.xml',
     ],
+    'assets': {
+        'web.assets_backend': [
+            'booking_engine/static/src/scss/gantt.scss',
+        ],
+        'web.assets_backend_lazy': [
+            'booking_engine/static/src/js/patch.js',  # web_gantt/gantt_renderer is lazy so this needs to be lazy too
+        ],
+    },
     'license': 'OEEL-1',
     'cloc_exclude': [
         'data/website_view.xml',
+        'static/src/scss/gantt.scss',
     ],
 }

--- a/booking_engine/data/base_automation.xml
+++ b/booking_engine/data/base_automation.xml
@@ -80,4 +80,83 @@
         <field name="filter_pre_domain">[('project_id.x_is_house_keeping_project', '!=', False)]</field>
         <field name="trigger_field_ids" eval="[(6, 0, [ref('project.field_project_task__stage_id')])]"/>
     </record>
+
+    <!--
+        Recomputation of availabilities
+    -->
+    <!-- planning.slot -->
+    <record id="automation_on_planning_slot_change" model="base.automation">
+        <field name="name">Booking Engine: Mark Availabilities To Recompute: Slot Change</field>
+        <field name="model_id" ref="planning.model_planning_slot"/>
+        <field name="trigger">on_create_or_write</field>
+        <field name="trigger_field_ids" eval="[(6, 0, [
+            ref('planning.field_planning_slot__start_datetime'), 
+            ref('planning.field_planning_slot__end_datetime'), 
+            ref('planning.field_planning_slot__resource_id')
+        ])]"/>
+        <field name="action_server_ids" eval="[(6, 0, [ref('booking_engine.server_action_update_availability_for_planning_slot')])]"/>
+    </record>
+    <record id="automation_on_planning_slot_delete" model="base.automation">
+        <field name="name">Booking Engine: Mark Availabilities To Recompute: Slot Delete</field>
+        <field name="model_id" ref="planning.model_planning_slot"/>
+        <field name="trigger">on_unlink</field>
+        <field name="action_server_ids" eval="[(6, 0, [ref('booking_engine.server_action_update_availability_for_planning_slot_delete')])]"/>
+    </record>
+
+    <!-- resource.calendar.leave -->
+    <record id="automation_on_resource_calendar_leaves_change" model="base.automation">
+        <field name="name">Booking Engine: Mark Availabilities To Recompute: Leave Change</field>
+        <field name="model_id" ref="resource.model_resource_calendar_leaves"/>
+        <field name="trigger">on_create_or_write</field>
+        <field name="trigger_field_ids" eval="[(6, 0, [
+            ref('resource.field_resource_calendar_leaves__date_from'), 
+            ref('resource.field_resource_calendar_leaves__date_to'), 
+            ref('resource.field_resource_calendar_leaves__resource_id'), 
+            ref('resource.field_resource_calendar_leaves__calendar_id')
+        ])]"/>
+        <field name="action_server_ids" eval="[(6, 0, [ref('booking_engine.server_action_update_availability_for_resource_calendar_leaves')])]"/>
+    </record>
+    <record id="automation_on_resource_calendar_leaves_delete" model="base.automation">
+        <field name="name">Booking Engine: Mark Availabilities To Recompute: Leave Delete</field>
+        <field name="model_id" ref="resource.model_resource_calendar_leaves"/>
+        <field name="trigger">on_unlink</field>
+        <field name="action_server_ids" eval="[(6, 0, [ref('booking_engine.server_action_update_availability_for_resource_calendar_leaves_delete')])]"/>
+    </record>
+
+    <!-- resource.resource -->
+    <record id="automation_on_resource_resource_change" model="base.automation">
+        <field name="name">Booking Engine: Mark Availabilities To Recompute: Room Change</field>
+        <field name="model_id" ref="resource.model_resource_resource"/>
+        <field name="trigger">on_create_or_write</field>
+        <field name="trigger_field_ids" eval="[(6, 0, [
+            ref('resource.field_resource_resource__active'), 
+            ref('resource.field_resource_resource__calendar_id')
+        ])]"/>
+        <field name="action_server_ids" eval="[(6, 0, [ref('booking_engine.server_action_update_availability_for_resource_resource')])]"/>
+    </record>
+    <record id="automation_on_resource_resource_delete" model="base.automation">
+        <field name="name">Booking Engine: Mark Availabilities To Recompute: Room Delete</field>
+        <field name="model_id" ref="resource.model_resource_resource"/>
+        <field name="trigger">on_unlink</field>
+        <field name="action_server_ids" eval="[(6, 0, [ref('booking_engine.server_action_update_availability_for_resource_resource_delete')])]"/>
+    </record>
+
+    <!-- product.template -->
+    <record id="automation_on_product_template_change" model="base.automation">
+        <field name="name">Booking Engine: Mark Availabilities To Recompute: Offer Change</field>
+        <field name="model_id" ref="product.model_product_template"/>
+        <field name="trigger">on_create_or_write</field>
+        <field name="trigger_field_ids" eval="[(6, 0, [
+            ref('booking_engine.product_model_product_template_x_resource_ids_field'), 
+            ref('booking_engine.product_model_product_template_x_is_a_room_offer_field'), 
+            ref('product.field_product_template__active')
+        ])]"/>
+        <field name="action_server_ids" eval="[(6, 0, ref('booking_engine.server_action_update_availability_for_product_template'))]"/>
+    </record>
+    <record id="automation_on_product_template_delete" model="base.automation">
+        <field name="name">Booking Engine: Mark Availabilities To Recompute: Offer Delete</field>
+        <field name="model_id" ref="product.model_product_template"/>
+        <field name="trigger">on_unlink</field>
+        <field name="action_server_ids" eval="[(6, 0, [ref('booking_engine.server_action_update_availability_for_product_template_delete')])]"/>
+    </record>
 </odoo>

--- a/booking_engine/data/ir_actions_server.xml
+++ b/booking_engine/data/ir_actions_server.xml
@@ -5,8 +5,7 @@
         <field name="model_id" ref="x_model_city_tax"/>
         <field name="state">code</field>
         <field name="code"><![CDATA[
-stay_tax_line = False
-sequence = 0
+sequence, stay_tax_line = 0, False
 for so_line in record.x_sale_order_id.order_line:
     if so_line.product_id.x_is_stay_tax: stay_tax_line = so_line
     sequence = max(sequence, so_line.sequence)
@@ -14,7 +13,7 @@ if stay_tax_line: stay_tax_line.write({'product_uom_qty': record.x_total, 'qty_d
 elif record.x_total > 0:
     product = env['product.product'].search([('x_is_stay_tax', '=', True)], limit=1)
     env['sale.order.line'].create({'order_id': record.x_sale_order_id.id, 'product_id': product.id, 'product_uom_qty': record.x_total, 'qty_delivered': record.x_total})
-        ]]></field>
+]]></field>
     </record>
     <record id="open_x_city_tax_action" model="ir.actions.act_window">
         <field name="name">City Tax</field>
@@ -197,6 +196,332 @@ if (project := env['project.project'].search([('x_is_house_keeping_project', '='
                 'user_ids': [(5,0)],
             })
     env['project.task'].create(newtasks)
+]]></field>
+    </record>
+
+    <!-- 
+        Availabilities: create & update logic
+    -->
+    <record id="server_action_update_availabilities" model="ir.actions.server">
+        <field name="name">Booking Engine: Update Availabilities</field>
+        <field name="model_id" ref="x_model_availability"/>
+        <field name="state">code</field>
+        <field name="code"><![CDATA[
+if (records := env['x_availability'].search([('x_to_recompute', '=', True)])):
+    all_offers = records.x_stay_offer_id
+    all_resources = all_offers.x_resource_ids
+
+    # Convert dates to datetimes for slot/leave domains
+    dt_min = datetime.datetime.combine(min(dates := records.mapped('x_date')), datetime.time.min)
+    dt_max = datetime.datetime.combine(max(dates), datetime.time.max)
+
+    # Fetch slots in the time frame
+    slots = env['planning.slot'].search([('resource_id', 'in', all_resources.ids), ('end_datetime', '>=', dt_min), ('start_datetime', '<=', dt_max)])
+
+    # Fetch leaves in the time frame (Resource specific OR Calendar specific)
+    leaves = env['resource.calendar.leaves'].search([
+        '|', ('resource_id', 'in', all_resources.ids), 
+            '&', ('calendar_id', 'in', all_resources.calendar_id.ids), ('resource_id', '=', False),
+        ('date_to', '>=', dt_min), ('date_from', '<=', dt_max)])
+
+    res_bookings, res_leaves, updates = {}, {}, {}
+
+    # resource: date mapping (/!\ nightly stays)
+    for slot in slots:
+        if (r_id := slot.resource_id.id) not in res_bookings: res_bookings[r_id] = set()
+
+        start_d, end_d = slot.start_datetime.date(), slot.end_datetime.date()
+
+        # If it spans multiple days, block the nights (exclusive of checkout day)
+        if (nights := (end_d - start_d).days) > 0:
+            res_bookings[r_id].update(start_d + datetime.timedelta(days=i) for i in range(nights))
+        # Fallback for a same-day booking (check-in and check-out on the same date, shouldn't be possible?)
+        else: res_bookings[r_id].add(start_d)
+
+    # resource: leave mapping
+    for leave in leaves:
+        # Handle global leaves by finding all resources sharing the calendar
+        target_res_ids = [leave.resource_id.id] if leave.resource_id else [r.id for r in all_resources if r.calendar_id.id == leave.calendar_id.id]
+        for r_id in target_res_ids:
+            if r_id not in res_leaves: res_leaves[r_id] = set()
+            curr = leave.date_from.date()
+            while curr <= leave.date_to.date():
+                res_leaves[r_id].add(curr)
+                curr += datetime.timedelta(days=1)
+
+    # Group records that share the same resulting (total, booked) values to save DB write calls
+    for avail in records:
+        offer, date = avail.x_stay_offer_id, avail.x_date
+
+        # Find all resources for this offer that are NOT on leave today
+        active_res_ids = [r.id for r in offer.x_resource_ids if date not in res_leaves.get(r.id, set())]
+
+        # Count how many of those active rooms ARE booked today
+        booked_count = sum(1 for r_id in active_res_ids if date in res_bookings.get(r_id, set()))
+
+        # Group by the result
+        if (val_tuple := (len(active_res_ids), booked_count)) not in updates: updates[val_tuple] = env['x_availability']
+        updates[val_tuple] |= avail
+
+    # Apply the bulk writes
+    for (total, booked), avail_batch in updates.items():
+        avail_batch.write({'x_total_units': total, 'x_booked': booked, 'x_to_recompute': False})
+]]></field>
+    </record>
+
+    <record id="server_action_create_500_days_availability" model="ir.actions.server">
+        <field name="name">Booking Engine: Update and create Availabilities</field>
+        <field name="model_id" ref="x_model_availability"/>
+        <field name="state">code</field>
+        <field name="usage">ir_cron</field>
+        <field name="code"><![CDATA[
+# This server action is called in a cron once a day and does 3 things:
+# 1. Archive the availabilities <= today
+#   (it's not informative to see them and clutters the view)
+# 2. Create new ones at the start of the day
+#   (so that we always have the right window of availabilities for Channex)
+# 3. Trigger a recomputation of all the availabilities 
+#   (to make sure we don't have a bugged/false state that does not reflect reality,
+#    because unavoidable race conditions)
+
+today, target_dates = datetime.date.today(), set(datetime.date.today() + datetime.timedelta(days=i) for i in range(500))
+
+env['x_availability'].search([('x_date', '<', today), ('x_active', '=', True)]).write({'x_active': False})
+
+if (offers := env['product.template'].search([('x_is_a_room_offer', '=', True)])):
+    existing_dates_by_offer = env['x_availability']._read_group(
+        [('x_stay_offer_id', 'in', offers.ids), ('x_date', '>=', today), ('x_date', '<', today + datetime.timedelta(days=500))],
+        groupby=['x_stay_offer_id'], aggregates=['x_date:array_agg']
+    )
+
+    # Create availabilities only for dates that don't exist
+    to_create = [{'x_stay_offer_id': offer_id, 'x_date': d, 'x_to_recompute': True}
+                 for offer_id in offers.ids
+                 for d in (target_dates - existing_dates_by_offer.get(offer_id, set()))]
+
+    if to_create: env['x_availability'].create(to_create)
+    # Recompute all availabilities (that are not archived) to make sure we have the correct information
+    env['x_availability'].search([('x_date', '>=', today)]).write({'x_to_recompute': True})
+
+env.ref('booking_engine.server_action_update_availabilities').run()
+]]></field>
+    </record>
+
+    <record id="server_action_helper_compute_new_avails_to_recompute" model="ir.actions.server">
+        <field name="name">Booking Engine: Availability Helper - Compute New Availabilities M2M</field>
+        <field name="model_id" ref="base.model_ir_actions_server"/>
+        <field name="state">code</field>
+        <field name="code"><![CDATA[
+# records: leaves OR slots
+# Required context arguments
+records, resources, start_f, end_f = [env.context.get(a) for a in ['records', 'resources', 'field_start', 'field_end']]
+
+# An availability is the number of rooms available for a given DAY for a given OFFER.
+# Therefore, to compute availabilities, we need 2 things:
+# 1. The dates,
+# 2. The offer (and its resources)
+# So, in this server action, we fetch all these for the leaves/slots we were given as a parameter,
+# then 3. we fetch all the corresponding availabilities
+# 4. Assign these new abilities to the leaves/slots to match their updated values (resources/dates) 
+
+# We also perform the optimization of fetching all records in one query for performance optimization,
+# which makes the code harder to understand, which is the reason for these lengthy comments.
+
+# 1. Find all the dates of the leaves/slots to know which days' availabilities we
+# need to recompute, and keep track of them per record, so we can find them back easily when
+# we have to assign them to the records.
+# This is an optimization to only do 1 availabilities search instead of 1 per record in a 'for'
+dates, unique_dates = {}, set()
+for rec in records:
+    if not rec[start_f] or not rec[end_f]: continue        # skip this record if it has no date (unusable)
+    
+    # find the start and end date of this leave/slot and find all dates in between
+    d_min, d_max = rec[start_f].date(), rec[end_f].date()
+    dates[rec.id] = [d_min + datetime.timedelta(days=i) for i in range((d_max - d_min).days + 1)]
+
+    # add these dates for this record in the dict
+    unique_dates.update(dates[rec.id])
+
+# 2. Fetch all the offers for all the records
+offers = env['product.template'].search([('x_resource_ids', 'in', resources.ids)]) if resources else []
+
+# 3. Fetch all availabilities for all the records
+avails = env['x_availability'].search([('x_date', 'in', list(unique_dates)), ('x_stay_offer_id', 'in', offers.ids)]) if unique_dates and offers else env['x_availability']
+
+# 4. For all records, find the availabilities they impact, and link them together
+new_avails_to_recompute = env['x_availability']
+
+for rec in records.filtered(lambda r: r.id in dates):
+    # To get the right availabilities for a slot/leave, we need 1. its resources, 2. its dates
+
+    # Filter the resources for this specific record
+    if records._name == 'planning.slot':
+        target_res_ids = [rec.resource_id.id]
+    else: # resource.calendar.leaves
+        # If it has no resources, it means the record (leave) is global, and applies to all the resources.
+        # Conversely, if the record (leave) has a resource, it means that the record (leave) is only for this resource. 
+        target_res_ids = [rec.resource_id.id] if rec.resource_id else resources.filtered(lambda r: r.calendar_id.id == rec.calendar_id.id).ids
+
+    if (target_offers := offers.filtered(lambda o: set(target_res_ids) & set(o.x_resource_ids.ids))):
+        # Since we had to cram everything into one query to get all availabilities,
+        # We now have to find back the resources and dates specific to this changed record
+        new_avails = avails.filtered(lambda a: a.x_stay_offer_id.id in target_offers.ids and a.x_date in dates[rec.id])
+        rec.write({'x_availability_ids': [(6, 0, new_avails.ids)]})
+        new_avails_to_recompute |= new_avails
+
+new_avails_to_recompute.write({'x_to_recompute': True})
+
+env.ref('booking_engine.server_action_update_availabilities').run()
+]]></field>
+    </record>
+
+    <!--
+        Availability dependencies: Delete
+
+        For the on_delete, since it's an operation that does not happen that often,
+        We allow ourselves to use the cron to be able to recompute the availabilities after
+        the slots have actually been deleted, which we cannot do with a simple server action.
+        We don't do this in the on_create_or_write because the cron trigger can take up to 1 min,
+        which is something we don't want in regular on_create_or_write.
+        Therefore, for those, we use the server action and not the cron, but this can lead to
+        race conditions. To try to mitigate this, we recompute all availabilities in the cron
+        once a day.
+    -->
+    <record id="server_action_update_availability_for_planning_slot_delete" model="ir.actions.server">
+        <field name="name">Booking Engine: Slot Delete Availability Logic</field>
+        <field name="model_id" ref="planning.model_planning_slot"/>
+        <field name="state">code</field>
+        <field name="code"><![CDATA[
+# Since the records don't exist anymore, it has to be reflected in the availabilities,
+# so we need to recompute them
+records.x_availability_ids.write({'x_to_recompute': True})
+
+# Use the cron so that the current records (to delete) aren't taken into account for the recomputation
+env.ref('booking_engine.ir_cron_create_500_days_availability')._trigger()
+]]></field>
+    </record>
+
+    <record id="server_action_update_availability_for_resource_calendar_leaves_delete" model="ir.actions.server">
+        <field name="name">Booking Engine: Leave Delete Availability Logic</field>
+        <field name="model_id" ref="resource.model_resource_calendar_leaves"/>
+        <field name="state">code</field>
+        <field name="code"><![CDATA[
+# Since the records don't exist anymore, it has to be reflected in the availabilities,
+# so we need to recompute them
+records.x_availability_ids.write({'x_to_recompute': True})
+
+# Use the cron so that the current records (to delete) aren't taken into account for the recomputation
+env.ref('booking_engine.ir_cron_create_500_days_availability')._trigger()
+]]></field>
+    </record>
+
+    <record id="server_action_update_availability_for_resource_resource_delete" model="ir.actions.server">
+        <field name="name">Booking Engine: Room Delete Availability Logic</field>
+        <field name="model_id" ref="resource.model_resource_resource"/>
+        <field name="state">code</field>
+        <field name="code"><![CDATA[
+# Since the records don't exist anymore, it has to be reflected in the availabilities,
+# so we need to recompute them
+env['x_availability'].search([('x_stay_offer_id.x_resource_ids', 'in', records.ids)]).write({'x_to_recompute': True})
+
+# Use the cron so that the current records (to delete) aren't taken into account for the recomputation
+env.ref('booking_engine.ir_cron_create_500_days_availability')._trigger()
+]]></field>
+    </record>
+
+    <record id="server_action_update_availability_for_product_template_delete" model="ir.actions.server">
+        <field name="name">Booking Engine: Stay Offer Delete Availability Logic</field>
+        <field name="model_id" ref="product.model_product_template"/>
+        <field name="state">code</field>
+        <field name="code"><![CDATA[
+# If a stay offer is deleted, we can delete the entirety of its availabilities because
+# we can't see that line in the Gantt chart anymore
+env['x_availability'].search([('x_stay_offer_id', 'in', records.ids)]).unlink()
+
+# No need to launch the cron since the whole row was removed, and there is no interaction with other rows
+]]></field>
+    </record>
+
+    <!-- 
+        Availability dependencies: Update
+    -->
+    <record id="server_action_update_availability_for_planning_slot" model="ir.actions.server">
+        <field name="name">Booking Engine: Availability Slot Modify Logic</field>
+        <field name="model_id" ref="planning.model_planning_slot"/>
+        <field name="state">code</field>
+        <field name="code"><![CDATA[
+# Mark all currently linked availabilities as to recompute
+# This catches the old dates AND the old resource if the user dragged it to a different resource
+records.x_availability_ids.write({'x_to_recompute': True})
+
+# Now that the resource/dates have changed, we need to propagate the info to the corresponding availabilities
+if (valid_slots := records.filtered('resource_id')):
+    env.ref('booking_engine.server_action_helper_compute_new_avails_to_recompute').with_context(
+        records=valid_slots, field_start='start_datetime', field_end='end_datetime', 
+        resources=valid_slots.resource_id).run()
+]]></field>
+    </record>
+
+    <record id="server_action_update_availability_for_resource_calendar_leaves" model="ir.actions.server">
+        <field name="name">Booking Engine: Availability Leave Modify Logic</field>
+        <field name="model_id" ref="resource.model_resource_calendar_leaves"/>
+        <field name="state">code</field>
+        <field name="code"><![CDATA[
+# Mark all currently linked availabilities as to recompute
+# This catches the old dates AND the old resources if the user changed them
+records.x_availability_ids.write({'x_to_recompute': True})
+
+global_leaves = records - (resource_leaves := records.filtered('resource_id'))
+
+# Now that the resource/dates have changed, we need to propagate the info to the corresponding availabilities
+if (resources := env['resource.resource'].search(['|', ('calendar_id', 'in', global_leaves.calendar_id.ids), ('id', 'in', resource_leaves.resource_id.ids)])):
+    env.ref('booking_engine.server_action_helper_compute_new_avails_to_recompute').with_context(
+        records=records, field_start='date_from', field_end='date_to', resources=resources).run()
+]]></field>
+    </record>
+
+    <record id="server_action_update_availability_for_resource_resource" model="ir.actions.server">
+        <field name="name">Booking Engine: Availability Room Modify Logic</field>
+        <field name="model_id" ref="resource.model_resource_resource"/>
+        <field name="state">code</field>
+        <field name="code"><![CDATA[
+# Mark all currently linked availabilities as to recompute
+env['x_availability'].search([('x_stay_offer_id.x_resource_ids', 'in', records.ids), ('x_date', '>=', datetime.date.today())
+    ]).write({'x_to_recompute': True})
+
+env.ref('booking_engine.server_action_update_availabilities').run()
+]]></field>
+    </record>
+
+    <record id="server_action_update_availability_for_product_template" model="ir.actions.server">
+        <field name="name">Booking Engine: Availability Offer Modify Logic</field>
+        <field name="model_id" ref="product.model_product_template"/>
+        <field name="state">code</field>
+        <field name="code"><![CDATA[
+# Impacting field changes: x_is_a_room_offer, x_resource_ids, active
+# We cannot filter on the domain because we need to catch 
+# x_is_a_room_offer True -> False and False -> True 
+# but don't want to execute the availabilities code on not room offers
+
+domain = [('x_date', '>=', (today := datetime.date.today())), ('x_stay_offer_id', 'in', records.ids)]
+
+# We need a new search every time to not operate on records that don't exist anymore
+
+# active logic
+env['x_availability'].search(domain + [('x_stay_offer_id.active', '=', False)]).unlink()
+# x_is_a_room_offer logic
+env['x_availability'].search(domain + [('x_stay_offer_id.x_is_a_room_offer', '=', False)]).unlink()
+# x_resource_ids logic
+(existing_avails := env['x_availability'].search(domain)).write({'x_to_recompute': True})
+
+# Find the new ROOM offers (ones that have 0 records in existing_avails, are active, and a room offer)
+# and create 500 days ONLY for them
+if (new_offers := records.filtered(lambda r: r.x_is_a_room_offer and r.active) - existing_avails.x_stay_offer_id):
+    env['x_availability'].create([
+        {'x_stay_offer_id': offer.id, 'x_date': today + datetime.timedelta(days=i), 'x_to_recompute': True} 
+        for i in range(500) for offer in new_offers])
+
+env.ref('booking_engine.server_action_update_availabilities').run()
 ]]></field>
     </record>
 </odoo>

--- a/booking_engine/data/ir_cron.xml
+++ b/booking_engine/data/ir_cron.xml
@@ -9,4 +9,14 @@
         <field name="state">code</field>
         <field name="ir_actions_server_id" ref="server_action_update_rooms"/>
     </record>
+    <!-- Availability/Occupancy-->
+    <record id="ir_cron_create_500_days_availability" model="ir.cron">
+        <field name="name">Booking Engine: Daily availability creation</field>
+        <field name="interval_number">1</field>
+        <field name="interval_type">days</field>
+        <field name="model_id" ref="x_model_availability"/>
+        <field name="state">code</field>
+        <field name="ir_actions_server_id" ref="server_action_create_500_days_availability"/>
+        <field name="nextcall" model="ir.cron" eval="(datetime.now(pytz.timezone(obj().env.user.tz or 'UTC')).replace(hour=1, minute=0, second=0) + timedelta(days=1)).astimezone(pytz.utc).strftime('%Y-%m-%d %H:%M:%S')"/>
+    </record>
 </odoo>

--- a/booking_engine/data/ir_default.xml
+++ b/booking_engine/data/ir_default.xml
@@ -1,0 +1,19 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<odoo noupdate="1">
+  <record id="default_x_active_field_x_availability" model="ir.default">
+    <field name="field_id" ref="x_active_field_x_availability"/>
+    <field name="json_value">true</field>
+  </record>
+  <record id="default_x_sequence_field_x_availability" model="ir.default">
+    <field name="field_id" ref="x_sequence_field_x_availability"/>
+    <field name="json_value">10</field>
+  </record>
+  <record id="default_x_total_units_field_x_availability" model="ir.default">
+    <field name="field_id" ref="x_total_units_field_x_availability"/>
+    <field name="json_value">"0"</field>
+  </record>
+  <record id="default_x_booked_field_x_availability" model="ir.default">
+    <field name="field_id" ref="x_booked_field_x_availability"/>
+    <field name="json_value">"0"</field>
+  </record>
+</odoo>

--- a/booking_engine/data/ir_model.xml
+++ b/booking_engine/data/ir_model.xml
@@ -9,4 +9,8 @@
         <field name="model">x_guests_line</field>
         <field name="name">Guests Line</field>
     </record>
+  <record id="x_model_availability" model="ir.model">
+    <field name="model">x_availability</field>
+    <field name="name">Availability</field>
+  </record>
 </odoo>

--- a/booking_engine/data/ir_model_access.xml
+++ b/booking_engine/data/ir_model_access.xml
@@ -18,4 +18,13 @@
         <field name="perm_write" eval="True"/>
         <field name="perm_unlink" eval="True"/>
     </record>
+    <record id="x_model_availability_access" model="ir.model.access">
+        <field name="group_id" ref="base.group_user"/>
+        <field name="model_id" ref="x_model_availability"/>
+        <field name="name">x_model_availability_group_user_access</field>
+        <field name="perm_create" eval="False"/>
+        <field name="perm_read" eval="True"/>
+        <field name="perm_write" eval="False"/>
+        <field name="perm_unlink" eval="False"/>
+    </record>
 </odoo>

--- a/booking_engine/data/ir_model_fields.xml
+++ b/booking_engine/data/ir_model_fields.xml
@@ -605,8 +605,7 @@ for record in self: record['x_is_in_stage_clean'] = record.x_house_keeping_stage
         <field name="store" eval="False"/>
         <field name="depends">x_cleaning</field>
         <field name="compute"><![CDATA[
-for record in self:
-    record['x_cleaning_color'] = 1 if record.x_cleaning == 'checkout' else 3        
+for record in self: record['x_cleaning_color'] = 1 if record.x_cleaning == 'checkout' else 3        
 ]]></field>
     </record>
     <record id="x_occupancy_color_field_resource_resource" model="ir.model.fields">
@@ -616,8 +615,7 @@ for record in self:
         <field name="name">x_occupancy_color</field>
         <field name="depends">x_occupancy</field>
         <field name="compute"><![CDATA[
-for record in self:
-    record['x_occupancy_color'] = 13 if record.x_occupancy == 'vacant' else 3
+for record in self: record['x_occupancy_color'] = 13 if record.x_occupancy == 'vacant' else 3
 ]]></field>
     </record>
     <record id="x_task_stage_color_field_project_task" model="ir.model.fields">
@@ -636,4 +634,139 @@ for record in self:
         <field name="store" eval="False"/>
         <field name="related">x_resource_id.x_occupancy_color</field>
     </record>
+  <record id="x_name_field_x_availability" model="ir.model.fields">
+    <field name="ttype">char</field>
+    <field name="field_description">Description</field>
+    <field name="model_id" ref="x_model_availability"/>
+    <field name="name">x_name</field>
+  </record>
+  <record id="x_active_field_x_availability" model="ir.model.fields">
+    <field name="ttype">boolean</field>
+    <field name="field_description">Active</field>
+    <field name="model_id" ref="x_model_availability"/>
+    <field name="name">x_active</field>
+    <field name="readonly" eval="True"/>
+  </record>
+  <record id="x_to_recompute_field_x_availability" model="ir.model.fields">
+    <field name="ttype">boolean</field>
+    <field name="field_description">To Recompute</field>
+    <field name="model_id" ref="x_model_availability"/>
+    <field name="name">x_to_recompute</field>
+  </record>
+  <record id="x_sequence_field_x_availability" model="ir.model.fields">
+    <field name="ttype">integer</field>
+    <field name="field_description">Sequence</field>
+    <field name="model_id" ref="x_model_availability"/>
+    <field name="name">x_sequence</field>
+    <field name="readonly" eval="True"/>
+  </record>
+  <record id="x_stay_offer_field_x_availability" model="ir.model.fields">
+    <field name="ttype">many2one</field>
+    <field name="domain">[("x_is_a_room_offer", "!=", False)]</field>
+    <field name="field_description">Stay Offer</field>
+    <field name="model_id" ref="x_model_availability"/>
+    <field name="name">x_stay_offer_id</field>
+    <field name="relation">product.template</field>
+    <field name="readonly" eval="True"/>
+  </record>
+  <record id="x_date_field_x_availability" model="ir.model.fields">
+    <field name="ttype">date</field>
+    <field name="field_description">Date</field>
+    <field name="model_id" ref="x_model_availability"/>
+    <field name="name">x_date</field>
+    <field name="readonly" eval="True"/>
+  </record>
+  <record id="x_total_units_field_x_availability" model="ir.model.fields">
+    <field name="ttype">integer</field>
+    <field name="field_description">Total Units</field>
+    <field name="model_id" ref="x_model_availability"/>
+    <field name="name">x_total_units</field>
+    <field name="readonly" eval="True"/>
+  </record>
+  <record id="x_booked_field_x_availability" model="ir.model.fields">
+    <field name="ttype">integer</field>
+    <field name="field_description">Booked</field>
+    <field name="model_id" ref="x_model_availability"/>
+    <field name="name">x_booked</field>
+    <field name="readonly" eval="True"/>
+  </record>
+  <record id="x_available_field_x_availability" model="ir.model.fields">
+    <field name="compute"><![CDATA[for record in self: record['x_available'] = record.x_total_units - record.x_booked]]></field>
+    <field name="ttype">integer</field>
+    <field name="depends">x_total_units,x_booked</field>
+    <field name="field_description">Available</field>
+    <field name="model_id" ref="x_model_availability"/>
+    <field name="name">x_available</field>
+    <field name="readonly" eval="True"/>
+    <field name="store" eval="False"/>
+  </record>
+  <record id="x_availability_field_x_availability" model="ir.model.fields">
+    <field name="compute"><![CDATA[for record in self:
+      record['x_availability'] = record.x_available / record.x_total_units if record.x_total_units > 0 else 0]]></field>
+    <field name="ttype">float</field>
+    <field name="depends">x_available,x_total_units</field>
+    <field name="field_description">Availability</field>
+    <field name="model_id" ref="x_model_availability"/>
+    <field name="name">x_availability</field>
+    <field name="readonly" eval="True"/>
+    <field name="selectable" eval="False"/>
+    <field name="store" eval="False"/>
+  </record>
+  <record id="x_occupancy_field_x_availability" model="ir.model.fields">
+    <field name="compute"><![CDATA[for record in self:
+      record['x_occupancy'] = 0 if not record.x_total_units else 1 - record.x_available / record.x_total_units ]]></field>
+    <field name="ttype">float</field>
+    <field name="depends">x_available,x_total_units</field>
+    <field name="field_description">Occupancy</field>
+    <field name="model_id" ref="x_model_availability"/>
+    <field name="name">x_occupancy</field>
+    <field name="readonly" eval="True"/>
+    <field name="selectable" eval="False"/>
+    <field name="store" eval="False"/>
+  </record>
+  <record id="x_occupancy_color_field_x_availability" model="ir.model.fields">
+    <field name="ttype">integer</field>
+    <field name="depends">x_availability,x_total_units</field>
+    <field name="field_description">Occupancy Color</field>
+    <field name="model_id" ref="x_model_availability"/>
+    <field name="name">x_occupancy_color</field>
+    <field name="readonly" eval="True"/>
+    <field name="selectable" eval="False"/>
+    <field name="store" eval="False"/>
+    <field name="compute"><![CDATA[
+for r in self:
+    # Directly return the integer index (0-9)
+    r['x_occupancy_color'] = 0 if r.x_total_units == 0 else min(9, max(0, int(r.x_availability * 10)))
+]]></field>
+  </record>
+  <record id="x_availability_color_field_x_availability" model="ir.model.fields">
+    <field name="ttype">integer</field>
+    <field name="depends">x_total_units,x_availability</field>
+    <field name="field_description">Availability Color</field>
+    <field name="model_id" ref="x_model_availability"/>
+    <field name="name">x_availability_color</field>
+    <field name="readonly" eval="True"/>
+    <field name="selectable" eval="False"/>
+    <field name="store" eval="False"/>
+    <field name="compute"><![CDATA[
+for r in self:
+    # Directly return the integer index (0-9)
+    r['x_availability_color'] = 0 if r.x_total_units == 0 else min(9, max(0, int((1 - r.x_availability) * 10)))]]></field>
+  </record>
+  <record id="x_availability_ids_field_planning_slot" model="ir.model.fields">
+    <field name="ttype">many2many</field>
+    <field name="field_description">Availabilities</field>
+    <field name="model_id" ref="planning.model_planning_slot"/>
+    <field name="name">x_availability_ids</field>
+    <field name="relation">x_availability</field>
+    <field name="readonly" eval="True"/>
+  </record>
+  <record id="x_availability_ids_field_resource_calendar_leaves" model="ir.model.fields">
+    <field name="ttype">many2many</field>
+    <field name="field_description">Availabilities</field>
+    <field name="model_id" ref="resource.model_resource_calendar_leaves"/>
+    <field name="name">x_availability_ids</field>
+    <field name="relation">x_availability</field>
+    <field name="readonly" eval="True"/>
+  </record>
 </odoo>

--- a/booking_engine/data/ir_ui_menu.xml
+++ b/booking_engine/data/ir_ui_menu.xml
@@ -7,6 +7,10 @@
       <menuitem id="menu_board_house_keeping" name="Board" action="act_window_board"/>
       <menuitem id="menu_tasks_house_keeping" name="Tasks" action="act_window_house_keeping_project_tasks"/>
     </menuitem>
+    <menuitem id="menu_availability_steering" name="Steering">
+      <menuitem id="menu_availability_occupancy" name="Occupancy" action="action_window_availability_occupancy"/>
+      <menuitem id="menu_availability_availability" name="Availability" action="action_window_availability_availability"/>
+    </menuitem>
     <menuitem id="booking_engine_rooms_menu" name="Configuration">
       <menuitem id="booking_engine_rooms_settings_menu" name="Settings" action="booking_engine_settings_action" sequence="1"/>
       <menuitem id="booking_engine_rooms_stay_offers_menu" name="Stay Offers">

--- a/booking_engine/data/ir_ui_view.xml
+++ b/booking_engine/data/ir_ui_view.xml
@@ -467,7 +467,7 @@
         <xpath expr="/gantt" position="attributes">
           <attribute name="form_view_id">%(booking_engine_schedule_form)d</attribute>
           <attribute name="multi_create_view"/>
-          <attribute name="color">partner_id</attribute>
+          <attribute name="color">sale_order_id</attribute>
         </xpath>
     </field>
     <field name="inherit_id" ref="planning.planning_view_gantt"/>
@@ -823,4 +823,170 @@
         <field name="type">form</field>
         <field name="active" eval="True"/>
     </record>
+  <!-- Availability / Occupancy -->
+  <record id="view_x_availability_list" model="ir.ui.view">
+    <field name="model">x_availability</field>
+    <field name="name">x_availability.view.list</field>
+    <field name="type">list</field>
+    <field name="active" eval="True"/>
+    <field name="arch" type="xml">
+      <list default_group_by="x_date:day" edit="0" open_form_view="0">
+        <field name="x_sequence" readonly="1" widget="handle"/>
+        <field name="x_date" readonly="1" optional="show"/>
+        <field name="x_stay_offer_id" readonly="1" optional="show"/>
+        <field name="x_total_units" readonly="1" optional="show"/>
+        <field name="x_booked" readonly="1" optional="show"/>
+        <field name="x_available" readonly="1" optional="show"/>
+        <field name="x_occupancy" readonly="1" optional="show" widget="percentage"/>
+      </list>
+    </field>
+  </record>
+
+  <record id="view_x_availability_form" model="ir.ui.view">
+    <field name="model">x_availability</field>
+    <field name="name">x_availability.view.form</field>
+    <field name="type">form</field>
+    <field name="active" eval="True"/>
+    <field name="arch" type="xml">
+      <form>
+        <header/>
+        <sheet string="Availability">
+          <widget name="web_ribbon" text="Archived" bg_color="text-bg-danger" invisible="x_active"/>
+          <field name="x_active" invisible="1"/>
+          <group>
+            <group>
+              <field name="x_date"/>
+              <field name="x_stay_offer_id"/>
+              <field name="x_total_units"/>
+              <field name="x_booked"/>
+              <field name="x_available"/>
+              <field name="x_availability" widget="percentage"/>
+              <field name="x_availability_color"/>
+              <field name="x_occupancy" widget="percentage"/>
+              <field name="x_occupancy_color"/>
+            </group>
+          </group>
+        </sheet>
+      </form>
+    </field>
+  </record>
+
+  <record id="view_x_availability_search" model="ir.ui.view">
+    <field name="model">x_availability</field>
+    <field name="name">x_availability.view.search</field>
+    <field name="type">search</field>
+    <field name="active" eval="True"/>
+    <field name="arch" type="xml">
+      <search>
+        <filter string="Archived" name="archived_x_availability" domain="[['x_active', '=', False]]"/>
+        <separator/>
+      </search>
+    </field>
+  </record>
+
+  <record id="view_x_availability_availability_gantt" model="ir.ui.view">
+    <field name="name">x_availability.view.gantt.base</field>
+    <field name="model">x_availability</field>
+    <field name="type">gantt</field>
+    <field name="active" eval="True"/>
+    <field name="arch" type="xml">
+      <gantt string="Availability" class="o_booking_occupancy_gantt" date_start="x_date" date_stop="x_date" default_range="month" display_mode="dense" default_group_by="x_stay_offer_id" color="x_availability_color" precision="{'month':'day:full','week':'day:full'}" cell_create="0" edit="0" create="0" pill_label="1">
+        <!-- load fields so they exist for the template -->
+        <field name="x_availability"/>
+        <field name="x_availability_color"/>
+        <field name="x_available"/>
+        <field name="x_occupancy_color"/>
+        <field name="x_occupancy"/>
+        <field name="x_booked"/>
+        <field name="x_date"/>
+        <field name="x_total_units"/>
+        <templates>
+          <div t-name="gantt-popover">
+            <t t-set="bar_color" t-value="x_availability_color"/>
+            <t t-set="bar_pct" t-value="x_availability"/>
+            <t t-set="main_title" t-value="'Availability:'"/>
+            
+            <t t-set="heat_scale" t-value="['#ffdc00', '#fbc904', '#f6b609', '#f2a30d', '#ed9011', '#e97d16', '#e4691a', '#e0561e', '#db4323', '#d73027']"/>
+
+            <div class="oe_kanban_global_click p-2">
+              <style>
+                .o_gantt_popover_footer, .o_popover_footer, .o_kanban_record_footer, footer, .o_gantt_popover button.btn, .o_popover button { display: none !important; }
+                .o_booking_occupancy_gantt .o_gantt_pill_title { max-width: 100% !important; text-align: center; overflow: hidden; text-overflow: clip; }
+              </style>
+              
+              <div class="o_kanban_record_top mb-1">
+                <div class="o_kanban_record_title fw-bold">
+                  <span t-esc="new Date(x_date).toLocaleDateString(undefined, { month: 'short', day: 'numeric' })"/>
+                </div>
+              </div>
+              
+              <div class="o_kanban_record_body" style="min-width: 160px;">
+                <div class="progress mt-1" style="height: 8px; background-color: #e9ecef;">
+                    <div
+                        role="progressbar"
+                        t-attf-style="width: {{bar_pct * 100}}%; background-color: {{heat_scale[bar_color]}} !important;"
+                        t-att-aria-valuenow="bar_pct * 100" aria-valuemin="0" aria-valuemax="100"/>
+                </div>
+                
+                <div class="d-flex justify-content-between align-items-center mt-2 gap-2">
+                    <strong><t t-esc="main_title"/></strong>
+                    <span class="ms-1"><strong><span t-esc="Math.round(bar_pct * 100) + '%'"/></strong></span>
+                </div>
+                
+                <div class="d-flex justify-content-between align-items-center gap-2">
+                  <span>Total Units:</span>
+                  <span class="ms-1" t-esc="x_total_units"/>
+                </div>
+                <div class="d-flex justify-content-between align-items-center gap-2">
+                  <span>Booked:</span>
+                  <span class="ms-1" t-esc="x_booked"/>
+                </div>
+                <div class="d-flex justify-content-between align-items-center gap-2">
+                  <span>Available:</span>
+                  <span class="ms-1" t-esc="x_available"/>
+                </div>
+              </div>
+            </div>
+          </div>
+        </templates>
+      </gantt>
+    </field>
+  </record>
+
+  <record id="action_window_availability_availability" model="ir.actions.act_window">
+    <field name="name">Availability</field>
+    <field name="res_model">x_availability</field>
+    <field name="view_mode">gantt,list</field>
+    <field name="view_ids" eval="[
+        (5, 0, 0),
+        (0, 0, {'view_mode': 'gantt', 'view_id': ref('view_x_availability_availability_gantt')}),
+    ]"/>
+  </record>
+
+  <record id="view_x_availability_occupancy_gantt" model="ir.ui.view">
+    <field name="name">x_availability.view.gantt.occupancy</field>
+    <field name="model">x_availability</field>
+    <field name="inherit_id" ref="view_x_availability_availability_gantt"/>
+    <field name="mode">primary</field>
+    <field name="active" eval="True"/>
+    <field name="arch" type="xml">
+      <xpath expr="//gantt" position="attributes">
+        <attribute name="string">Occupancy</attribute>
+        <attribute name="color">x_occupancy_color</attribute>
+      </xpath>
+      <xpath expr="//t[@t-set='bar_color']" position="attributes"><attribute name="t-value">x_occupancy_color</attribute></xpath>
+      <xpath expr="//t[@t-set='bar_pct']" position="attributes"><attribute name="t-value">x_occupancy</attribute></xpath>
+      <xpath expr="//t[@t-set='main_title']" position="attributes"><attribute name="t-value">'Occupancy:'</attribute></xpath>
+    </field>
+  </record>
+
+  <record id="action_window_availability_occupancy" model="ir.actions.act_window">
+    <field name="name">Occupancy</field>
+    <field name="res_model">x_availability</field>
+    <field name="view_mode">gantt,list</field>
+    <field name="view_ids" eval="[
+        (5, 0, 0),
+        (0, 0, {'view_mode': 'gantt', 'view_id': ref('view_x_availability_occupancy_gantt')}),
+    ]"/>
+  </record>
 </odoo>

--- a/booking_engine/static/src/js/patch.js
+++ b/booking_engine/static/src/js/patch.js
@@ -1,0 +1,10 @@
+import { patch } from "@web/core/utils/patch";
+import { GanttRenderer } from "@web_gantt/gantt_renderer";
+
+// In the booking_engine.action_window_availability_occupancy Gantt chart, display the occupancy percentage in the pill
+patch(GanttRenderer.prototype, { getDisplayName(pill) {
+    if (this.env.config.actionXmlId == "booking_engine.action_window_availability_occupancy") {
+        return (pill.record.x_occupancy !== undefined) ? Math.round((100 * pill.record.x_occupancy).toString()) + "%" : ""}
+    if (this.env.config.actionXmlId == "booking_engine.action_window_availability_availability") {
+        return pill.record.x_available.toString()}
+    return super.getDisplayName(pill)}});

--- a/booking_engine/static/src/scss/gantt.scss
+++ b/booking_engine/static/src/scss/gantt.scss
@@ -1,0 +1,16 @@
+/*Still display text when 1-day pill in month view*/
+.o_booking_occupancy_gantt { .o_gantt_pill_title {max-width: 100% !important;}}
+/* 
+    Custom Heatmap for Occupancy Gantt (Yellow to Red) 
+    Overrides the Gantt's default colors (.o_gantt_color_{color field value})
+*/
+.o_booking_occupancy_gantt .o_gantt_color_0 { background-color: #ffdc00 !important; }
+.o_booking_occupancy_gantt .o_gantt_color_1 { background-color: #fbc904 !important; }
+.o_booking_occupancy_gantt .o_gantt_color_2 { background-color: #f6b609 !important; }
+.o_booking_occupancy_gantt .o_gantt_color_3 { background-color: #f2a30d !important; }
+.o_booking_occupancy_gantt .o_gantt_color_4 { background-color: #ed9011 !important; }
+.o_booking_occupancy_gantt .o_gantt_color_5 { background-color: #e97d16 !important; }
+.o_booking_occupancy_gantt .o_gantt_color_6 { background-color: #e4691a !important; }
+.o_booking_occupancy_gantt .o_gantt_color_7 { background-color: #e0561e !important; }
+.o_booking_occupancy_gantt .o_gantt_color_8 { background-color: #db4323 !important; }
+.o_booking_occupancy_gantt .o_gantt_color_9 { background-color: #d73027 !important; }

--- a/campsite/data/knowledge_article.xml
+++ b/campsite/data/knowledge_article.xml
@@ -243,6 +243,25 @@
                 Invoicing</a>
             <a class="btn btn-fill-secondary" href="https://www.odoo.com/documentation/latest/applications/sales/point_of_sale.html">🎓 POS</a>
         </p><p><br/></p>
+        <h3>🚀 Strategic Oversight</h3>
+        <hr/>
+        <p>Beyond daily operations, the Steering menu serves as the "Captain’s Bridge" of your campsite. It provides a 500-day horizon to anticipate market trends, manage risks, and optimize your revenue.</p>
+        <h4>Monitoring success with occupancy</h4>
+        <p>The Occupancy view allows you to visualize your "Sales Success". It answers one simple question: <i>How well am I filling my campsite?</i></p>
+        <ul>
+            <li>Open the Steering menu and select Occupancy.</li>
+            <li>The Gantt chart is color-coded to reflect on the occupancy, the higher the better.</li>
+            <li>Access to more details clicking the slot.</li>
+        </ul>
+
+        <h4>Managing scarcity with availability</h4>
+        <p>While Occupancy focuses on what is full, the Availability view focuses on what is left to sell. It is your primary tool for operational safety and "Scarcity Pricing."</p>
+        <ul>
+            <li>Open the Steering menu and select Availability.</li>
+            <li>The Gantt chart is color-coded to reflect on the availability for you to work on filling in.</li>
+            <li>Access to more details clicking the slot.</li>
+        </ul>
+        <p><br/></p>
         <h3 >🔢 Running multiple places</h3>
         <hr/>
         <p>You may be running multiple places at the same time and most likely be willing to run them all from the same database.<b/>We got you covered with this using multiple companies or branches!</p>

--- a/campsite/data/views.xml
+++ b/campsite/data/views.xml
@@ -1,13 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo auto_sequence="1">
+<odoo>
   <record id="booking_engine.booking_engine_menu_root" model="ir.ui.menu" forcecreate="1">
     <field name="web_icon_data" type="base64" file="campsite/static/description/icon.png"/>
     <field name="name">Campsite</field>
-  </record>
-  <record id="booking_engine.planning_model_planning_role_x_is_a_room_offer_field" model="ir.model.fields" forcecreate="0">
-    <field name="field_description">Is Stay Offer</field>
-  </record>
-  <record id="booking_engine.product_model_product_template_x_is_a_room_offer_field" model="ir.model.fields" forcecreate="0">
-    <field name="field_description">Is Stay Offer</field>
   </record>
 </odoo>

--- a/campsite/demo/sale_order.xml
+++ b/campsite/demo/sale_order.xml
@@ -35,4 +35,95 @@
         <field name="rental_start_date" eval="datetime.today().date() + relativedelta(days=5)"/>
         <field name="rental_return_date" eval="datetime.today().date() + relativedelta(days=15)"/>
     </record>
+    <record id="sale_order_6" model="sale.order">
+        <field name="partner_id" ref="base_industry_data.res_partner_26"/>
+        <field name="user_id" ref="base.user_admin"/>
+        <field name="is_rental_order" eval="True"/>
+        <field name="rental_start_date" eval="datetime.today().date() - relativedelta(days=4)"/>
+        <field name="rental_return_date" eval="datetime.today().date()"/>
+    </record>
+    <record id="sale_order_7" model="sale.order">
+        <field name="partner_id" ref="base_industry_data.res_partner_22"/>
+        <field name="user_id" ref="base.user_admin"/>
+        <field name="is_rental_order" eval="True"/>
+        <field name="rental_start_date" eval="datetime.today().date() + relativedelta(days=3)"/>
+        <field name="rental_return_date" eval="datetime.today().date() + relativedelta(days=11)"/>
+    </record>
+    <record id="sale_order_8" model="sale.order">
+        <field name="partner_id" ref="base_industry_data.res_partner_29"/>
+        <field name="user_id" ref="base.user_admin"/>
+        <field name="is_rental_order" eval="True"/>
+        <field name="rental_start_date" eval="datetime.today().date() + relativedelta(days=3)"/>
+        <field name="rental_return_date" eval="datetime.today().date() + relativedelta(days=5)"/>
+    </record>
+    <record id="sale_order_9" model="sale.order">
+        <field name="partner_id" ref="base_industry_data.res_partner_28"/>
+        <field name="user_id" ref="base.user_admin"/>
+        <field name="is_rental_order" eval="True"/>
+        <field name="rental_start_date" eval="datetime.today().date() + relativedelta(days=11)"/>
+        <field name="rental_return_date" eval="datetime.today().date() + relativedelta(days=13)"/>
+    </record>
+    <record id="sale_order_10" model="sale.order">
+        <field name="partner_id" ref="base_industry_data.res_partner_30"/>
+        <field name="user_id" ref="base.user_admin"/>
+        <field name="is_rental_order" eval="True"/>
+        <field name="rental_start_date" eval="datetime.today().date()"/>
+        <field name="rental_return_date" eval="datetime.today().date() + relativedelta(days=6)"/>
+    </record>
+    <record id="sale_order_11" model="sale.order">
+        <field name="partner_id" ref="base_industry_data.res_partner_23"/>
+        <field name="user_id" ref="base.user_admin"/>
+        <field name="is_rental_order" eval="True"/>
+        <field name="rental_start_date" eval="datetime.today().date() - relativedelta(days=2)"/>
+        <field name="rental_return_date" eval="datetime.today().date()"/>
+    </record>
+    <record id="sale_order_12" model="sale.order">
+        <field name="partner_id" ref="base_industry_data.res_partner_23"/>
+        <field name="user_id" ref="base.user_admin"/>
+        <field name="is_rental_order" eval="True"/>
+        <field name="rental_start_date" eval="datetime.today().date() + relativedelta(days=2)"/>
+        <field name="rental_return_date" eval="datetime.today().date() + relativedelta(days=5)"/>
+    </record>
+    <record id="sale_order_13" model="sale.order">
+        <field name="partner_id" ref="base_industry_data.res_partner_30"/>
+        <field name="user_id" ref="base.user_admin"/>
+        <field name="is_rental_order" eval="True"/>
+        <field name="rental_start_date" eval="datetime.today().date() + relativedelta(days=8)"/>
+        <field name="rental_return_date" eval="datetime.today().date() + relativedelta(days=11)"/>
+    </record>
+    <record id="sale_order_14" model="sale.order">
+        <field name="partner_id" ref="base_industry_data.res_partner_25"/>
+        <field name="user_id" ref="base.user_admin"/>
+        <field name="is_rental_order" eval="True"/>
+        <field name="rental_start_date" eval="datetime.today().date() - relativedelta(days=1)"/>
+        <field name="rental_return_date" eval="datetime.today().date() + relativedelta(days=4)"/>
+    </record>
+    <record id="sale_order_15" model="sale.order">
+        <field name="partner_id" ref="base_industry_data.res_partner_24"/>
+        <field name="user_id" ref="base.user_admin"/>
+        <field name="is_rental_order" eval="True"/>
+        <field name="rental_start_date" eval="datetime.today().date()"/>
+        <field name="rental_return_date" eval="datetime.today().date() + relativedelta(days=4)"/>
+    </record>
+    <record id="sale_order_16" model="sale.order">
+        <field name="partner_id" ref="base_industry_data.res_partner_30"/>
+        <field name="user_id" ref="base.user_admin"/>
+        <field name="is_rental_order" eval="True"/>
+        <field name="rental_start_date" eval="datetime.today().date() - relativedelta(days=2)"/>
+        <field name="rental_return_date" eval="datetime.today().date() + relativedelta(days=1)"/>
+    </record>
+    <record id="sale_order_17" model="sale.order">
+        <field name="partner_id" ref="base_industry_data.res_partner_26"/>
+        <field name="user_id" ref="base.user_admin"/>
+        <field name="is_rental_order" eval="True"/>
+        <field name="rental_start_date" eval="datetime.today().date() + relativedelta(days=1)"/>
+        <field name="rental_return_date" eval="datetime.today().date() + relativedelta(days=5)"/>
+    </record>
+    <record id="sale_order_18" model="sale.order">
+        <field name="partner_id" ref="base_industry_data.res_partner_20"/>
+        <field name="user_id" ref="base.user_admin"/>
+        <field name="is_rental_order" eval="True"/>
+        <field name="rental_start_date" eval="datetime.today().date() + relativedelta(days=4)"/>
+        <field name="rental_return_date" eval="datetime.today().date() + relativedelta(days=8)"/>
+    </record>
 </odoo>

--- a/campsite/demo/sale_order_line.xml
+++ b/campsite/demo/sale_order_line.xml
@@ -30,4 +30,89 @@
     <field name="product_id" ref="product_product_25"/>
     <field name="is_rental" eval="True"/>
   </record>
+  <record id="sale_order_line_6" model="sale.order.line">
+    <field name="order_id" ref="sale_order_6"/>
+    <field name="product_id" ref="product_product_22"/>
+    <field name="is_rental" eval="True"/>
+  </record>
+  <record id="sale_order_line_7a" model="sale.order.line">
+    <field name="order_id" ref="sale_order_7"/>
+    <field name="product_id" ref="product_product_15"/>
+    <field name="is_rental" eval="True"/>
+  </record>
+  <record id="sale_order_line_7b" model="sale.order.line">
+    <field name="order_id" ref="sale_order_7"/>
+    <field name="product_id" ref="product_product_22"/>
+    <field name="is_rental" eval="True"/>
+  </record>
+  <record id="sale_order_line_8" model="sale.order.line">
+    <field name="order_id" ref="sale_order_8"/>
+    <field name="product_id" ref="product_product_22"/>
+    <field name="is_rental" eval="True"/>
+  </record>
+  <record id="sale_order_line_9" model="sale.order.line">
+    <field name="order_id" ref="sale_order_9"/>
+    <field name="product_id" ref="product_product_22"/>
+    <field name="is_rental" eval="True"/>
+  </record>
+  <record id="sale_order_line_10" model="sale.order.line">
+    <field name="order_id" ref="sale_order_10"/>
+    <field name="product_id" ref="product_product_22"/>
+    <field name="is_rental" eval="True"/>
+  </record>
+  <record id="sale_order_line_11a" model="sale.order.line">
+    <field name="order_id" ref="sale_order_11"/>
+    <field name="product_id" ref="product_product_14"/>
+    <field name="is_rental" eval="True"/>
+  </record>
+  <record id="sale_order_line_11b" model="sale.order.line">
+    <field name="order_id" ref="sale_order_11"/>
+    <field name="product_id" ref="product_product_12"/>
+    <field name="is_rental" eval="True"/>
+  </record>
+  <record id="sale_order_line_12" model="sale.order.line">
+    <field name="order_id" ref="sale_order_12"/>
+    <field name="product_id" ref="product_product_14"/>
+    <field name="is_rental" eval="True"/>
+  </record>
+  <record id="sale_order_line_13a" model="sale.order.line">
+    <field name="order_id" ref="sale_order_13"/>
+    <field name="product_id" ref="product_product_14"/>
+    <field name="is_rental" eval="True"/>
+  </record>
+  <record id="sale_order_line_13b" model="sale.order.line">
+    <field name="order_id" ref="sale_order_13"/>
+    <field name="product_id" ref="product_product_12"/>
+    <field name="is_rental" eval="True"/>
+  </record>
+  <record id="sale_order_line_13c" model="sale.order.line">
+    <field name="order_id" ref="sale_order_13"/>
+    <field name="product_id" ref="product_product_12"/>
+    <field name="is_rental" eval="True"/>
+  </record>
+  <record id="sale_order_line_14" model="sale.order.line">
+    <field name="order_id" ref="sale_order_14"/>
+    <field name="product_id" ref="product_product_14"/>
+    <field name="is_rental" eval="True"/>
+  </record>
+  <record id="sale_order_line_15" model="sale.order.line">
+    <field name="order_id" ref="sale_order_15"/>
+    <field name="product_id" ref="product_product_12"/>
+    <field name="is_rental" eval="True"/>
+  </record>
+  <record id="sale_order_line_16" model="sale.order.line">
+    <field name="order_id" ref="sale_order_16"/>
+    <field name="product_id" ref="product_product_12"/>
+    <field name="is_rental" eval="True"/>
+  </record>
+  <record id="sale_order_line_17" model="sale.order.line">
+    <field name="order_id" ref="sale_order_17"/>
+    <field name="product_id" ref="product_product_12"/>
+    <field name="is_rental" eval="True"/>
+  </record>
+  <record id="sale_order_line_18" model="sale.order.line">
+    <field name="order_id" ref="sale_order_18"/>
+    <field name="product_id" ref="product_product_29"/>
+    <field name="is_rental" eval="True"/>
+  </record>
 </odoo>

--- a/campsite/demo/sale_order_post.xml
+++ b/campsite/demo/sale_order_post.xml
@@ -59,10 +59,126 @@
         <value model="sale.order.line" eval="obj().search([('order_id', '=', ref('sale_order_1')), ('product_id', '=', ref('booking_engine.product_product_city_tax'))], limit=1).id" />
         <value eval="{'qty_delivered': 7}" />
     </function>
-    <function name="action_confirm" model="sale.order">
-        <value eval="[
-            ref('sale_order_4'),
-            ref('sale_order_5'),
-        ]"/>
+
+    <!-- manually assign the slots to circumvent the undeterministic algorithm causing scheduling conflicts -->
+    <function name="write" model="planning.slot">
+        <value model="planning.slot" eval="[obj().search([('sale_line_id', '=', ref('sale_order_line_1'))], limit=1).id]"/>
+        <value eval="{'resource_id': ref('planning_resource_8')}"/>
+    </function>
+    
+    <function name="write" model="planning.slot">
+        <value model="planning.slot" eval="[obj().search([('sale_line_id', '=', ref('sale_order_line_2a'))], limit=1).id]"/>
+        <value eval="{'resource_id': ref('planning_resource_9')}"/>
+    </function>
+
+    <function name="write" model="planning.slot">
+        <value model="planning.slot" eval="[obj().search([('sale_line_id', '=', ref('sale_order_line_3'))], limit=1).id]"/>
+        <value eval="{'resource_id': ref('planning_resource_14')}"/>
+    </function>
+
+    <function name="action_confirm" model="sale.order" eval="[ref('sale_order_4')]"/>
+    <function name="write" model="planning.slot">
+        <value model="planning.slot" eval="[obj().search([('sale_line_id', '=', ref('sale_order_line_4'))], limit=1).id]"/>
+        <value eval="{'resource_id': ref('planning_resource_10')}"/>
+    </function>
+
+    <function name="action_confirm" model="sale.order" eval="[ref('sale_order_5')]"/>
+    <function name="write" model="planning.slot">
+        <value model="planning.slot" eval="[obj().search([('sale_line_id', '=', ref('sale_order_line_5'))], limit=1).id]"/>
+        <value eval="{'resource_id': ref('planning_resource_5')}"/>
+    </function>
+
+    <function name="action_confirm" model="sale.order" eval="[ref('sale_order_6')]"/>
+    <function name="write" model="planning.slot">
+        <value model="planning.slot" eval="obj().search([('sale_line_id', '=', ref('sale_order_line_6'))], limit=1).id"/>
+        <value eval="{'resource_id': ref('planning_resource_1')}"/>
+    </function>
+
+    <function name="action_confirm" model="sale.order" eval="[ref('sale_order_7')]"/>
+    <function name="write" model="planning.slot">
+        <value model="planning.slot" eval="obj().search([('sale_line_id', '=', ref('sale_order_line_7a'))], limit=1).id"/>
+        <value eval="{'resource_id': ref('planning_resource_8')}"/>
+    </function>
+    <function name="write" model="planning.slot">
+        <value model="planning.slot" eval="obj().search([('sale_line_id', '=', ref('sale_order_line_7b'))], limit=1).id"/>
+        <value eval="{'resource_id': ref('planning_resource_1')}"/>
+    </function>
+
+    <function name="action_confirm" model="sale.order" eval="[ref('sale_order_8')]"/>
+    <function name="write" model="planning.slot">
+        <value model="planning.slot" eval="obj().search([('sale_line_id', '=', ref('sale_order_line_8'))], limit=1).id"/>
+        <value eval="{'resource_id': ref('planning_resource_2')}"/>
+    </function>
+
+    <function name="action_confirm" model="sale.order" eval="[ref('sale_order_9')]"/>
+    <function name="write" model="planning.slot">
+        <value model="planning.slot" eval="obj().search([('sale_line_id', '=', ref('sale_order_line_9'))], limit=1).id"/>
+        <value eval="{'resource_id': ref('planning_resource_3')}"/>
+    </function>
+
+    <function name="action_confirm" model="sale.order" eval="[ref('sale_order_10')]"/>
+    <function name="write" model="planning.slot">
+        <value model="planning.slot" eval="obj().search([('sale_line_id', '=', ref('sale_order_line_10'))], limit=1).id"/>
+        <value eval="{'resource_id': ref('planning_resource_4')}"/>
+    </function>
+
+    <function name="action_confirm" model="sale.order" eval="[ref('sale_order_11')]"/>
+    <function name="write" model="planning.slot">
+        <value model="planning.slot" eval="obj().search([('sale_line_id', '=', ref('sale_order_line_11a'))], limit=1).id"/>
+        <value eval="{'resource_id': ref('planning_resource_15')}"/>
+    </function>
+    <function name="write" model="planning.slot">
+        <value model="planning.slot" eval="obj().search([('sale_line_id', '=', ref('sale_order_line_11b'))], limit=1).id"/>
+        <value eval="{'resource_id': ref('planning_resource_11')}"/>
+    </function>
+
+    <function name="action_confirm" model="sale.order" eval="[ref('sale_order_12')]"/>
+    <function name="write" model="planning.slot">
+        <value model="planning.slot" eval="obj().search([('sale_line_id', '=', ref('sale_order_line_12'))], limit=1).id"/>
+        <value eval="{'resource_id': ref('planning_resource_15')}"/>
+    </function>
+
+    <function name="action_confirm" model="sale.order" eval="[ref('sale_order_13')]"/>
+    <function name="write" model="planning.slot">
+        <value model="planning.slot" eval="obj().search([('sale_line_id', '=', ref('sale_order_line_13a'))], limit=1).id"/>
+        <value eval="{'resource_id': ref('planning_resource_15')}"/>
+    </function>
+    <function name="write" model="planning.slot">
+        <value model="planning.slot" eval="obj().search([('sale_line_id', '=', ref('sale_order_line_13b'))], limit=1).id"/>
+        <value eval="{'resource_id': ref('planning_resource_11')}"/>
+    </function>
+    <function name="write" model="planning.slot">
+        <value model="planning.slot" eval="obj().search([('sale_line_id', '=', ref('sale_order_line_13c'))], limit=1).id"/>
+        <value eval="{'resource_id': ref('planning_resource_12')}"/>
+    </function>
+
+    <function name="action_confirm" model="sale.order" eval="[ref('sale_order_14')]"/>
+    <function name="write" model="planning.slot">
+        <value model="planning.slot" eval="obj().search([('sale_line_id', '=', ref('sale_order_line_14'))], limit=1).id"/>
+        <value eval="{'resource_id': ref('planning_resource_16')}"/>
+    </function>
+
+    <function name="action_confirm" model="sale.order" eval="[ref('sale_order_15')]"/>
+    <function name="write" model="planning.slot">
+        <value model="planning.slot" eval="obj().search([('sale_line_id', '=', ref('sale_order_line_15'))], limit=1).id"/>
+        <value eval="{'resource_id': ref('planning_resource_12')}"/>
+    </function>
+
+    <function name="action_confirm" model="sale.order" eval="[ref('sale_order_16')]"/>
+    <function name="write" model="planning.slot">
+        <value model="planning.slot" eval="obj().search([('sale_line_id', '=', ref('sale_order_line_16'))], limit=1).id"/>
+        <value eval="{'resource_id': ref('planning_resource_13')}"/>
+    </function>
+
+    <function name="action_confirm" model="sale.order" eval="[ref('sale_order_17')]"/>
+    <function name="write" model="planning.slot">
+        <value model="planning.slot" eval="obj().search([('sale_line_id', '=', ref('sale_order_line_17'))], limit=1).id"/>
+        <value eval="{'resource_id': ref('planning_resource_13')}"/>
+    </function>
+
+    <function name="action_confirm" model="sale.order" eval="[ref('sale_order_18')]"/>
+    <function name="write" model="planning.slot">
+        <value model="planning.slot" eval="[obj().search([('sale_line_id', '=', ref('sale_order_line_18'))], limit=1).id]"/>
+        <value eval="{'resource_id': ref('planning_resource_10')}"/>
     </function>
 </odoo>

--- a/campsite/static/description/index.html
+++ b/campsite/static/description/index.html
@@ -12,6 +12,9 @@
 <h3><strong>Customizations</strong></h3>
 <ul>
     <li>
+        <strong>Steering:</strong> Capture in record time how your business perform with occupancy and availability monitoring.
+    </li>
+    <li>
         Manage plan, check in and check out your bookings from <strong><font class="text-o-color-1">Campsite App</font></strong>.
     </li>
     <li>

--- a/guest_house/data/ir_ui_menu.xml
+++ b/guest_house/data/ir_ui_menu.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo auto_sequence="1">
+<odoo>
   <record id="booking_engine.booking_engine_menu_root" model="ir.ui.menu" forcecreate="1">
     <field name="web_icon_data" type="base64" file="guest_house/static/description/icon.png"/>
     <field name="name">Guest House</field>

--- a/guest_house/data/knowledge_article.xml
+++ b/guest_house/data/knowledge_article.xml
@@ -289,6 +289,25 @@
                 class="btn btn-secondary">🎓 Invoicing</a>
         </p>
         <p><br/></p>
+        <h3>🚀 Strategic Oversight</h3>
+        <hr/>
+        <p>Beyond daily operations, the Steering menu serves as the "Captain’s Bridge" of your guest house. It provides a 500-day horizon to anticipate market trends, manage risks, and optimize your revenue.</p>
+        <h4>Monitoring success with occupancy</h4>
+        <p>The Occupancy view allows you to visualize your "Sales Success". It answers one simple question: <i>How well am I filling my guest house?</i></p>
+        <ul>
+            <li>Open the Steering menu and select Occupancy.</li>
+            <li>The Gantt chart is color-coded to reflect on the occupancy, the higher the better.</li>
+            <li>Access to more details clicking the slot.</li>
+        </ul>
+
+        <h4>Managing scarcity with availability</h4>
+        <p>While Occupancy focuses on what is full, the Availability view focuses on what is left to sell. It is your primary tool for operational safety and "Scarcity Pricing."</p>
+        <ul>
+            <li>Open the Steering menu and select Availability.</li>
+            <li>The Gantt chart is color-coded to reflect on the availability for you to work on filling in.</li>
+            <li>Access to more details clicking the slot.</li>
+        </ul>
+        <p><br/></p>
         <h3 >🔢 Running multiple places</h3>
         <hr/>
         <p>You may be running multiple places at the same time and most likely be willing to run them all from the same database.<b/>We got you covered with this using multiple companies or branches!</p>

--- a/guest_house/demo/sale_order.xml
+++ b/guest_house/demo/sale_order.xml
@@ -42,4 +42,67 @@
         <field name="rental_start_date" eval="datetime.today().date() + relativedelta(days=4)"/>
         <field name="rental_return_date" eval="datetime.today().date() + relativedelta(days=7)"/>
     </record>
+    <record id="sale_order_7" model="sale.order">
+        <field name="partner_id" ref="base_industry_data.res_partner_23"/>
+        <field name="user_id" ref="base.user_admin"/>
+        <field name="is_rental_order" eval="True"/>
+        <field name="rental_start_date" eval="datetime.today().date() - relativedelta(days=2)"/>
+        <field name="rental_return_date" eval="datetime.today().date()"/>
+    </record>
+    <record id="sale_order_8" model="sale.order">
+        <field name="partner_id" ref="base_industry_data.res_partner_25"/>
+        <field name="user_id" ref="base.user_admin"/>
+        <field name="is_rental_order" eval="True"/>
+        <field name="rental_start_date" eval="datetime.today().date() + relativedelta(days=2)"/>
+        <field name="rental_return_date" eval="datetime.today().date() + relativedelta(days=5)"/>
+    </record>
+    <record id="sale_order_9" model="sale.order">
+        <field name="partner_id" ref="base_industry_data.res_partner_22"/>
+        <field name="user_id" ref="base.user_admin"/>
+        <field name="is_rental_order" eval="True"/>
+        <field name="rental_start_date" eval="datetime.today().date() + relativedelta(days=7)"/>
+        <field name="rental_return_date" eval="datetime.today().date() + relativedelta(days=10)"/>
+    </record>
+    <record id="sale_order_10" model="sale.order">
+        <field name="partner_id" ref="base_industry_data.res_partner_24"/>
+        <field name="user_id" ref="base.user_admin"/>
+        <field name="is_rental_order" eval="True"/>
+        <field name="rental_start_date" eval="datetime.today().date()"/>
+        <field name="rental_return_date" eval="datetime.today().date() + relativedelta(days=3)"/>
+    </record>
+    <record id="sale_order_11" model="sale.order">
+        <field name="partner_id" ref="base_industry_data.res_partner_28"/>
+        <field name="user_id" ref="base.user_admin"/>
+        <field name="is_rental_order" eval="True"/>
+        <field name="rental_start_date" eval="datetime.today().date() + relativedelta(days=9)"/>
+        <field name="rental_return_date" eval="datetime.today().date() + relativedelta(days=10)"/>
+    </record>
+    <record id="sale_order_12" model="sale.order">
+        <field name="partner_id" ref="base_industry_data.res_partner_30"/>
+        <field name="user_id" ref="base.user_admin"/>
+        <field name="is_rental_order" eval="True"/>
+        <field name="rental_start_date" eval="datetime.today().date() + relativedelta(days=3)"/>
+        <field name="rental_return_date" eval="datetime.today().date() + relativedelta(days=7)"/>
+    </record>
+    <record id="sale_order_13" model="sale.order">
+        <field name="partner_id" ref="base_industry_data.res_partner_23"/>
+        <field name="user_id" ref="base.user_admin"/>
+        <field name="is_rental_order" eval="True"/>
+        <field name="rental_start_date" eval="datetime.today().date() + relativedelta(days=4)"/>
+        <field name="rental_return_date" eval="datetime.today().date() + relativedelta(days=5)"/>
+    </record>
+    <record id="sale_order_14" model="sale.order">
+        <field name="partner_id" ref="base_industry_data.res_partner_22"/>
+        <field name="user_id" ref="base.user_admin"/>
+        <field name="is_rental_order" eval="True"/>
+        <field name="rental_start_date" eval="datetime.today().date() - relativedelta(days=2)"/>
+        <field name="rental_return_date" eval="datetime.today().date() + relativedelta(days=1)"/>
+    </record>
+    <record id="sale_order_15" model="sale.order">
+        <field name="partner_id" ref="base_industry_data.res_partner_21"/>
+        <field name="user_id" ref="base.user_admin"/>
+        <field name="is_rental_order" eval="True"/>
+        <field name="rental_start_date" eval="datetime.today().date() + relativedelta(days=6)"/>
+        <field name="rental_return_date" eval="datetime.today().date() + relativedelta(days=13)"/>
+    </record>
 </odoo>

--- a/guest_house/demo/sale_order_line.xml
+++ b/guest_house/demo/sale_order_line.xml
@@ -40,4 +40,64 @@
     <field name="product_id" ref="product_product_19"/>
     <field name="is_rental" eval="True"/>
   </record>
+  <record id="sale_order_line_7a" model="sale.order.line">
+    <field name="order_id" ref="sale_order_7"/>
+    <field name="product_id" ref="product_product_17"/>
+    <field name="is_rental" eval="True"/>
+  </record>
+  <record id="sale_order_line_7b" model="sale.order.line">
+    <field name="order_id" ref="sale_order_7"/>
+    <field name="product_id" ref="product_product_16"/>
+    <field name="is_rental" eval="True"/>
+  </record>
+  <record id="sale_order_line_8" model="sale.order.line">
+    <field name="order_id" ref="sale_order_8"/>
+    <field name="product_id" ref="product_product_17"/>
+    <field name="is_rental" eval="True"/>
+  </record>
+  <record id="sale_order_line_9a" model="sale.order.line">
+    <field name="order_id" ref="sale_order_9"/>
+    <field name="product_id" ref="product_product_14"/>
+    <field name="is_rental" eval="True"/>
+  </record>
+  <record id="sale_order_line_9b" model="sale.order.line">
+    <field name="order_id" ref="sale_order_9"/>
+    <field name="product_id" ref="product_product_16"/>
+    <field name="is_rental" eval="True"/>
+  </record>
+  <record id="sale_order_line_9c" model="sale.order.line">
+    <field name="order_id" ref="sale_order_9"/>
+    <field name="product_id" ref="product_product_18"/>
+    <field name="is_rental" eval="True"/>
+  </record>
+  <record id="sale_order_line_10" model="sale.order.line">
+    <field name="order_id" ref="sale_order_10"/>
+    <field name="product_id" ref="product_product_19"/>
+    <field name="is_rental" eval="True"/>
+  </record>
+  <record id="sale_order_line_11" model="sale.order.line">
+    <field name="order_id" ref="sale_order_11"/>
+    <field name="product_id" ref="product_product_19"/>
+    <field name="is_rental" eval="True"/>
+  </record>
+  <record id="sale_order_line_12" model="sale.order.line">
+    <field name="order_id" ref="sale_order_12"/>
+    <field name="product_id" ref="product_product_16"/>
+    <field name="is_rental" eval="True"/>
+  </record>
+  <record id="sale_order_line_13" model="sale.order.line">
+    <field name="order_id" ref="sale_order_13"/>
+    <field name="product_id" ref="product_product_18"/>
+    <field name="is_rental" eval="True"/>
+  </record>
+  <record id="sale_order_line_14" model="sale.order.line">
+    <field name="order_id" ref="sale_order_14"/>
+    <field name="product_id" ref="product_product_15"/>
+    <field name="is_rental" eval="True"/>
+  </record>
+  <record id="sale_order_line_15" model="sale.order.line">
+    <field name="order_id" ref="sale_order_15"/>
+    <field name="product_id" ref="product_product_15"/>
+    <field name="is_rental" eval="True"/>
+  </record>
 </odoo>

--- a/guest_house/demo/sale_order_post.xml
+++ b/guest_house/demo/sale_order_post.xml
@@ -73,4 +73,15 @@
         <field name="x_guest_partner_id" ref="base_industry_data.res_partner_26"/>
         <field name="x_room_resource_id" model="resource.resource" eval="obj().env.ref('guest_house.sale_order_6').order_line[:1].x_resource_id.id"/>
     </record>
+
+    <!-- one by one to avoid scheduling problems due to recomputation of start/end dates by our custom -->
+    <function name="action_confirm" model="sale.order" eval="[ref('sale_order_7')]"/>
+    <function name="action_confirm" model="sale.order" eval="[ref('sale_order_8')]"/>
+    <function name="action_confirm" model="sale.order" eval="[ref('sale_order_9')]"/>
+    <function name="action_confirm" model="sale.order" eval="[ref('sale_order_10')]"/>
+    <function name="action_confirm" model="sale.order" eval="[ref('sale_order_11')]"/>
+    <function name="action_confirm" model="sale.order" eval="[ref('sale_order_12')]"/>
+    <function name="action_confirm" model="sale.order" eval="[ref('sale_order_13')]"/>
+    <function name="action_confirm" model="sale.order" eval="[ref('sale_order_14')]"/>
+    <function name="action_confirm" model="sale.order" eval="[ref('sale_order_15')]"/>
 </odoo>

--- a/guest_house/static/description/index.html
+++ b/guest_house/static/description/index.html
@@ -12,6 +12,9 @@
 <h3><strong>Customizations</strong></h3>
 <ul>
     <li>
+        <strong>Steering:</strong> Capture in record time how your business perform with occupancy and availability monitoring.
+    </li>
+    <li>
         Manage plan, check in and check out your bookings from <strong><font class="text-o-color-1">Guest House App</font></strong>.
     </li>
     <li>

--- a/holiday_house/data/knowledge_article.xml
+++ b/holiday_house/data/knowledge_article.xml
@@ -236,6 +236,25 @@ The Holiday House App relies on the Rental and Planning Apps binding, with a few
         <a class="btn btn-secondary" href="https://www.odoo.com/documentation/latest/applications/finance/accounting.html">🎓 Invoicing</a>
     </p>
     <p><br/></p>
+    <h3>🚀 Strategic Oversight</h3>
+    <hr/>
+    <p>Beyond daily operations, the Steering menu serves as the "Captain’s Bridge" of your holiday houses. It provides a 500-day horizon to anticipate market trends, manage risks, and optimize your revenue.</p>
+    <h4>Monitoring success with occupancy</h4>
+    <p>The Occupancy view allows you to visualize your "Sales Success". It answers one simple question: <i>How well am I filling my holiday houses?</i></p>
+    <ul>
+        <li>Open the Steering menu and select Occupancy.</li>
+        <li>The Gantt chart is color-coded to reflect on the occupancy, the higher the better.</li>
+        <li>Access to more details clicking the slot.</li>
+    </ul>
+
+    <h4>Managing scarcity with availability</h4>
+    <p>While Occupancy focuses on what is full, the Availability view focuses on what is left to sell. It is your primary tool for operational safety and "Scarcity Pricing."</p>
+    <ul>
+        <li>Open the Steering menu and select Availability.</li>
+        <li>The Gantt chart is color-coded to reflect on the availability for you to work on filling in.</li>
+        <li>Access to more details clicking the slot.</li>
+    </ul>
+    <p><br/></p>
     <h3 >🔢 Running multiple places</h3>
     <hr/>
     <p>You may be running multiple places at the same time and most likely be willing to run them all from the same database.<b/>We got you covered with this using multiple companies or branches!</p>

--- a/holiday_house/data/views.xml
+++ b/holiday_house/data/views.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo auto_sequence="1">
+<odoo>
   <record id="booking_engine.booking_engine_menu_root" model="ir.ui.menu" forcecreate="1">
     <field name="web_icon_data" type="base64" file="holiday_house/static/description/icon.png"/>
     <field name="name">Holiday House</field>

--- a/holiday_house/demo/sale_order.xml
+++ b/holiday_house/demo/sale_order.xml
@@ -35,4 +35,46 @@
         <field name="rental_start_date" eval="datetime.today().date() + relativedelta(days=5)"/>
         <field name="rental_return_date" eval="datetime.today().date() + relativedelta(days=15)"/>
     </record>
+    <record id="sale_order_6" model="sale.order">
+        <field name="partner_id" ref="base_industry_data.res_partner_26"/>
+        <field name="user_id" ref="base.user_admin"/>
+        <field name="is_rental_order" eval="True"/>
+        <field name="rental_start_date" eval="datetime.today().date() - relativedelta(days=2)"/>
+        <field name="rental_return_date" eval="datetime.today().date()"/>
+    </record>
+    <record id="sale_order_7" model="sale.order">
+        <field name="partner_id" ref="base_industry_data.res_partner_22"/>
+        <field name="user_id" ref="base.user_admin"/>
+        <field name="is_rental_order" eval="True"/>
+        <field name="rental_start_date" eval="datetime.today().date() + relativedelta(days=3)"/>
+        <field name="rental_return_date" eval="datetime.today().date() + relativedelta(days=5)"/>
+    </record>
+    <record id="sale_order_8" model="sale.order">
+        <field name="partner_id" ref="base_industry_data.res_partner_30"/>
+        <field name="user_id" ref="base.user_admin"/>
+        <field name="is_rental_order" eval="True"/>
+        <field name="rental_start_date" eval="datetime.today().date() + relativedelta(days=7)"/>
+        <field name="rental_return_date" eval="datetime.today().date() + relativedelta(days=8)"/>
+    </record>
+    <record id="sale_order_9" model="sale.order">
+        <field name="partner_id" ref="base_industry_data.res_partner_25"/>
+        <field name="user_id" ref="base.user_admin"/>
+        <field name="is_rental_order" eval="True"/>
+        <field name="rental_start_date" eval="datetime.today().date() + relativedelta(days=13)"/>
+        <field name="rental_return_date" eval="datetime.today().date() + relativedelta(days=14)"/>
+    </record>
+    <record id="sale_order_10" model="sale.order">
+        <field name="partner_id" ref="base_industry_data.res_partner_28"/>
+        <field name="user_id" ref="base.user_admin"/>
+        <field name="is_rental_order" eval="True"/>
+        <field name="rental_start_date" eval="datetime.today().date() + relativedelta(days=11)"/>
+        <field name="rental_return_date" eval="datetime.today().date() + relativedelta(days=13)"/>
+    </record>
+    <record id="sale_order_11" model="sale.order">
+        <field name="partner_id" ref="base_industry_data.res_partner_23"/>
+        <field name="user_id" ref="base.user_admin"/>
+        <field name="is_rental_order" eval="True"/>
+        <field name="rental_start_date" eval="datetime.today().date()"/>
+        <field name="rental_return_date" eval="datetime.today().date() + relativedelta(days=3)"/>
+    </record>
 </odoo>

--- a/holiday_house/demo/sale_order_line.xml
+++ b/holiday_house/demo/sale_order_line.xml
@@ -25,4 +25,39 @@
     <field name="product_id" ref="product_product_12"/>
     <field name="is_rental" eval="True"/>
   </record>
+  <record id="sale_order_line_6" model="sale.order.line">
+    <field name="order_id" ref="sale_order_6"/>
+    <field name="product_id" ref="product_product_13"/>
+    <field name="is_rental" eval="True"/>
+  </record>
+  <record id="sale_order_line_7a" model="sale.order.line">
+    <field name="order_id" ref="sale_order_7"/>
+    <field name="product_id" ref="product_product_13"/>
+    <field name="is_rental" eval="True"/>
+  </record>
+  <record id="sale_order_line_7b" model="sale.order.line">
+    <field name="order_id" ref="sale_order_7"/>
+    <field name="product_id" ref="product_product_12"/>
+    <field name="is_rental" eval="True"/>
+  </record>
+  <record id="sale_order_line_8" model="sale.order.line">
+    <field name="order_id" ref="sale_order_8"/>
+    <field name="product_id" ref="product_product_13"/>
+    <field name="is_rental" eval="True"/>
+  </record>
+  <record id="sale_order_line_9" model="sale.order.line">
+    <field name="order_id" ref="sale_order_9"/>
+    <field name="product_id" ref="product_product_13"/>
+    <field name="is_rental" eval="True"/>
+  </record>
+  <record id="sale_order_line_10" model="sale.order.line">
+    <field name="order_id" ref="sale_order_10"/>
+    <field name="product_id" ref="product_product_14"/>
+    <field name="is_rental" eval="True"/>
+  </record>
+  <record id="sale_order_line_11" model="sale.order.line">
+    <field name="order_id" ref="sale_order_11"/>
+    <field name="product_id" ref="product_product_12"/>
+    <field name="is_rental" eval="True"/>
+  </record>
 </odoo>

--- a/holiday_house/demo/sale_order_post.xml
+++ b/holiday_house/demo/sale_order_post.xml
@@ -59,10 +59,14 @@
         <value model="sale.order.line" eval="obj().search([('order_id', '=', ref('sale_order_1')), ('product_id', '=', ref('booking_engine.product_product_city_tax'))], limit=1).id" />
         <value eval="{'qty_delivered': 7}" />
     </function>
-    <function name="action_confirm" model="sale.order">
-        <value eval="[
-            ref('sale_order_4'),
-            ref('sale_order_5'),
-        ]"/>
-    </function>
+
+    <!-- one by one to avoid scheduling problems due to recomputation of start/end dates by our custom -->
+    <function name="action_confirm" model="sale.order" eval="[ref('sale_order_4')]"/>
+    <function name="action_confirm" model="sale.order" eval="[ref('sale_order_5')]"/>
+    <function name="action_confirm" model="sale.order" eval="[ref('sale_order_6')]"/>
+    <function name="action_confirm" model="sale.order" eval="[ref('sale_order_7')]"/>
+    <function name="action_confirm" model="sale.order" eval="[ref('sale_order_8')]"/>
+    <function name="action_confirm" model="sale.order" eval="[ref('sale_order_9')]"/>
+    <function name="action_confirm" model="sale.order" eval="[ref('sale_order_10')]"/>
+    <function name="action_confirm" model="sale.order" eval="[ref('sale_order_11')]"/>
 </odoo>

--- a/holiday_house/static/description/index.html
+++ b/holiday_house/static/description/index.html
@@ -12,6 +12,9 @@
 <h3><strong>Customizations</strong></h3>
 <ul>
     <li>
+        <strong>Steering:</strong> Capture in record time how your business perform with occupancy and availability monitoring.
+    </li>
+    <li>
         Manage plan, check in and check out your bookings from <strong><font class="text-o-color-1">Holiday House App</font></strong>.
     </li>
     <li>

--- a/hotel/data/knowledge_article.xml
+++ b/hotel/data/knowledge_article.xml
@@ -361,6 +361,25 @@
                 class="btn btn-fill-secondary">🎓 POS</a>
         </p>
         <p><br/></p>
+        <h3>🚀 Strategic Oversight</h3>
+        <hr/>
+        <p>Beyond daily operations, the Steering menu serves as the "Captain’s Bridge" of your hotel. It provides a 500-day horizon to anticipate market trends, manage risks, and optimize your revenue.</p>
+        <h4>Monitoring success with occupancy</h4>
+        <p>The Occupancy view allows you to visualize your "Sales Success". It answers one simple question: <i>How well am I filling my hotel?</i></p>
+        <ul>
+            <li>Open the Steering menu and select Occupancy.</li>
+            <li>The Gantt chart is color-coded to reflect on the occupancy, the higher the better.</li>
+            <li>Access to more details clicking the slot.</li>
+        </ul>
+
+        <h4>Managing scarcity with availability</h4>
+        <p>While Occupancy focuses on what is full, the Availability view focuses on what is left to sell. It is your primary tool for operational safety and "Scarcity Pricing."</p>
+        <ul>
+            <li>Open the Steering menu and select Availability.</li>
+            <li>The Gantt chart is color-coded to reflect on the availability for you to work on filling in.</li>
+            <li>Access to more details clicking the slot.</li>
+        </ul>
+        <p><br/></p>
         <h3 >🔢 Running multiple places</h3>
         <hr/>
         <p>You may be running multiple places at the same time and most likely be willing to run them all from the same database.<b/>We got you covered with this using multiple companies or branches!</p>

--- a/hotel/demo/sale_order.xml
+++ b/hotel/demo/sale_order.xml
@@ -35,4 +35,102 @@
         <field name="rental_start_date" eval="datetime.today().date() + relativedelta(days=5)"/>
         <field name="rental_return_date" eval="datetime.today().date() + relativedelta(days=15)"/>
     </record>
+    <record id="sale_order_6" model="sale.order">
+        <field name="partner_id" ref="base_industry_data.res_partner_23"/>
+        <field name="user_id" ref="base.user_admin"/>
+        <field name="is_rental_order" eval="True"/>
+        <field name="rental_start_date" eval="datetime.today().date() - relativedelta(days=2)"/>
+        <field name="rental_return_date" eval="datetime.today().date()"/>
+    </record>
+    <record id="sale_order_7" model="sale.order">
+        <field name="partner_id" ref="base_industry_data.res_partner_23"/>
+        <field name="user_id" ref="base.user_admin"/>
+        <field name="is_rental_order" eval="True"/>
+        <field name="rental_start_date" eval="datetime.today().date() + relativedelta(days=2)"/>
+        <field name="rental_return_date" eval="datetime.today().date() + relativedelta(days=5)"/>
+    </record>
+    <record id="sale_order_8" model="sale.order">
+        <field name="partner_id" ref="base_industry_data.res_partner_30"/>
+        <field name="user_id" ref="base.user_admin"/>
+        <field name="is_rental_order" eval="True"/>
+        <field name="rental_start_date" eval="datetime.today().date() + relativedelta(days=8)"/>
+        <field name="rental_return_date" eval="datetime.today().date() + relativedelta(days=11)"/>
+    </record>
+    <record id="sale_order_9" model="sale.order">
+        <field name="partner_id" ref="base_industry_data.res_partner_24"/>
+        <field name="user_id" ref="base.user_admin"/>
+        <field name="is_rental_order" eval="True"/>
+        <field name="rental_start_date" eval="datetime.today().date() - relativedelta(days=1)"/>
+        <field name="rental_return_date" eval="datetime.today().date() + relativedelta(days=4)"/>
+    </record>
+    <record id="sale_order_10" model="sale.order">
+        <field name="partner_id" ref="base_industry_data.res_partner_25"/>
+        <field name="user_id" ref="base.user_admin"/>
+        <field name="is_rental_order" eval="True"/>
+        <field name="rental_start_date" eval="datetime.today().date()"/>
+        <field name="rental_return_date" eval="datetime.today().date() + relativedelta(days=4)"/>
+    </record>
+    <record id="sale_order_11" model="sale.order">
+        <field name="partner_id" ref="base_industry_data.res_partner_30"/>
+        <field name="user_id" ref="base.user_admin"/>
+        <field name="is_rental_order" eval="True"/>
+        <field name="rental_start_date" eval="datetime.today().date() - relativedelta(days=2)"/>
+        <field name="rental_return_date" eval="datetime.today().date() + relativedelta(days=1)"/>
+    </record>
+    <record id="sale_order_12" model="sale.order">
+        <field name="partner_id" ref="base_industry_data.res_partner_20"/>
+        <field name="user_id" ref="base.user_admin"/>
+        <field name="is_rental_order" eval="True"/>
+        <field name="rental_start_date" eval="datetime.today().date() + relativedelta(days=1)"/>
+        <field name="rental_return_date" eval="datetime.today().date() + relativedelta(days=5)"/>
+    </record>
+    <record id="sale_order_13" model="sale.order">
+        <field name="partner_id" ref="base_industry_data.res_partner_21"/>
+        <field name="user_id" ref="base.user_admin"/>
+        <field name="is_rental_order" eval="True"/>
+        <field name="rental_start_date" eval="datetime.today().date() + relativedelta(days=11)"/>
+        <field name="rental_return_date" eval="datetime.today().date() + relativedelta(days=15)"/>
+    </record>
+    <record id="sale_order_14" model="sale.order">
+        <field name="partner_id" ref="base_industry_data.res_partner_26"/>
+        <field name="user_id" ref="base.user_admin"/>
+        <field name="is_rental_order" eval="True"/>
+        <field name="rental_start_date" eval="datetime.today().date()"/>
+        <field name="rental_return_date" eval="datetime.today().date() + relativedelta(days=4)"/>
+    </record>
+    <record id="sale_order_15" model="sale.order">
+        <field name="partner_id" ref="base_industry_data.res_partner_26"/>
+        <field name="user_id" ref="base.user_admin"/>
+        <field name="is_rental_order" eval="True"/>
+        <field name="rental_start_date" eval="datetime.today().date() + relativedelta(days=7)"/>
+        <field name="rental_return_date" eval="datetime.today().date() + relativedelta(days=13)"/>
+    </record>
+    <record id="sale_order_16" model="sale.order">
+        <field name="partner_id" ref="base_industry_data.res_partner_22"/>
+        <field name="user_id" ref="base.user_admin"/>
+        <field name="is_rental_order" eval="True"/>
+        <field name="rental_start_date" eval="datetime.today().date() + relativedelta(days=3)"/>
+        <field name="rental_return_date" eval="datetime.today().date() + relativedelta(days=11)"/>
+    </record>
+    <record id="sale_order_17" model="sale.order">
+        <field name="partner_id" ref="base_industry_data.res_partner_30"/>
+        <field name="user_id" ref="base.user_admin"/>
+        <field name="is_rental_order" eval="True"/>
+        <field name="rental_start_date" eval="datetime.today().date() - relativedelta(days=4)"/>
+        <field name="rental_return_date" eval="datetime.today().date()"/>
+    </record>
+    <record id="sale_order_18" model="sale.order">
+        <field name="partner_id" ref="base_industry_data.res_partner_30"/>
+        <field name="user_id" ref="base.user_admin"/>
+        <field name="is_rental_order" eval="True"/>
+        <field name="rental_start_date" eval="datetime.today().date() + relativedelta(days=3)"/>
+        <field name="rental_return_date" eval="datetime.today().date() + relativedelta(days=5)"/>
+    </record>
+    <record id="sale_order_19" model="sale.order">
+        <field name="partner_id" ref="base_industry_data.res_partner_28"/>
+        <field name="user_id" ref="base.user_admin"/>
+        <field name="is_rental_order" eval="True"/>
+        <field name="rental_start_date" eval="datetime.today().date() + relativedelta(days=11)"/>
+        <field name="rental_return_date" eval="datetime.today().date() + relativedelta(days=13)"/>
+    </record>
 </odoo>

--- a/hotel/demo/sale_order_line.xml
+++ b/hotel/demo/sale_order_line.xml
@@ -39,4 +39,81 @@
     <field name="product_id" ref="standard_room_2p_breakfast"/>
     <field name="is_rental" eval="True"/>
   </record>
+  <record id="sale_order_line_6a" model="sale.order.line">
+    <field name="order_id" ref="sale_order_6"/>
+    <field name="product_id" ref="standard_room_1p_breakfast"/>
+    <field name="is_rental" eval="True"/>
+  </record>
+  <record id="sale_order_line_6b" model="sale.order.line">
+    <field name="order_id" ref="sale_order_6"/>
+    <field name="product_id" ref="standard_room_1p_breakfast"/>
+    <field name="is_rental" eval="True"/>
+  </record>
+  <record id="sale_order_line_7" model="sale.order.line">
+    <field name="order_id" ref="sale_order_7"/>
+    <field name="product_id" ref="standard_room_1p_breakfast"/>
+    <field name="is_rental" eval="True"/>
+  </record>
+  <record id="sale_order_line_8" model="sale.order.line">
+    <field name="order_id" ref="sale_order_8"/>
+    <field name="product_id" ref="standard_room_1p_breakfast"/>
+    <field name="is_rental" eval="True"/>
+    <field name="product_uom_qty">3</field>
+  </record>
+  <record id="sale_order_line_9" model="sale.order.line">
+    <field name="order_id" ref="sale_order_9"/>
+    <field name="product_id" ref="standard_room_1p_breakfast"/>
+    <field name="is_rental" eval="True"/>
+  </record>
+  <record id="sale_order_line_10" model="sale.order.line">
+    <field name="order_id" ref="sale_order_10"/>
+    <field name="product_id" ref="standard_room_1p_breakfast"/>
+    <field name="is_rental" eval="True"/>
+  </record>
+  <record id="sale_order_line_11" model="sale.order.line">
+    <field name="order_id" ref="sale_order_11"/>
+    <field name="product_id" ref="standard_room_1p_breakfast"/>
+    <field name="is_rental" eval="True"/>
+  </record>
+  <record id="sale_order_line_12" model="sale.order.line">
+    <field name="order_id" ref="sale_order_12"/>
+    <field name="product_id" ref="standard_room_1p_breakfast"/>
+    <field name="is_rental" eval="True"/>
+  </record>
+  <record id="sale_order_line_13" model="sale.order.line">
+    <field name="order_id" ref="sale_order_13"/>
+    <field name="product_id" ref="standard_room_1p_breakfast"/>
+    <field name="is_rental" eval="True"/>
+  </record>
+  <record id="sale_order_line_14" model="sale.order.line">
+    <field name="order_id" ref="sale_order_14"/>
+    <field name="product_id" ref="deluxe_room_1p_breakfast"/>
+    <field name="is_rental" eval="True"/>
+  </record>
+  <record id="sale_order_line_15" model="sale.order.line">
+    <field name="order_id" ref="sale_order_15"/>
+    <field name="product_id" ref="deluxe_room_1p_breakfast"/>
+    <field name="is_rental" eval="True"/>
+  </record>
+  <record id="sale_order_line_16" model="sale.order.line">
+    <field name="order_id" ref="sale_order_16"/>
+    <field name="product_id" ref="deluxe_room_1p_breakfast"/>
+    <field name="is_rental" eval="True"/>
+    <field name="product_uom_qty">2</field>
+  </record>
+  <record id="sale_order_line_17" model="sale.order.line">
+    <field name="order_id" ref="sale_order_17"/>
+    <field name="product_id" ref="deluxe_room_1p_breakfast"/>
+    <field name="is_rental" eval="True"/>
+  </record>
+  <record id="sale_order_line_18" model="sale.order.line">
+    <field name="order_id" ref="sale_order_18"/>
+    <field name="product_id" ref="deluxe_suite_1p_breakfast"/>
+    <field name="is_rental" eval="True"/>
+  </record>
+  <record id="sale_order_line_19" model="sale.order.line">
+    <field name="order_id" ref="sale_order_19"/>
+    <field name="product_id" ref="deluxe_suite_1p_breakfast"/>
+    <field name="is_rental" eval="True"/>
+  </record>
 </odoo>

--- a/hotel/demo/sale_order_post.xml
+++ b/hotel/demo/sale_order_post.xml
@@ -63,10 +63,132 @@
         <value model="sale.order.line" eval="obj().search([('order_id', '=', ref('sale_order_1')), ('product_id', '=', ref('product_product_17'))], limit=1).id" />
         <value eval="{'qty_delivered': 2}" />
     </function>
-    <function name="action_confirm" model="sale.order">
-        <value eval="[
-            ref('sale_order_4'),
-            ref('sale_order_5'),
-        ]"/>
+
+    <!-- manually assign the slots to circumvent the undeterministic algorithm causing scheduling conflicts -->
+    <function name="write" model="planning.slot">
+        <value model="planning.slot" eval="[obj().search([('sale_line_id', '=', ref('sale_order_line_1a'))], limit=1).id]"/>
+        <value eval="{'resource_id': ref('planning_resource_4')}"/>
+    </function>
+
+    <function name="write" model="planning.slot">
+        <value model="planning.slot" eval="obj().search([('sale_line_id', '=', ref('sale_order_line_2'))], limit=1).id"/>
+        <value eval="{'resource_id': ref('planning_resource_10')}"/>
+    </function>
+
+    <function name="write" model="planning.slot">
+        <value model="planning.slot" eval="obj().search([('sale_line_id', '=', ref('sale_order_line_3a'))], limit=1).id"/>
+        <value eval="{'resource_id': ref('planning_resource_7')}"/>
+    </function>
+
+    <function name="action_confirm" model="sale.order" eval="[ref('sale_order_4')]"/>
+    <function name="write" model="planning.slot">
+        <value model="planning.slot" eval="obj().search([('sale_line_id', '=', ref('sale_order_line_4'))], limit=1).id"/>
+        <value eval="{'resource_id': ref('planning_resource_3')}"/>
+    </function>
+
+    <function name="action_confirm" model="sale.order" eval="[ref('sale_order_5')]"/>
+    <function name="write" model="planning.slot">
+        <value model="planning.slot" eval="obj().search([('sale_line_id', '=', ref('sale_order_line_5'))], limit=1).id"/>
+        <value eval="{'resource_id': ref('planning_resource_2')}"/>
+    </function>
+
+    <function name="action_confirm" model="sale.order" eval="[ref('sale_order_6')]"/>
+    <function name="write" model="planning.slot">
+        <value model="planning.slot" eval="obj().search([('sale_line_id', '=', ref('sale_order_line_6a'))], limit=1).id"/>
+        <value eval="{'resource_id': ref('planning_resource_1')}"/>
+    </function>
+    <function name="write" model="planning.slot">
+        <value model="planning.slot" eval="obj().search([('sale_line_id', '=', ref('sale_order_line_6b'))], limit=1).id"/>
+        <value eval="{'resource_id': ref('planning_resource_3')}"/>
+    </function>
+
+    <function name="action_confirm" model="sale.order" eval="[ref('sale_order_7')]"/>
+    <function name="write" model="planning.slot">
+        <value model="planning.slot" eval="obj().search([('sale_line_id', '=', ref('sale_order_line_7'))], order='id DESC', limit=1).id"/>
+        <value eval="{'resource_id': ref('planning_resource_1')}"/>
+    </function>
+    
+    <function name="action_confirm" model="sale.order" eval="[ref('sale_order_8')]"/>
+    <function name="write" model="planning.slot">
+        <value model="planning.slot" eval="obj().search([('sale_line_id', '=', ref('sale_order_line_8'))], order='id DESC')[0].id"/>
+        <value eval="{'resource_id': ref('planning_resource_1')}"/>
+    </function>
+    <function name="write" model="planning.slot">
+        <value model="planning.slot" eval="obj().search([('sale_line_id', '=', ref('sale_order_line_8'))], order='id DESC')[1].id"/>
+        <value eval="{'resource_id': ref('planning_resource_3')}"/>
+    </function>
+    <function name="write" model="planning.slot">
+        <value model="planning.slot" eval="obj().search([('sale_line_id', '=', ref('sale_order_line_8'))], order='id DESC')[2].id"/>
+        <value eval="{'resource_id': ref('planning_resource_4')}"/>
+    </function>
+
+    <function name="action_confirm" model="sale.order" eval="[ref('sale_order_9')]"/>
+    <function name="write" model="planning.slot">
+        <value model="planning.slot" eval="obj().search([('sale_line_id', '=', ref('sale_order_line_9'))], limit=1).id"/>
+        <value eval="{'resource_id': ref('planning_resource_2')}"/>
+    </function>
+
+    <function name="action_confirm" model="sale.order" eval="[ref('sale_order_10')]"/>
+    <function name="write" model="planning.slot">
+        <value model="planning.slot" eval="obj().search([('sale_line_id', '=', ref('sale_order_line_10'))], limit=1).id"/>
+        <value eval="{'resource_id': ref('planning_resource_4')}"/>
+    </function>
+
+    <function name="action_confirm" model="sale.order" eval="[ref('sale_order_11')]"/>
+    <function name="write" model="planning.slot">
+        <value model="planning.slot" eval="obj().search([('sale_line_id', '=', ref('sale_order_line_11'))], limit=1).id"/>
+        <value eval="{'resource_id': ref('planning_resource_5')}"/>
+    </function>
+
+    <function name="action_confirm" model="sale.order" eval="[ref('sale_order_12')]"/>
+    <function name="write" model="planning.slot">
+        <value model="planning.slot" eval="obj().search([('sale_line_id', '=', ref('sale_order_line_12'))], limit=1).id"/>
+        <value eval="{'resource_id': ref('planning_resource_5')}"/>
+    </function>
+
+    <function name="action_confirm" model="sale.order" eval="[ref('sale_order_13')]"/>
+    <function name="write" model="planning.slot">
+        <value model="planning.slot" eval="obj().search([('sale_line_id', '=', ref('sale_order_line_13'))], limit=1).id"/>
+        <value eval="{'resource_id': ref('planning_resource_5')}"/>
+    </function>
+
+    <function name="action_confirm" model="sale.order" eval="[ref('sale_order_14')]"/>
+    <function name="write" model="planning.slot">
+        <value model="planning.slot" eval="obj().search([('sale_line_id', '=', ref('sale_order_line_14'))], limit=1).id"/>
+        <value eval="{'resource_id': ref('planning_resource_6')}"/>
+    </function>
+
+    <function name="action_confirm" model="sale.order" eval="[ref('sale_order_15')]"/>
+    <function name="write" model="planning.slot">
+        <value model="planning.slot" eval="obj().search([('sale_line_id', '=', ref('sale_order_line_15'))], limit=1).id"/>
+        <value eval="{'resource_id': ref('planning_resource_6')}"/>
+    </function>
+
+    <function name="action_confirm" model="sale.order" eval="[ref('sale_order_16')]"/>
+    <function name="write" model="planning.slot">
+        <value model="planning.slot" eval="obj().search([('sale_line_id', '=', ref('sale_order_line_16'))], order='id DESC')[0].id"/>
+        <value eval="{'resource_id': ref('planning_resource_7')}"/>
+    </function>
+    <function name="write" model="planning.slot">
+        <value model="planning.slot" eval="obj().search([('sale_line_id', '=', ref('sale_order_line_16'))], order='id DESC')[1].id"/>
+        <value eval="{'resource_id': ref('planning_resource_8')}"/>
+    </function>
+
+    <function name="action_confirm" model="sale.order" eval="[ref('sale_order_17')]"/>
+    <function name="write" model="planning.slot">
+        <value model="planning.slot" eval="obj().search([('sale_line_id', '=', ref('sale_order_line_17'))], limit=1).id"/>
+        <value eval="{'resource_id': ref('planning_resource_8')}"/>
+    </function>
+
+    <function name="action_confirm" model="sale.order" eval="[ref('sale_order_18')]"/>
+    <function name="write" model="planning.slot">
+        <value model="planning.slot" eval="obj().search([('sale_line_id', '=', ref('sale_order_line_18'))], limit=1).id"/>
+        <value eval="{'resource_id': ref('planning_resource_9')}"/>
+    </function>
+
+    <function name="action_confirm" model="sale.order" eval="[ref('sale_order_19')]"/>
+    <function name="write" model="planning.slot">
+        <value model="planning.slot" eval="obj().search([('sale_line_id', '=', ref('sale_order_line_19'))], limit=1).id"/>
+        <value eval="{'resource_id': ref('planning_resource_10')}"/>
     </function>
 </odoo>

--- a/hotel/static/description/index.html
+++ b/hotel/static/description/index.html
@@ -13,6 +13,9 @@
 <h2>Basics</h2>
 <ul>
     <li>
+        <strong>Steering:</strong> Capture in record time how your business perform with occupancy and availability monitoring.
+    </li>
+    <li>
         <strong>Website &amp; eCommerce App:</strong> Showcase your rooms and amenities online, enabling customers to
         book directly through a professional, mobile-friendly portal.
     </li>

--- a/tests/test_booking_engine/tests/test_action_server.py
+++ b/tests/test_booking_engine/tests/test_action_server.py
@@ -369,3 +369,347 @@ class BookingEngineAutomationsTestCase(TransactionCase):
                          "City Tax action should search on the current sale order")
         self.assertEqual(action['context'].get('default_x_sale_order_id'), order.id,
                          "City Tax action should default to the current sale order")
+
+    ### Availability / Occupancy
+    def test_automation_availability_product(self):
+        """Test the lifecycle of x_availability records tied to a room offer (create, update, delete)."""
+
+        # Setup
+        tmpl = self.product.product_tmpl_id
+
+        order, order_line = self._create_sale_line(self.product)
+        tmpl.write({'x_is_a_room_offer': True})
+        order.action_confirm()
+
+        slot = order_line.planning_slot_ids[0]
+        slot.write({
+            'resource_id': self.resource.id,
+            'start_datetime': self.today.replace(hour=9),
+            'end_datetime': (self.today + timedelta(days=1)).replace(hour=10),
+        })
+
+        # Assert availabilities exist after creating the product
+        avails = self.env['x_availability'].search([('x_stay_offer_id', '=', tmpl.id)])
+        self.assertTrue(avails, "Availabilities should be created when a room offer is created.")
+        self.assertEqual(len(avails), 500, "Exactly 500 days of availability should be generated.")
+
+        # --- TEST 1: Change the room offer status changes the availabilities ---
+
+        tmpl.write({'x_is_a_room_offer': False})
+
+        avails = self.env['x_availability'].search([('x_stay_offer_id', '=', tmpl.id)])
+        self.assertFalse(avails, "Availabilities should be removed when product is no longer a room offer.")
+
+        tmpl.write({'x_is_a_room_offer': True})
+
+        avails = self.env['x_availability'].search([('x_stay_offer_id', '=', tmpl.id)])
+        self.assertEqual(len(avails), 500, "Availabilities should be recreated when toggled back.")
+
+        # --- TEST 2: Archiving changes the availabilities ---
+
+        tmpl.write({'active': False})
+
+        avails = self.env['x_availability'].with_context(active_test=False).search([('x_stay_offer_id', '=', tmpl.id)])
+        self.assertFalse(avails, "Availabilities should be unlinked when the product is archived.")
+
+        tmpl.write({'active': True})
+
+        avails = self.env['x_availability'].search([('x_stay_offer_id', '=', tmpl.id)])
+        self.assertEqual(len(avails), 500, "Availabilities should be restored when the product is unarchived.")
+
+        # --- TEST 3: Deleting the product changes the availabilities ---
+
+        slot.unlink()
+        order.action_cancel()
+        order.unlink()
+        tmpl.unlink()
+
+        avails = self.env['x_availability'].search([('x_stay_offer_id', '=', tmpl.id)])
+        self.assertFalse(avails, "Availabilities should be completely deleted when the product is deleted.")
+
+    def test_automation_availability_resource_change(self):
+        """Test that changing a room's active state or calendar marks its availabilities for recomputation."""
+
+        # Setup
+        self.room_offer_template.write({
+            'x_resource_ids': [Command.link(self.resource.id)],
+        })
+
+        avails = self.env['x_availability'].search([('x_stay_offer_id', '=', self.room_offer_template.id)])
+        self.assertTrue(avails, "Availabilities should exist for the room offer after linking the resource.")
+
+        # --- CRITICAL ISOLATION STEP ---
+        # Disable the master computation action so it doesn't instantly reset our flags to False
+        master_action = self.env.ref('booking_engine.server_action_update_availabilities')
+        master_action.write({'code': '# Master action disabled for flag testing'})
+
+        # --- TEST 1: Changing the calendar_id flags the correct availabilities ---
+
+        # Reset the dirty flags to False so we can detect the change
+        avails.write({'x_to_recompute': False})
+
+        new_calendar = self.env['resource.calendar'].create({'name': 'New Test Calendar'})
+        self.resource.write({'calendar_id': new_calendar.id})
+
+        avails = self.env['x_availability'].search([('x_stay_offer_id', '=', self.room_offer_template.id)])
+        self.assertTrue(
+            all(a.x_to_recompute for a in avails),
+            "Changing calendar_id on the resource should flag its linked availabilities to recompute.",
+        )
+
+        # --- TEST 2: Archiving the resource flags the correct availabilities ---
+
+        avails.write({'x_to_recompute': False})
+        self.resource.write({'active': False})
+
+        avails = self.env['x_availability'].search([('x_stay_offer_id', '=', self.room_offer_template.id)])
+        self.assertTrue(
+            all(a.x_to_recompute for a in avails),
+            "Archiving the resource should flag its linked availabilities to recompute.",
+        )
+
+        # --- TEST 3: Test a non-triggering field ---
+
+        avails.write({'x_to_recompute': False})
+
+        # Change the name (which is NOT in the automation's trigger_field_ids)
+        self.resource.write({'name': 'Test Room Due Out Renamed'})
+
+        avails = self.env['x_availability'].search([('x_stay_offer_id', '=', self.room_offer_template.id)])
+        self.assertFalse(
+            any(a.x_to_recompute for a in avails),
+            "Changing an untriggered field (like name) should NOT flag availabilities to recompute.",
+        )
+
+    def test_automation_availability_leave_change(self):
+        """Test that creating or modifying a resource leave correctly links and flags availabilities."""
+
+        # Setup
+        calendar = self.env.company.resource_calendar_id
+        self.resource.write({'calendar_id': calendar.id})
+
+        self.room_offer_template.write({
+            'x_resource_ids': [Command.link(self.resource.id)],
+        })
+
+        # --- CRITICAL ISOLATION STEP ---
+        # Disable the master computation action so it doesn't instantly reset our flags to False.
+        master_action = self.env.ref('booking_engine.server_action_update_availabilities')
+        master_action.write({'code': '# Master action disabled for flag testing'})
+
+        # --- TEST 1: Creating a direct resource leave ---
+
+        leave_start = self.today
+        leave_end = self.today + timedelta(days=2)
+
+        leave = self.env['resource.calendar.leaves'].create({
+            'name': 'Test Room Maintenance',
+            'resource_id': self.resource.id,
+            'calendar_id': calendar.id,
+            'date_from': leave_start,
+            'date_to': leave_end,
+        })
+
+        self.assertTrue(leave.x_availability_ids, "Creating a leave should link it to the corresponding daily availabilities.")
+        self.assertTrue(
+            all(a.x_to_recompute for a in leave.x_availability_ids),
+            "Newly linked availabilities from the leave should be flagged to recompute.",
+        )
+
+        # --- TEST 2: Modify the dates ---
+
+        leave.x_availability_ids.write({'x_to_recompute': False})
+
+        leave.write({'date_to': leave_end + timedelta(days=1)})
+
+        # Because the dates changed, the helper should have re-evaluated the links and flagged them
+        self.assertTrue(
+            all(a.x_to_recompute for a in leave.x_availability_ids),
+            "Changing the leave dates should flag the updated availabilities to recompute.",
+        )
+
+        # --- TEST 3: Modify to a Global Leave (Remove resource_id) ---
+
+        leave.x_availability_ids.write({'x_to_recompute': False})
+
+        # Changing from a specific resource leave to a global calendar leave
+        leave.write({'resource_id': False})
+
+        # The automation should catch the change, evaluate the calendar_id, find our resource, and flag it
+        self.assertTrue(
+            all(a.x_to_recompute for a in leave.x_availability_ids),
+            "Changing to a global calendar leave should flag the affected resource availabilities.",
+        )
+
+        # --- TEST 4: Change a non-triggering field ---
+
+        leave.x_availability_ids.write({'x_to_recompute': False})
+
+        # Change the name (NOT in the automation's trigger_field_ids)
+        leave.write({'name': 'Test Room Maintenance Updated'})
+
+        self.assertFalse(
+            any(a.x_to_recompute for a in leave.x_availability_ids),
+            "Changing an untriggered field (like name) should NOT flag availabilities to recompute.",
+        )
+
+    def test_automation_availability_slot_change(self):
+        """Test that creating or modifying a planning slot correctly links and flags availabilities."""
+
+        # Setup
+        self.room_offer_template.write({
+            'x_resource_ids': [Command.link(self.resource.id)],
+        })
+
+        # --- CRITICAL ISOLATION STEP ---
+        # Disable the master computation action so it doesn't instantly reset our flags to False.
+        master_action = self.env.ref('booking_engine.server_action_update_availabilities')
+        master_action.write({'code': '# Master action disabled for flag testing'})
+
+        # --- TEST 1: Create a Slot ---
+
+        # We use the sale order to generate the slot
+        order, order_line = self._create_sale_line(self.product)
+        order.action_confirm()
+
+        slot = order_line.planning_slot_ids[0]
+
+        # Trigger the automation by setting the resource and dates
+        slot.write({
+            'resource_id': self.resource.id,
+            'start_datetime': self.today.replace(hour=9),
+            'end_datetime': (self.today + timedelta(days=2)).replace(hour=10),
+        })
+
+        self.assertTrue(slot.x_availability_ids, "Setting a resource and dates on a slot should link it to daily availabilities.")
+        self.assertTrue(
+            all(a.x_to_recompute for a in slot.x_availability_ids),
+            "Newly linked availabilities from the slot should be flagged to recompute.",
+        )
+
+        # --- TEST 2: Modify the Dates ---
+
+        # Reset the flags on the currently linked availabilities
+        slot.x_availability_ids.write({'x_to_recompute': False})
+
+        # Extend the slot by 1 day
+        slot.write({'end_datetime': (self.today + timedelta(days=3)).replace(hour=10)})
+
+        self.assertTrue(
+            all(a.x_to_recompute for a in slot.x_availability_ids),
+            "Changing the slot dates should flag the updated availabilities to recompute.",
+        )
+
+        # --- TEST 3: Modify the Resource (Drag & Drop behavior) ---
+
+        # Create a second physical room and link it to the offer
+        resource_2 = self.env['resource.resource'].create({
+            'name': 'Test Room 2',
+            'resource_type': 'material',
+        })
+        self.room_offer_template.write({
+            'x_resource_ids': [Command.link(resource_2.id)],
+        })
+
+        old_avails = slot.x_availability_ids
+        old_avails.write({'x_to_recompute': False})
+
+        slot.write({'resource_id': resource_2.id})
+
+        # 1. Did the old availabilities get flagged before unlinking? (Freeing up Room 1)
+        self.assertTrue(
+            all(a.x_to_recompute for a in old_avails),
+            "The previously linked availabilities should be flagged so the old room is freed up.",
+        )
+
+        # 2. Did the new availabilities get linked and flagged? (Occupying Room 2)
+        self.assertTrue(
+            all(a.x_to_recompute for a in slot.x_availability_ids),
+            "The newly linked availabilities should be flagged when the slot moves to a new resource.",
+        )
+
+        # --- TEST 4: Change a non-triggering field ---
+
+        # Reset the flags
+        slot.x_availability_ids.write({'x_to_recompute': False})
+
+        # Change allocated percentage (NOT in the automation's trigger_field_ids)
+        slot.write({'allocated_percentage': 50})
+
+        self.assertFalse(
+            any(a.x_to_recompute for a in slot.x_availability_ids),
+            "Changing an untriggered field (like allocated_percentage) should NOT flag availabilities.",
+        )
+
+    def test_availability_flow_double_book_then_cancel(self):
+        """Integration test to verify the actual math of availability computations during a booking flow."""
+
+        # Setup
+        resource_1 = self.resource
+        resource_2 = self.env['resource.resource'].create({
+            'name': 'Test Room 2',
+            'resource_type': 'material',
+        })
+
+        tmpl = self.product.product_tmpl_id
+        tmpl.write({
+            'x_is_a_room_offer': True,
+            'x_resource_ids': [Command.link(resource_1.id), Command.link(resource_2.id)],
+        })
+
+        # Helper to force the master computation action (in case any triggers use async crons)
+        def force_computation():
+            self.env.ref('booking_engine.server_action_update_availabilities').run()
+
+        force_computation()
+
+        target_date = self.today.date()
+        avail = self.env['x_availability'].search([
+            ('x_stay_offer_id', '=', tmpl.id),
+            ('x_date', '=', target_date),
+        ])
+
+        # --- INITIAL STATE CHECK ---
+        self.assertEqual(avail.x_total_units, 2, "There are 2 physical rooms linked to the offer.")
+        self.assertEqual(avail.x_booked, 0, "No bookings yet, booked count should be 0.")
+
+        # --- FLOW 1: First Reservation ---
+        order1, order_line1 = self._create_sale_line(self.product)
+        order1.action_confirm()
+        slot1 = order_line1.planning_slot_ids[0]
+        slot1.write({
+            'resource_id': resource_1.id,
+            'start_datetime': self.today.replace(hour=15),
+            'end_datetime': (self.today + timedelta(days=1)).replace(hour=11),
+        })
+
+        force_computation()
+        avail.invalidate_recordset()  # Clear ORM cache so we pull the fresh computed values from the DB
+
+        self.assertEqual(avail.x_booked, 1, "First booking should increase x_booked to 1.")
+
+        # --- FLOW 2: Second Reservation (Overlapping on the same day) ---
+        order2, order_line2 = self._create_sale_line(self.product)
+        order2.action_confirm()
+        slot2 = order_line2.planning_slot_ids[0]
+        slot2.write({
+            'resource_id': resource_2.id,
+            'start_datetime': self.today.replace(hour=15),
+            'end_datetime': (self.today + timedelta(days=1)).replace(hour=11),
+        })
+
+        force_computation()
+        avail.invalidate_recordset()
+
+        self.assertEqual(avail.x_booked, 2, "Second booking should increase x_booked to 2.")
+
+        # --- FLOW 3: Cancellation ---
+        # Unlinking the slot simulates the user freeing up the resource on the Gantt chart
+        slot1.unlink()
+        order1.action_cancel()
+
+        force_computation()
+        avail.invalidate_recordset()
+
+        self.assertEqual(avail.x_booked, 1, "Canceling the first booking should reduce x_booked back to 1.")
+        self.assertEqual(avail.x_total_units, 2, "Total units should remain unaffected by bookings/cancellations.")


### PR DESCRIPTION
Adds a new feature for the booking engine: availability & occupancy, which allow the user to monitor the occupancy of their planning resources for each day using pills in a color-coded Gantt chart heatmap.

This is done with automations on create & update of several models tied to the computation of an availability, namely resource.calendar.leaves, planning.slot, product.template & resource.resource. A CRON is also scheduled at night to create the availability records for the next 500 days in prospect of the channex integration.

In more detail, a single update server action is used across all the automations' server actions to recompute all the availabilities flagged with a `x_to_recompute` boolean to minimize faulty states due to race conditions. This way, each automation only has to flag the current (and new availabilites in the case of on create or edit) availabilities tied to records being updated or unlinked with that boolean, then trigger the recomputation in a separate server action that will fetch all the availabilities that have to be recomputed instead of each automation recomputing it separately with its own state.
A CRON is used for the unlinks instead of just a server action because calling the server action directly does not have the desired behavior since the server action is triggered before the records are actually deleted. Therefore, the records to be deleted are still taken into account for the recomputation. Using a CRON fixes this because the computation happens after the records are removed from the DB. Unlinks of these 4 models are rare cases, and therefore less likely to cause a problem than running the CRON for every little change, hence why we still use the server action for those, in addition to it working properly unlike the unlink.

Also adds more demo data for each of the industries using booking_engine.

task-5913061