### PR TITLE
[FIX] test_booking_engine: ensure the resource is assigned to a planning slot

### DIFF
--- a/tests/test_booking_engine/tests/test_action_server.py
+++ b/tests/test_booking_engine/tests/test_action_server.py
@@ -24,9 +24,11 @@ class BookingEngineAutomationsTestCase(TransactionCase):
         cls.resource = cls.env['resource.resource'].create({
             'name': 'Room Resource Due Out',
             'resource_type': 'material',
+            'calendar_id': False,
         })
         cls.role = cls.env['planning.role'].create({
             'name': 'Role',
+            'sync_shift_rental': True,
             'x_is_a_room_offer': True,
             'resource_ids': [Command.link(cls.resource.id)],
         })


### PR DESCRIPTION
**Before commit:**

Confirming a sale order in tests created a planning slot without a resource because the product role had `sync_shift_rental` disabled. As a result, no resource was assigned to the order line's rental planning slot.

**After commit:**

When `sync_shift_rental` is enabled, the resource is correctly assigned for the planning slot of order line from here [1]. Additionally, a resource is created without a `calendar_id` to allow more flexibility in planning.

Link 1: https://github.com/odoo/enterprise/blob/85bd9d80a1a784f1baff1493b2eaec4a17ea9c9b/sale_renting_planning/models/sale_order_line.py#L81-L84