### PR TITLE
[FIX] food_distribution: fix singleton error with do_pass on quality.check

### DIFF
--- a/food_distribution/demo/mrp_production.xml
+++ b/food_distribution/demo/mrp_production.xml
@@ -49,9 +49,10 @@
     <function name="do_pass" model="quality.check">
         <value model="quality.check" eval="obj().search([('product_id', '=', ref('product_product_13'))], offset=1, limit=1).id"/>
     </function>
-    <!-- TODO check why the next one is useful as the check is not active -->
-    <function name="do_pass" model="quality.check">
+    <!-- TODO check why quality check of archived quality point get created -->
+    <function name="write" model="quality.check">
         <value model="quality.check" eval="obj().search([('product_id', '=', ref('product_product_13'))], offset=2, limit=1).id"/>
+        <value model="quality.check" eval="{'quality_state': 'pass', 'user_id': obj().env.user.id, 'control_date': datetime.now()}"/>
     </function>
 
     <function name="button_mark_done" model="mrp.production">


### PR DESCRIPTION
There is an unresolved issue with an unactive quality.check
and do_pass has an ensure_one method, meaning it fails if
there is no quality.check.
This commit removes this problem by using the write method,
which does not suffer from this limitation.