### PR TITLE
[FIX] construction_developer: assign variant price to work item line

### DIFF
--- a/construction_developer/__manifest__.py
+++ b/construction_developer/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Construction Developer',
-    'version': '1.10',
+    'version': '1.11',
     'category': 'Construction',
     'depends': [
         'base_industry_data',

--- a/construction_developer/data/ir_actions_server.xml
+++ b/construction_developer/data/ir_actions_server.xml
@@ -121,7 +121,7 @@ record.write({'x_name': record.x_product_id.name})
         <field name="model_id" ref="x_work_item_line_model" />
         <field name="state">code</field>
         <field name="code"><![CDATA[
-record.write({'x_unit_price': record.x_product_id.list_price, 'x_unit_cost': record.x_product_id.standard_price})
+record.write({'x_unit_price': record.x_product_id.lst_price, 'x_unit_cost': record.x_product_id.standard_price})
 ]]></field>
     </record>
     <record id="server_action_update_related_work_item_lines" model="ir.actions.server">


### PR DESCRIPTION
Before this commit, in the server action server_action_set_unit_cost_price_from_product, we used the list_price field of the product to assign to the price of the work item line. 
This field is defined in the product template, which does not take into account extra price from attribute values, nor custom price assigned on the variant directly.
This commit fixes it by assigning the variant price, lst_price