### PR TITLE
[FIX] test_industry: Align CLI behavior by removing active_test=False

### DIFF
--- a/food_distribution/demo/mrp_production.xml
+++ b/food_distribution/demo/mrp_production.xml
@@ -49,11 +49,6 @@
     <function name="do_pass" model="quality.check">
         <value model="quality.check" eval="obj().search([('product_id', '=', ref('product_product_13'))], offset=1, limit=1).id"/>
     </function>
-    <!-- TODO check why quality check of archived quality point get created -->
-    <function name="write" model="quality.check">
-        <value model="quality.check" eval="obj().search([('product_id', '=', ref('product_product_13'))], offset=2, limit=1).id"/>
-        <value model="quality.check" eval="{'quality_state': 'pass', 'user_id': obj().env.user.id, 'control_date': datetime.now()}"/>
-    </function>
 
     <function name="button_mark_done" model="mrp.production">
         <value model="mrp.production" eval="obj().search([('name', '=', 'Mayonnaise Production')], limit=1).id"/>

--- a/tests/test_industry/cli/test_industry.py
+++ b/tests/test_industry/cli/test_industry.py
@@ -90,7 +90,7 @@ class Test_Industry(Command):
                 registry = Registry(target_db)
                 if install:
                     with registry.cursor() as cr:
-                        env = api.Environment(cr, api.SUPERUSER_ID, {'active_test': False})
+                        env = api.Environment(cr, api.SUPERUSER_ID, {})
                         with_demo = res.industry_demo
                         _logger.info('Loading module %s into database %s %s', industry_module, target_db, with_demo and 'with demo data' or '')
                         existing_module = env['ir.module.module'].search([])


### PR DESCRIPTION
In the industry CLI, the environment was initialized with `active_test=False`, which disables the default filtering of inactive (archived) records. This caused searches to return archived records as well, leading to incorrect behavior such as creating quality checks from archived quality points in `Food Distribution` module.

Remove `active_test=False` to restore the default behavior where only active records are considered.

Task ID: 6076908