### PR TITLE
[FIX] *: assigning correct model object

### DIFF
--- a/accounting_firm/demo/mail_activity.xml
+++ b/accounting_firm/demo/mail_activity.xml
@@ -10,7 +10,7 @@
     </record>
     <record id="mail_activity_2" model="mail.activity">
         <field name="res_model_id" ref="account.model_account_journal" />
-        <field name="res_id" ref="account.1_general" />
+        <field name="res_id" eval="ref(f'account.{ref('base.main_company')}_general')"/>
         <field name="summary" eval="'VAT Return (BE): ' + DateTime.now().strftime('%B')"/>
         <field name="user_id" ref="base.user_admin" />
         <field name="date_deadline" eval="(DateTime.today() + relativedelta(days=1)).strftime('%Y-%m-%d %H:%M')" />

--- a/agriculture_shop/data/product_image.xml
+++ b/agriculture_shop/data/product_image.xml
@@ -3,6 +3,6 @@
     <record id="product_image_1" model="product.image">
         <field name="image_1920" type="base64" file="agriculture_shop/static/src/binary/product_image/1-image_1920"/>
         <field name="name">SPray.webp</field>
-        <field name="product_tmpl_id" ref="product_product_22"/>
+        <field name="product_tmpl_id" ref="product_product_22_product_template"/>
     </record>
 </odoo>

--- a/agriculture_shop/data/product_template_attribute_line.xml
+++ b/agriculture_shop/data/product_template_attribute_line.xml
@@ -1,202 +1,202 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
     <record id="product_template_attribute_line_1" model="product.template.attribute.line">
-        <field name="product_tmpl_id" ref="product_product_5"/>
+        <field name="product_tmpl_id" ref="product_product_5_product_template"/>
         <field name="attribute_id" ref="product_attribute_9"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_7')])]"/>
     </record>
     <record id="product_template_attribute_line_2" model="product.template.attribute.line">
-        <field name="product_tmpl_id" ref="product_product_6"/>
+        <field name="product_tmpl_id" ref="product_product_6_product_template"/>
         <field name="attribute_id" ref="product_attribute_9"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_7')])]"/>
     </record>
     <record id="product_template_attribute_line_3" model="product.template.attribute.line">
-        <field name="product_tmpl_id" ref="product_product_7"/>
+        <field name="product_tmpl_id" ref="product_product_7_product_template"/>
         <field name="attribute_id" ref="product_attribute_9"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_8')])]"/>
     </record>
     <record id="product_template_attribute_line_4" model="product.template.attribute.line">
-        <field name="product_tmpl_id" ref="product_product_8"/>
+        <field name="product_tmpl_id" ref="product_product_8_product_template"/>
         <field name="attribute_id" ref="product_attribute_9"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_8')])]"/>
     </record>
     <record id="product_template_attribute_line_5" model="product.template.attribute.line">
-        <field name="product_tmpl_id" ref="product_product_9"/>
+        <field name="product_tmpl_id" ref="product_product_9_product_template"/>
         <field name="attribute_id" ref="product_attribute_9"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_7')])]"/>
     </record>
     <record id="product_template_attribute_line_6" model="product.template.attribute.line">
-        <field name="product_tmpl_id" ref="product_product_12"/>
+        <field name="product_tmpl_id" ref="product_product_12_product_template"/>
         <field name="attribute_id" ref="product_attribute_9"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_8')])]"/>
     </record>
     <record id="product_template_attribute_line_7" model="product.template.attribute.line">
-        <field name="product_tmpl_id" ref="product_product_13"/>
+        <field name="product_tmpl_id" ref="product_product_13_product_template"/>
         <field name="attribute_id" ref="product_attribute_9"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_8')])]"/>
     </record>
     <record id="product_template_attribute_line_8" model="product.template.attribute.line">
-        <field name="product_tmpl_id" ref="product_product_10"/>
+        <field name="product_tmpl_id" ref="product_product_10_product_template"/>
         <field name="attribute_id" ref="product_attribute_10"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_4')])]"/>
     </record>
     <record id="product_template_attribute_line_9" model="product.template.attribute.line">
-        <field name="product_tmpl_id" ref="product_product_11"/>
+        <field name="product_tmpl_id" ref="product_product_11_product_template"/>
         <field name="attribute_id" ref="product_attribute_10"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_6')])]"/>
     </record>
     <record id="product_template_attribute_line_10" model="product.template.attribute.line">
-        <field name="product_tmpl_id" ref="product_product_14"/>
+        <field name="product_tmpl_id" ref="product_product_14_product_template"/>
         <field name="attribute_id" ref="product_attribute_10"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_3')])]"/>
     </record>
     <record id="product_template_attribute_line_11" model="product.template.attribute.line">
-        <field name="product_tmpl_id" ref="product_product_15"/>
+        <field name="product_tmpl_id" ref="product_product_15_product_template"/>
         <field name="attribute_id" ref="product_attribute_10"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_4')])]"/>
     </record>
     <record id="product_template_attribute_line_12" model="product.template.attribute.line">
-        <field name="product_tmpl_id" ref="product_product_16"/>
+        <field name="product_tmpl_id" ref="product_product_16_product_template"/>
         <field name="attribute_id" ref="product_attribute_10"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_3')])]"/>
     </record>
     <record id="product_template_attribute_line_13" model="product.template.attribute.line">
-        <field name="product_tmpl_id" ref="product_product_17"/>
+        <field name="product_tmpl_id" ref="product_product_17_product_template"/>
         <field name="attribute_id" ref="product_attribute_10"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_3')])]"/>
     </record>
     <record id="product_template_attribute_line_14" model="product.template.attribute.line">
-        <field name="product_tmpl_id" ref="product_product_5"/>
+        <field name="product_tmpl_id" ref="product_product_5_product_template"/>
         <field name="attribute_id" ref="product_attribute_11"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_1')])]"/>
     </record>
     <record id="product_template_attribute_line_15" model="product.template.attribute.line">
-        <field name="product_tmpl_id" ref="product_product_6"/>
+        <field name="product_tmpl_id" ref="product_product_6_product_template"/>
         <field name="attribute_id" ref="product_attribute_11"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_1')])]"/>
     </record>
     <record id="product_template_attribute_line_16" model="product.template.attribute.line">
-        <field name="product_tmpl_id" ref="product_product_7"/>
+        <field name="product_tmpl_id" ref="product_product_7_product_template"/>
         <field name="attribute_id" ref="product_attribute_11"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_1')])]"/>
     </record>
     <record id="product_template_attribute_line_17" model="product.template.attribute.line">
-        <field name="product_tmpl_id" ref="product_product_8"/>
+        <field name="product_tmpl_id" ref="product_product_8_product_template"/>
         <field name="attribute_id" ref="product_attribute_11"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_2')])]"/>
     </record>
     <record id="product_template_attribute_line_18" model="product.template.attribute.line">
-        <field name="product_tmpl_id" ref="product_product_9"/>
+        <field name="product_tmpl_id" ref="product_product_9_product_template"/>
         <field name="attribute_id" ref="product_attribute_11"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_1')])]"/>
     </record>
     <record id="product_template_attribute_line_19" model="product.template.attribute.line">
-        <field name="product_tmpl_id" ref="product_product_10"/>
+        <field name="product_tmpl_id" ref="product_product_10_product_template"/>
         <field name="attribute_id" ref="product_attribute_11"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_2')])]"/>
     </record>
     <record id="product_template_attribute_line_20" model="product.template.attribute.line">
-        <field name="product_tmpl_id" ref="product_product_11"/>
+        <field name="product_tmpl_id" ref="product_product_11_product_template"/>
         <field name="attribute_id" ref="product_attribute_11"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_2')])]"/>
     </record>
     <record id="product_template_attribute_line_21" model="product.template.attribute.line">
-        <field name="product_tmpl_id" ref="product_product_12"/>
+        <field name="product_tmpl_id" ref="product_product_12_product_template"/>
         <field name="attribute_id" ref="product_attribute_11"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_1')])]"/>
     </record>
     <record id="product_template_attribute_line_22" model="product.template.attribute.line">
-        <field name="product_tmpl_id" ref="product_product_13"/>
+        <field name="product_tmpl_id" ref="product_product_13_product_template"/>
         <field name="attribute_id" ref="product_attribute_11"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_1')])]"/>
     </record>
     <record id="product_template_attribute_line_23" model="product.template.attribute.line">
-        <field name="product_tmpl_id" ref="product_product_14"/>
+        <field name="product_tmpl_id" ref="product_product_14_product_template"/>
         <field name="attribute_id" ref="product_attribute_11"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_2')])]"/>
     </record>
     <record id="product_template_attribute_line_24" model="product.template.attribute.line">
-        <field name="product_tmpl_id" ref="product_product_15"/>
+        <field name="product_tmpl_id" ref="product_product_15_product_template"/>
         <field name="attribute_id" ref="product_attribute_11"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_2')])]"/>
     </record>
     <record id="product_template_attribute_line_25" model="product.template.attribute.line">
-        <field name="product_tmpl_id" ref="product_product_16"/>
+        <field name="product_tmpl_id" ref="product_product_16_product_template"/>
         <field name="attribute_id" ref="product_attribute_11"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_2')])]"/>
     </record>
     <record id="product_template_attribute_line_26" model="product.template.attribute.line">
-        <field name="product_tmpl_id" ref="product_product_17"/>
+        <field name="product_tmpl_id" ref="product_product_17_product_template"/>
         <field name="attribute_id" ref="product_attribute_11"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_2')])]"/>
     </record>
     <record id="product_template_attribute_line_27" model="product.template.attribute.line">
-        <field name="product_tmpl_id" ref="product_product_5"/>
+        <field name="product_tmpl_id" ref="product_product_5_product_template"/>
         <field name="attribute_id" ref="product_attribute_12"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_10')])]"/>
     </record>
     <record id="product_template_attribute_line_28" model="product.template.attribute.line">
-        <field name="product_tmpl_id" ref="product_product_6"/>
+        <field name="product_tmpl_id" ref="product_product_6_product_template"/>
         <field name="attribute_id" ref="product_attribute_12"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_11')])]"/>
     </record>
     <record id="product_template_attribute_line_29" model="product.template.attribute.line">
-        <field name="product_tmpl_id" ref="product_product_7"/>
+        <field name="product_tmpl_id" ref="product_product_7_product_template"/>
         <field name="attribute_id" ref="product_attribute_12"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_10')])]"/>
     </record>
     <record id="product_template_attribute_line_30" model="product.template.attribute.line">
-        <field name="product_tmpl_id" ref="product_product_8"/>
+        <field name="product_tmpl_id" ref="product_product_8_product_template"/>
         <field name="attribute_id" ref="product_attribute_12"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_10')])]"/>
     </record>
     <record id="product_template_attribute_line_31" model="product.template.attribute.line">
-        <field name="product_tmpl_id" ref="product_product_9"/>
+        <field name="product_tmpl_id" ref="product_product_9_product_template"/>
         <field name="attribute_id" ref="product_attribute_12"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_10')])]"/>
     </record>
     <record id="product_template_attribute_line_32" model="product.template.attribute.line">
-        <field name="product_tmpl_id" ref="product_product_10"/>
+        <field name="product_tmpl_id" ref="product_product_10_product_template"/>
         <field name="attribute_id" ref="product_attribute_12"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_11')])]"/>
     </record>
     <record id="product_template_attribute_line_33" model="product.template.attribute.line">
-        <field name="product_tmpl_id" ref="product_product_11"/>
+        <field name="product_tmpl_id" ref="product_product_11_product_template"/>
         <field name="attribute_id" ref="product_attribute_12"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_10')])]"/>
     </record>
     <record id="product_template_attribute_line_34" model="product.template.attribute.line">
-        <field name="product_tmpl_id" ref="product_product_12"/>
+        <field name="product_tmpl_id" ref="product_product_12_product_template"/>
         <field name="attribute_id" ref="product_attribute_12"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_10')])]"/>
     </record>
     <record id="product_template_attribute_line_35" model="product.template.attribute.line">
-        <field name="product_tmpl_id" ref="product_product_13"/>
+        <field name="product_tmpl_id" ref="product_product_13_product_template"/>
         <field name="attribute_id" ref="product_attribute_12"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_10')])]"/>
     </record>
     <record id="product_template_attribute_line_36" model="product.template.attribute.line">
-        <field name="product_tmpl_id" ref="product_product_14"/>
+        <field name="product_tmpl_id" ref="product_product_14_product_template"/>
         <field name="attribute_id" ref="product_attribute_12"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_11')])]"/>
     </record>
     <record id="product_template_attribute_line_37" model="product.template.attribute.line">
-        <field name="product_tmpl_id" ref="product_product_15"/>
+        <field name="product_tmpl_id" ref="product_product_15_product_template"/>
         <field name="attribute_id" ref="product_attribute_12"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_11')])]"/>
     </record>
     <record id="product_template_attribute_line_38" model="product.template.attribute.line">
-        <field name="product_tmpl_id" ref="product_product_16"/>
+        <field name="product_tmpl_id" ref="product_product_16_product_template"/>
         <field name="attribute_id" ref="product_attribute_12"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_11')])]"/>
     </record>
     <record id="product_template_attribute_line_39" model="product.template.attribute.line">
-        <field name="product_tmpl_id" ref="product_product_17"/>
+        <field name="product_tmpl_id" ref="product_product_17_product_template"/>
         <field name="attribute_id" ref="product_attribute_12"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_11')])]"/>
     </record>
     <record id="product_template_attribute_line_40" model="product.template.attribute.line">
-        <field name="product_tmpl_id" ref="product_product_22"/>
+        <field name="product_tmpl_id" ref="product_product_22_product_template"/>
         <field name="attribute_id" ref="product_attribute_12"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_10')])]"/>
     </record>

--- a/agriculture_shop/demo/sale_order_line.xml
+++ b/agriculture_shop/demo/sale_order_line.xml
@@ -50,7 +50,7 @@
   </record>
   <record id="sale_order_line_12" model="sale.order.line">
     <field name="order_id" ref="sale_order_6"/>
-    <field name="product_id" ref="product_product_34"/>
+    <field name="product_id" model="product.template" eval="obj().env.ref('agriculture_shop.product_product_34').product_variant_id.id"/>
     <field name="price_unit">-1400.0</field>
   </record>
   <record id="sale_order_line_11" model="sale.order.line">

--- a/bakery/demo/sale_order.xml
+++ b/bakery/demo/sale_order.xml
@@ -7,14 +7,14 @@
     </record>
     <record id="sale_order_3" model="sale.order">
         <field name="partner_id" ref="base.partner_admin"/>
-        <field name="pickup_location_data" eval="{'id': 1, 'city': 'Brussels', 'name': 'Bakery Industry', 'street': 'Rue Des Pains, 9', 'distance': 1.6889012473646934, 'latitude': 50.8465573, 'zip_code': '1000', 'longitude': 4.351697, 'country_code': 'BE', 'opening_hours': {}, 'additional_data': {'in_store_stock': {'in_stock': True}}}"/>
+        <field name="pickup_location_data" eval="{'id': ref('stock.warehouse0'), 'city': 'Brussels', 'name': 'Bakery Industry', 'street': 'Rue Des Pains, 9', 'distance': 1.6889012473646934, 'latitude': 50.8465573, 'zip_code': '1000', 'longitude': 4.351697, 'country_code': 'BE', 'opening_hours': {}, 'additional_data': {'in_store_stock': {'in_stock': True}}}"/>
         <field name="carrier_id" ref="website_sale_collect.carrier_pick_up_in_store"/>
         <field name="website_id" ref="website.default_website"/>
         <field name="user_id" ref="base.user_admin"/>
     </record>
     <record id="sale_order_2" model="sale.order">
         <field name="partner_id" ref="base.partner_admin"/>
-        <field name="pickup_location_data" eval="{'id': 1, 'city': 'Brussels', 'name': 'Bakery Industry', 'street': 'Rue Des Pains, 9', 'distance': 1.6889012473646934, 'latitude': 50.8465573, 'zip_code': '1000', 'longitude': 4.351697, 'country_code': 'BE', 'opening_hours': {}, 'additional_data': {'in_store_stock': {'in_stock': True}}}"/>
+        <field name="pickup_location_data" eval="{'id': ref('stock.warehouse0'), 'city': 'Brussels', 'name': 'Bakery Industry', 'street': 'Rue Des Pains, 9', 'distance': 1.6889012473646934, 'latitude': 50.8465573, 'zip_code': '1000', 'longitude': 4.351697, 'country_code': 'BE', 'opening_hours': {}, 'additional_data': {'in_store_stock': {'in_stock': True}}}"/>
         <field name="carrier_id" ref="website_sale_collect.carrier_pick_up_in_store"/>
         <field name="website_id" ref="website.default_website"/>
         <field name="user_id" ref="base.user_admin"/>

--- a/catering/demo/planning_slot.xml
+++ b/catering/demo/planning_slot.xml
@@ -6,7 +6,7 @@
     <field name="end_datetime" model="hr.employee" eval="pytz.timezone(obj().env.user.tz or 'UTC').localize(DateTime.today() + relativedelta(days=+40)).astimezone(pytz.UTC).replace(tzinfo=None)"/>
     <field name="template_id" ref="planning_slot_template_6"/>
     <field name="sale_line_id" ref="sale_order_line_2"/>
-    <field name="resource_id" eval="ref('hr_employee_2')"/>
+    <field name="resource_id" model="hr.employee" eval="obj().env.ref('catering.hr_employee_2').resource_id.id"/>
     <field name="role_id" ref="planning_role_3"/>
     <field name="state">published</field>
     <field name="previous_template_id" ref="planning_slot_template_6"/>
@@ -17,7 +17,7 @@
     <field name="end_datetime" model="hr.employee" eval="pytz.timezone(obj().env.user.tz or 'UTC').localize(DateTime.today() + relativedelta(days=+40)).astimezone(pytz.UTC).replace(tzinfo=None)"/>
     <field name="template_id" ref="planning_slot_template_6"/>
     <field name="sale_line_id" ref="sale_order_line_2"/>
-    <field name="resource_id" eval="ref('hr_employee_4')"/>
+    <field name="resource_id" model="hr.employee" eval="obj().env.ref('catering.hr_employee_4').resource_id.id"/>
     <field name="role_id" ref="planning_role_3"/>
     <field name="state">published</field>
     <field name="previous_template_id" ref="planning_slot_template_6"/>
@@ -28,7 +28,7 @@
     <field name="end_datetime" model="hr.employee" eval="pytz.timezone(obj().env.user.tz or 'UTC').localize(DateTime.today() + relativedelta(days=+40)).astimezone(pytz.UTC).replace(tzinfo=None)"/>
     <field name="template_id" ref="planning_slot_template_6"/>
     <field name="sale_line_id" ref="sale_order_line_2"/>
-    <field name="resource_id" eval="ref('hr_employee_5')"/>
+    <field name="resource_id" model="hr.employee" eval="obj().env.ref('catering.hr_employee_5').resource_id.id"/>
     <field name="role_id" ref="planning_role_3"/>
     <field name="state">published</field>
     <field name="previous_template_id" ref="planning_slot_template_6"/>
@@ -69,7 +69,7 @@
     <field name="end_datetime" model="hr.employee" eval="pytz.timezone(obj().env.user.tz or 'UTC').localize(DateTime.today() + relativedelta(days=+40)).astimezone(pytz.UTC).replace(tzinfo=None)"/>
     <field name="template_id" ref="planning_slot_template_1"/>
     <field name="sale_line_id" ref="sale_order_line_2"/>
-    <field name="resource_id" eval="ref('hr_employee_6')"/>
+    <field name="resource_id" model="hr.employee" eval="obj().env.ref('catering.hr_employee_6').resource_id.id"/>
     <field name="role_id" ref="planning_role_1"/>
     <field name="state">published</field>
     <field name="previous_template_id" ref="planning_slot_template_1"/>
@@ -90,7 +90,7 @@
     <field name="end_datetime" model="hr.employee" eval="pytz.timezone(obj().env.user.tz or 'UTC').localize(DateTime.today() + relativedelta(days=+40)).astimezone(pytz.UTC).replace(tzinfo=None)"/>
     <field name="sale_line_id" ref="sale_order_line_2"/>
     <field name="role_id" ref="planning_role_1"/>
-    <field name="resource_id" eval="ref('hr_employee_3')"/>
+    <field name="resource_id" model="hr.employee" eval="obj().env.ref('catering.hr_employee_3').resource_id.id"/>
     <field name="state">published</field>
     <field name="template_reset" eval="True"/>
   </record>

--- a/catering/demo/product_supplierinfo.xml
+++ b/catering/demo/product_supplierinfo.xml
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
   <record id="product_supplierinfo_16" model="product.supplierinfo">
-    <field name="partner_id" ref="base.user_admin"/>
+    <field name="partner_id" ref="base.main_partner"/>
     <field name="product_id" ref="product_product_110"/>
     <field name="min_qty">1.0</field>
     <field name="delay" eval="False"/>
   </record>
   <record id="product_supplierinfo_17" model="product.supplierinfo">
-    <field name="partner_id" ref="base.user_admin"/>
+    <field name="partner_id" ref="base.main_partner"/>
     <field name="product_id" ref="product_product_118"/>
     <field name="min_qty">1.0</field>
     <field name="delay" eval="False"/>

--- a/climbing_gym/demo/planning_slot.xml
+++ b/climbing_gym/demo/planning_slot.xml
@@ -4,63 +4,63 @@
         <field name="role_id" ref="planning_role_1"/>
         <field name="start_datetime" model="hr.employee" eval="pytz.timezone(obj().env.user.tz or 'UTC').localize(DateTime.today().date() + relativedelta(days=-6, weekday=0) + relativedelta(days=0, hour=10)).astimezone(pytz.UTC).replace(tzinfo=None)"/>
         <field name="end_datetime" model="hr.employee" eval="pytz.timezone(obj().env.user.tz or 'UTC').localize(DateTime.today().date() + relativedelta(days=-6, weekday=0) + relativedelta(days=0, hour=16)).astimezone(pytz.UTC).replace(tzinfo=None)"/>
-        <field name="resource_id" eval="ref('hr_employee_5')"/>
+        <field name="resource_id" model="hr.employee" eval="obj().env.ref('climbing_gym.hr_employee_5').resource_id.id"/>
         <field name="state">published</field>
     </record>
     <record id="planning_slot_2" model="planning.slot">
         <field name="role_id" ref="planning_role_1"/>
         <field name="start_datetime" model="hr.employee" eval="pytz.timezone(obj().env.user.tz or 'UTC').localize(DateTime.today().date() + relativedelta(days=-6, weekday=0) + relativedelta(days=1, hour=16)).astimezone(pytz.UTC).replace(tzinfo=None)"/>
         <field name="end_datetime" model="hr.employee" eval="pytz.timezone(obj().env.user.tz or 'UTC').localize(DateTime.today().date() + relativedelta(days=-6, weekday=0) + relativedelta(days=1, hour=22)).astimezone(pytz.UTC).replace(tzinfo=None)"/>
-        <field name="resource_id" eval="ref('hr_employee_5')"/>
+        <field name="resource_id" model="hr.employee" eval="obj().env.ref('climbing_gym.hr_employee_5').resource_id.id"/>
         <field name="state">published</field>
     </record>
     <record id="planning_slot_3" model="planning.slot">
         <field name="role_id" ref="planning_role_2"/>
         <field name="start_datetime" model="hr.employee" eval="pytz.timezone(obj().env.user.tz or 'UTC').localize(DateTime.today().date() + relativedelta(days=-6, weekday=0) + relativedelta(days=1, hour=15)).astimezone(pytz.UTC).replace(tzinfo=None)"/>
         <field name="end_datetime" model="hr.employee" eval="pytz.timezone(obj().env.user.tz or 'UTC').localize(DateTime.today().date() + relativedelta(days=-6, weekday=0) + relativedelta(days=1, hour=20)).astimezone(pytz.UTC).replace(tzinfo=None)"/>
-        <field name="resource_id" eval="ref('hr_employee_4')"/>
+        <field name="resource_id" model="hr.employee" eval="obj().env.ref('climbing_gym.hr_employee_4').resource_id.id"/>
         <field name="state">published</field>
     </record>
         <record id="planning_slot_4" model="planning.slot">
         <field name="role_id" ref="planning_role_2"/>
         <field name="start_datetime" model="hr.employee" eval="pytz.timezone(obj().env.user.tz or 'UTC').localize(DateTime.today().date() + relativedelta(days=-6, weekday=0) + relativedelta(days=2, hour=15)).astimezone(pytz.UTC).replace(tzinfo=None)"/>
         <field name="end_datetime" model="hr.employee" eval="pytz.timezone(obj().env.user.tz or 'UTC').localize(DateTime.today().date() + relativedelta(days=-6, weekday=0) + relativedelta(days=2, hour=20)).astimezone(pytz.UTC).replace(tzinfo=None)"/>
-        <field name="resource_id" eval="ref('hr_employee_4')"/>
+        <field name="resource_id" model="hr.employee" eval="obj().env.ref('climbing_gym.hr_employee_4').resource_id.id"/>
         <field name="state">published</field>
     </record>
     <record id="planning_slot_5" model="planning.slot">
         <field name="role_id" ref="planning_role_2"/>
         <field name="start_datetime" model="hr.employee" eval="pytz.timezone(obj().env.user.tz or 'UTC').localize(DateTime.today().date() + relativedelta(days=-6, weekday=0) + relativedelta(days=2, hour=15)).astimezone(pytz.UTC).replace(tzinfo=None)"/>
         <field name="end_datetime" model="hr.employee" eval="pytz.timezone(obj().env.user.tz or 'UTC').localize(DateTime.today().date() + relativedelta(days=-6, weekday=0) + relativedelta(days=2, hour=20)).astimezone(pytz.UTC).replace(tzinfo=None)"/>
-        <field name="resource_id" eval="ref('hr_employee_2')"/>
+        <field name="resource_id" model="hr.employee" eval="obj().env.ref('climbing_gym.hr_employee_2').resource_id.id"/>
         <field name="state">published</field>
     </record>
     <record id="planning_slot_6" model="planning.slot">
         <field name="role_id" ref="planning_role_1"/>
         <field name="start_datetime" model="hr.employee" eval="pytz.timezone(obj().env.user.tz or 'UTC').localize(DateTime.today().date() + relativedelta(days=-6, weekday=0) + relativedelta(days=3, hour=16)).astimezone(pytz.UTC).replace(tzinfo=None)"/>
         <field name="end_datetime" model="hr.employee" eval="pytz.timezone(obj().env.user.tz or 'UTC').localize(DateTime.today().date() + relativedelta(days=-6, weekday=0) + relativedelta(days=3, hour=22)).astimezone(pytz.UTC).replace(tzinfo=None)"/>
-        <field name="resource_id" eval="ref('hr_employee_3')"/>
+        <field name="resource_id" model="hr.employee" eval="obj().env.ref('climbing_gym.hr_employee_3').resource_id.id"/>
         <field name="state">published</field>
     </record>
     <record id="planning_slot_7" model="planning.slot">
         <field name="role_id" ref="planning_role_1"/>
         <field name="start_datetime" model="hr.employee" eval="pytz.timezone(obj().env.user.tz or 'UTC').localize(DateTime.today().date() + relativedelta(days=-6, weekday=0) + relativedelta(days=4, hour=16)).astimezone(pytz.UTC).replace(tzinfo=None)"/>
         <field name="end_datetime" model="hr.employee" eval="pytz.timezone(obj().env.user.tz or 'UTC').localize(DateTime.today().date() + relativedelta(days=-6, weekday=0) + relativedelta(days=4, hour=22)).astimezone(pytz.UTC).replace(tzinfo=None)"/>
-        <field name="resource_id" eval="ref('hr_employee_3')"/>
+        <field name="resource_id" model="hr.employee" eval="obj().env.ref('climbing_gym.hr_employee_3').resource_id.id"/>
         <field name="state">published</field>
     </record>
     <record id="planning_slot_8" model="planning.slot">
         <field name="role_id" ref="planning_role_1"/>
         <field name="start_datetime" model="hr.employee" eval="pytz.timezone(obj().env.user.tz or 'UTC').localize(DateTime.today().date() + relativedelta(days=-6, weekday=0) + relativedelta(days=4, hour=16)).astimezone(pytz.UTC).replace(tzinfo=None)"/>
         <field name="end_datetime" model="hr.employee" eval="pytz.timezone(obj().env.user.tz or 'UTC').localize(DateTime.today().date() + relativedelta(days=-6, weekday=0) + relativedelta(days=4, hour=22)).astimezone(pytz.UTC).replace(tzinfo=None)"/>
-        <field name="resource_id" eval="ref('hr_employee_5')"/>
+        <field name="resource_id" model="hr.employee" eval="obj().env.ref('climbing_gym.hr_employee_5').resource_id.id"/>
         <field name="state">published</field>
     </record>
     <record id="planning_slot_9" model="planning.slot">
         <field name="role_id" ref="planning_role_1"/>
         <field name="start_datetime" model="hr.employee" eval="pytz.timezone(obj().env.user.tz or 'UTC').localize(DateTime.today().date() + relativedelta(days=-6, weekday=0) + relativedelta(days=4, hour=10)).astimezone(pytz.UTC).replace(tzinfo=None)"/>
         <field name="end_datetime" model="hr.employee" eval="pytz.timezone(obj().env.user.tz or 'UTC').localize(DateTime.today().date() + relativedelta(days=-6, weekday=0) + relativedelta(days=4, hour=16)).astimezone(pytz.UTC).replace(tzinfo=None)"/>
-        <field name="resource_id" eval="ref('hr_employee_3')"/>
+        <field name="resource_id" model="hr.employee" eval="obj().env.ref('climbing_gym.hr_employee_3').resource_id.id"/>
         <field name="state">published</field>
     </record>
     <record id="planning_slot_10" model="planning.slot">
@@ -73,48 +73,48 @@
         <field name="role_id" ref="planning_role_1"/>
         <field name="start_datetime" model="hr.employee" eval="pytz.timezone(obj().env.user.tz or 'UTC').localize(DateTime.today().date() + relativedelta(days=-6, weekday=0) + relativedelta(weeks=1, days=0, hour=16)).astimezone(pytz.UTC).replace(tzinfo=None)"/>
         <field name="end_datetime" model="hr.employee" eval="pytz.timezone(obj().env.user.tz or 'UTC').localize(DateTime.today().date() + relativedelta(days=-6, weekday=0) + relativedelta(weeks=1, days=0, hour=22)).astimezone(pytz.UTC).replace(tzinfo=None)"/>
-        <field name="resource_id" eval="ref('hr_employee_5')"/>
+        <field name="resource_id" model="hr.employee" eval="obj().env.ref('climbing_gym.hr_employee_5').resource_id.id"/>
     </record>
     <record id="planning_slot_12" model="planning.slot">
         <field name="role_id" ref="planning_role_2"/>
         <field name="start_datetime" model="hr.employee" eval="pytz.timezone(obj().env.user.tz or 'UTC').localize(DateTime.today().date() + relativedelta(days=-6, weekday=0) + relativedelta(weeks=1, days=1, hour=15)).astimezone(pytz.UTC).replace(tzinfo=None)"/>
         <field name="end_datetime" model="hr.employee" eval="pytz.timezone(obj().env.user.tz or 'UTC').localize(DateTime.today().date() + relativedelta(days=-6, weekday=0) + relativedelta(weeks=1, days=1, hour=20)).astimezone(pytz.UTC).replace(tzinfo=None)"/>
-        <field name="resource_id" eval="ref('hr_employee_4')"/>
+        <field name="resource_id" model="hr.employee" eval="obj().env.ref('climbing_gym.hr_employee_4').resource_id.id"/>
     </record>
     <record id="planning_slot_13" model="planning.slot">
         <field name="role_id" ref="planning_role_2"/>
         <field name="start_datetime" model="hr.employee" eval="pytz.timezone(obj().env.user.tz or 'UTC').localize(DateTime.today().date() + relativedelta(days=-6, weekday=0) + relativedelta(weeks=1, days=2, hour=15)).astimezone(pytz.UTC).replace(tzinfo=None)"/>
         <field name="end_datetime" model="hr.employee" eval="pytz.timezone(obj().env.user.tz or 'UTC').localize(DateTime.today().date() + relativedelta(days=-6, weekday=0) + relativedelta(weeks=1, days=2, hour=20)).astimezone(pytz.UTC).replace(tzinfo=None)"/>
-        <field name="resource_id" eval="ref('hr_employee_4')"/>
+        <field name="resource_id" model="hr.employee" eval="obj().env.ref('climbing_gym.hr_employee_4').resource_id.id"/>
     </record>
     <record id="planning_slot_14" model="planning.slot">
         <field name="role_id" ref="planning_role_2"/>
         <field name="start_datetime" model="hr.employee" eval="pytz.timezone(obj().env.user.tz or 'UTC').localize(DateTime.today().date() + relativedelta(days=-6, weekday=0) + relativedelta(weeks=1, days=2, hour=15)).astimezone(pytz.UTC).replace(tzinfo=None)"/>
         <field name="end_datetime" model="hr.employee" eval="pytz.timezone(obj().env.user.tz or 'UTC').localize(DateTime.today().date() + relativedelta(days=-6, weekday=0) + relativedelta(weeks=1, days=2, hour=20)).astimezone(pytz.UTC).replace(tzinfo=None)"/>
-        <field name="resource_id" eval="ref('hr_employee_2')"/>
+        <field name="resource_id" model="hr.employee" eval="obj().env.ref('climbing_gym.hr_employee_2').resource_id.id"/>
     </record>
     <record id="planning_slot_15" model="planning.slot">
         <field name="role_id" ref="planning_role_1"/>
         <field name="start_datetime" model="hr.employee" eval="pytz.timezone(obj().env.user.tz or 'UTC').localize(DateTime.today().date() + relativedelta(days=-6, weekday=0) + relativedelta(weeks=1, days=2, hour=16)).astimezone(pytz.UTC).replace(tzinfo=None)"/>
         <field name="end_datetime" model="hr.employee" eval="pytz.timezone(obj().env.user.tz or 'UTC').localize(DateTime.today().date() + relativedelta(days=-6, weekday=0) + relativedelta(weeks=1, days=2, hour=22)).astimezone(pytz.UTC).replace(tzinfo=None)"/>
-        <field name="resource_id" eval="ref('hr_employee_3')"/>
+        <field name="resource_id" model="hr.employee" eval="obj().env.ref('climbing_gym.hr_employee_3').resource_id.id"/>
     </record>
     <record id="planning_slot_16" model="planning.slot">
         <field name="role_id" ref="planning_role_1"/>
         <field name="start_datetime" model="hr.employee" eval="pytz.timezone(obj().env.user.tz or 'UTC').localize(DateTime.today().date() + relativedelta(days=-6, weekday=0) + relativedelta(weeks=1, days=3, hour=16)).astimezone(pytz.UTC).replace(tzinfo=None)"/>
         <field name="end_datetime" model="hr.employee" eval="pytz.timezone(obj().env.user.tz or 'UTC').localize(DateTime.today().date() + relativedelta(days=-6, weekday=0) + relativedelta(weeks=1, days=3, hour=22)).astimezone(pytz.UTC).replace(tzinfo=None)"/>
-        <field name="resource_id" eval="ref('hr_employee_3')"/>
+        <field name="resource_id" model="hr.employee" eval="obj().env.ref('climbing_gym.hr_employee_3').resource_id.id"/>
     </record>
     <record id="planning_slot_17" model="planning.slot">
         <field name="role_id" ref="planning_role_1"/>
         <field name="start_datetime" model="hr.employee" eval="pytz.timezone(obj().env.user.tz or 'UTC').localize(DateTime.today().date() + relativedelta(days=-6, weekday=0) + relativedelta(weeks=1, days=3, hour=16)).astimezone(pytz.UTC).replace(tzinfo=None)"/>
         <field name="end_datetime" model="hr.employee" eval="pytz.timezone(obj().env.user.tz or 'UTC').localize(DateTime.today().date() + relativedelta(days=-6, weekday=0) + relativedelta(weeks=1, days=3, hour=22)).astimezone(pytz.UTC).replace(tzinfo=None)"/>
-        <field name="resource_id" eval="ref('hr_employee_5')"/>
+        <field name="resource_id" model="hr.employee" eval="obj().env.ref('climbing_gym.hr_employee_5').resource_id.id"/>
     </record>
     <record id="planning_slot_18" model="planning.slot">
         <field name="role_id" ref="planning_role_1"/>
         <field name="start_datetime" model="hr.employee" eval="pytz.timezone(obj().env.user.tz or 'UTC').localize(DateTime.today().date() + relativedelta(days=-6, weekday=0) + relativedelta(weeks=1, days=4, hour=10)).astimezone(pytz.UTC).replace(tzinfo=None)"/>
         <field name="end_datetime" model="hr.employee" eval="pytz.timezone(obj().env.user.tz or 'UTC').localize(DateTime.today().date() + relativedelta(days=-6, weekday=0) + relativedelta(weeks=1, days=4, hour=16)).astimezone(pytz.UTC).replace(tzinfo=None)"/>
-        <field name="resource_id" eval="ref('hr_employee_3')"/>
+        <field name="resource_id" model="hr.employee" eval="obj().env.ref('climbing_gym.hr_employee_3').resource_id.id"/>
     </record>
 </odoo>

--- a/cosmetics_store/demo/sale_order.xml
+++ b/cosmetics_store/demo/sale_order.xml
@@ -3,7 +3,7 @@
   <record id="sale_order_9" model="sale.order">
     <field name="partner_id" ref="base.partner_admin"/>
     <field name="user_id" ref="base.user_admin"/>
-    <field name="pickup_location_data" eval="{'id': ref('base.main_partner'), 'city': '', 'name': 'Cosmetics Store', 'state': 'VBR', 'street': '', 'latitude': 50.8686516, 'zip_code': '', 'longitude': 4.7886238, 'country_code': 'BE', 'opening_hours': {}}"/>
+    <field name="pickup_location_data" eval="{'id': ref('stock.warehouse0'), 'city': '', 'name': 'Cosmetics Store', 'state': 'VBR', 'street': '', 'latitude': 50.8686516, 'zip_code': '', 'longitude': 4.7886238, 'country_code': 'BE', 'opening_hours': {}}"/>
     <field name="carrier_id" ref="website_sale_collect.carrier_pick_up_in_store"/>
     <field name="website_id" ref="website.default_website"/>
   </record>

--- a/coworking/data/helpdesk_team.xml
+++ b/coworking/data/helpdesk_team.xml
@@ -6,6 +6,5 @@
         <field name="stage_ids" eval="[(6, 0, [ref('helpdesk.stage_new'), ref('helpdesk.stage_in_progress'), ref('helpdesk.stage_on_hold'), ref('helpdesk.stage_solved'), ref('helpdesk.stage_cancelled')])]"/>
         <field name="use_website_helpdesk_form" eval="True"/>
         <field name="to_stage_id" ref="helpdesk.stage_solved"/>
-        <field name="website_form_view_id" ref="website_helpdesk.team_form_1"/>
     </record>
 </odoo>

--- a/florist/demo/loyalty_program.xml
+++ b/florist/demo/loyalty_program.xml
@@ -6,7 +6,7 @@
         <field name="applies_on">future</field>
         <field name="portal_visible" eval="True"/>
         <field name="portal_point_name">£</field>
-        <field name="trigger_product_ids" eval="[(6, 0, [ref('product_template_15')])]"/>
+        <field name="trigger_product_ids" eval="[(6, 0, [ref('product_product_22')])]"/>
         <field name="mail_template_id" ref="loyalty.mail_template_gift_card"/>
         <field name="pos_config_ids" eval="[(6, 0, [ref('pos_config_1')])]"/>
     </record>

--- a/hvac_services/__manifest__.py
+++ b/hvac_services/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'HVAC Services',
-    'version': '1.2',
+    'version': '1.3',
     'category': 'Services',
     'depends': [
         'appointment_account_payment',

--- a/hvac_services/data/ir_actions_server.xml
+++ b/hvac_services/data/ir_actions_server.xml
@@ -37,15 +37,15 @@ for stock_pick in records:
         <field name="model_id" ref="x_new_devices"/>
         <field name="state">code</field>
         <field name="code"><![CDATA[
-if env['stock.lot'].search([('name', '=', record.x_serial_number),('product_id', '=', record.x_device_id.id)], limit=1):
+if env['stock.lot'].search_count([('name', '=', record.x_serial_number),('product_id', '=', record.x_product_id.id)], limit=1):
     raise UserError('This serial number already exists for this product. Make sure to introduce a unique serial number.')
-lot = env['stock.lot'].create({'name': record.x_serial_number, 'product_id': record.x_device_id.id, })
+lot = env['stock.lot'].create({'name': record.x_serial_number, 'product_id': record.x_product_id.id, })
 picking = env['stock.picking'].create({'partner_id': record.x_partner_id.id,
     'picking_type_id': env.ref('stock.picking_type_out').id,
     'location_id': env.ref('stock.stock_location_suppliers').id,
     'location_dest_id': env.ref('stock.stock_location_customers').id,
 })
-env['stock.move.line'].create({'picking_id': picking.id, 'lot_id': lot.id, 'product_id': record.x_device_id.id, 'quantity': 1, })
+env['stock.move.line'].create({'picking_id': picking.id, 'lot_id': lot.id, 'product_id': record.x_product_id.id, 'quantity': 1, })
 picking.with_context(skip_sms=True).button_validate()
 picking.write({'date_done': record.x_delivery_date})
 action = {'type': 'ir.actions.client', 'tag': 'display_notification','params': {'type': 'success', 'sticky': False,'message': ("New device created."), 'next': {'type': 'ir.actions.act_window_close'}, }}

--- a/hvac_services/data/ir_model_fields.xml
+++ b/hvac_services/data/ir_model_fields.xml
@@ -264,12 +264,12 @@ for record in self:
         <field name="required" eval="True"/>
         <field name="on_delete">cascade</field>
     </record>
-    <record id="x_device_id_field" model="ir.model.fields">
-        <field name="name">x_device_id</field>
+    <record id="x_product_id_field" model="ir.model.fields">
+        <field name="name">x_product_id</field>
         <field name="ttype">many2one</field>
         <field name="field_description">Device</field>
         <field name="model_id" ref="x_new_devices"/>
-        <field name="relation">product.template</field>
+        <field name="relation">product.product</field>
         <field name="domain" eval="[('categ_id', '=', ref('product_category_devices'))]"/>
         <field name="required" eval="True"/>
         <field name="on_delete">cascade</field>

--- a/hvac_services/data/ir_ui_view.xml
+++ b/hvac_services/data/ir_ui_view.xml
@@ -295,7 +295,7 @@
                 <sheet>
                     <field name="x_partner_id" invisible="1"/>
                     <group>
-                        <field name="x_device_id" options="{'no_quick_create': True, 'no_create_edit': True}"/>
+                        <field name="x_product_id" options="{'no_quick_create': True, 'no_create_edit': True}"/>
                         <field name="x_serial_number" string="Serial"/>
                         <field name="x_delivery_date" string="Delivery Date"/>
                     </group>

--- a/industry_real_estate/demo/account_move.xml
+++ b/industry_real_estate/demo/account_move.xml
@@ -6,7 +6,7 @@
         <field name="team_id" ref="sales_team.team_sales_department"/>
     </record>
     <record id="account_move_63" model="account.move">
-        <field name="partner_id" ref="base.user_admin"/>
+        <field name="partner_id" ref="base.main_partner"/>
         <field name="move_type">in_invoice</field>
         <field name="invoice_payment_term_id" ref="account.account_payment_term_end_following_month"/>
         <field name="team_id" ref="sales_team.team_sales_department"/>

--- a/industry_real_estate/demo/sale_order.xml
+++ b/industry_real_estate/demo/sale_order.xml
@@ -63,7 +63,7 @@
         <field name="start_date" eval="datetime.today().date() - relativedelta(years=3)"/>
         <field name="end_date" eval="datetime.today().date() + relativedelta(years=1)"/>
         <field name="plan_id" ref="sale_subscription.subscription_plan_month"/>
-        <field name="partner_id" ref="base.user_admin"/>
+        <field name="partner_id" ref="base.main_partner"/>
         <field name="x_account_analytic_account_id" ref="account_analytic_account_23"/>
         <field name="user_id" ref="base.user_admin"/>
     </record>
@@ -72,7 +72,7 @@
         <field name="end_date" eval="datetime.today().date().replace(month=7, day=31)"/>
         <field name="plan_id" ref="sale_subscription.subscription_plan_month"/>
         <field name="close_reason_id" ref="sale_subscription.close_reason_end_of_contract"/>
-        <field name="partner_id" ref="base.user_admin"/>
+        <field name="partner_id" ref="base.main_partner"/>
         <field name="x_account_analytic_account_id" ref="account_analytic_account_24"/>
         <field name="user_id" ref="base.user_admin"/>
     </record>
@@ -80,7 +80,7 @@
         <field name="start_date" eval="datetime.today().replace(month=9, day=1)"/>
         <field name="end_date" eval="datetime.today() + relativedelta(months=18)"/>
         <field name="plan_id" ref="sale_subscription.subscription_plan_month"/>
-        <field name="partner_id" ref="base.user_admin"/>
+        <field name="partner_id" ref="base.main_partner"/>
         <field name="x_account_analytic_account_id" ref="account_analytic_account_24"/>
         <field name="user_id" ref="base.user_admin"/>
     </record>

--- a/machine_tool_rental/data/product_product.xml
+++ b/machine_tool_rental/data/product_product.xml
@@ -128,7 +128,7 @@
     <field name="purchase_method">receive</field>
     <field name="service_type">manual</field>
     <field name="invoice_policy">delivery</field>
-    <field name="optional_product_ids" eval="[(6, 0, [ref('product_product_15')])]"/>
+    <field name="optional_product_ids" eval="[(6, 0, [ref('product_product_15_product_template')])]"/>
     <field name="rent_ok" eval="True"/>
   </record>
   <record id="product_product_6" model="product.product">

--- a/machine_tool_rental/data/x_recurring_maintenance_rules.xml
+++ b/machine_tool_rental/data/x_recurring_maintenance_rules.xml
@@ -2,18 +2,18 @@
 <odoo noupdate="1">
   <record id="x_recurring_maintenance_rules_1" model="x_recurring_maintenance_rules">
     <field name="x_run_time_increment_h">500.0</field>
-    <field name="x_product_id" ref="product_product_4"/>
+    <field name="x_product_id" ref="product_product_4_product_template"/>
   </record>
   <record id="x_recurring_maintenance_rules_2" model="x_recurring_maintenance_rules">
     <field name="x_run_time_increment_h">1000.0</field>
-    <field name="x_product_id" ref="product_product_10"/>
+    <field name="x_product_id" ref="product_product_10_product_template"/>
   </record>
   <record id="x_recurring_maintenance_rules_3" model="x_recurring_maintenance_rules">
     <field name="x_run_time_increment_h">500.0</field>
-    <field name="x_product_id" ref="product_product_6"/>
+    <field name="x_product_id" ref="product_product_6_product_template"/>
   </record>
   <record id="x_recurring_maintenance_rules_4" model="x_recurring_maintenance_rules">
     <field name="x_run_time_increment_h">2500.0</field>
-    <field name="x_product_id" ref="product_product_9"/>
+    <field name="x_product_id" ref="product_product_9_product_template"/>
   </record>
 </odoo>

--- a/machine_tool_rental/demo/x_run_time_meter.xml
+++ b/machine_tool_rental/demo/x_run_time_meter.xml
@@ -1,91 +1,91 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
   <record id="x_run_time_meter_13" model="x_run_time_meter">
-    <field name="x_product_id" ref="product_product_9"/>
+    <field name="x_product_id" ref="product_product_9_product_template"/>
     <field name="x_date" eval="DateTime.today() - relativedelta(months=1, days=12)"/>
     <field name="x_run_time">25.0</field>
     <field name="x_serial_id" ref="stock_lot_8"/>
   </record>
   <record id="x_run_time_meter_14" model="x_run_time_meter">
-    <field name="x_product_id" ref="product_product_9"/>
+    <field name="x_product_id" ref="product_product_9_product_template"/>
     <field name="x_date" eval="DateTime.today() - relativedelta(months=1, days=10)"/>
     <field name="x_run_time">55.0</field>
     <field name="x_serial_id" ref="stock_lot_8"/>
   </record>
   <record id="x_run_time_meter_15" model="x_run_time_meter">
-    <field name="x_product_id" ref="product_product_9"/>
+    <field name="x_product_id" ref="product_product_9_product_template"/>
     <field name="x_date" eval="DateTime.today() - relativedelta(months=1, days=7)"/>
     <field name="x_run_time">62.0</field>
     <field name="x_serial_id" ref="stock_lot_8"/>
   </record>
   <record id="x_run_time_meter_16" model="x_run_time_meter">
-    <field name="x_product_id" ref="product_product_14"/>
+    <field name="x_product_id" ref="product_product_14_product_template"/>
     <field name="x_date" eval="DateTime.today() - relativedelta(months=3, days=12)"/>
     <field name="x_run_time">22.0</field>
     <field name="x_serial_id" ref="stock_lot_22"/>
   </record>
   <record id="x_run_time_meter_17" model="x_run_time_meter">
-    <field name="x_product_id" ref="product_product_14"/>
+    <field name="x_product_id" ref="product_product_14_product_template"/>
     <field name="x_date" eval="DateTime.today() - relativedelta(months=3, days=4)"/>
     <field name="x_run_time">33.0</field>
     <field name="x_serial_id" ref="stock_lot_22"/>
   </record>
   <record id="x_run_time_meter_18" model="x_run_time_meter">
-    <field name="x_product_id" ref="product_product_6"/>
+    <field name="x_product_id" ref="product_product_6_product_template"/>
     <field name="x_date" eval="DateTime.today() - relativedelta(months=2, days=6)"/>
     <field name="x_run_time">80.0</field>
     <field name="x_serial_id" ref="stock_lot_19"/>
   </record>
   <record id="x_run_time_meter_19" model="x_run_time_meter">
-    <field name="x_product_id" ref="product_product_6"/>
+    <field name="x_product_id" ref="product_product_6_product_template"/>
     <field name="x_date" eval="DateTime.today() - relativedelta(months=2, days=3)"/>
     <field name="x_run_time">120.0</field>
     <field name="x_serial_id" ref="stock_lot_19"/>
   </record>
   <record id="x_run_time_meter_20" model="x_run_time_meter">
-    <field name="x_product_id" ref="product_product_6"/>
+    <field name="x_product_id" ref="product_product_6_product_template"/>
     <field name="x_date" eval="DateTime.today() - relativedelta(months=1, days=26)"/>
     <field name="x_run_time">160.0</field>
     <field name="x_serial_id" ref="stock_lot_19"/>
   </record>
   <record id="x_run_time_meter_21" model="x_run_time_meter">
-    <field name="x_product_id" ref="product_product_6"/>
+    <field name="x_product_id" ref="product_product_6_product_template"/>
     <field name="x_date" eval="DateTime.today() - relativedelta(months=2, days=9)"/>
     <field name="x_run_time">65.0</field>
     <field name="x_serial_id" ref="stock_lot_20"/>
   </record>
   <record id="x_run_time_meter_22" model="x_run_time_meter">
-    <field name="x_product_id" ref="product_product_6"/>
+    <field name="x_product_id" ref="product_product_6_product_template"/>
     <field name="x_date" eval="DateTime.today() - relativedelta(months=2, days=8)"/>
     <field name="x_run_time">120.0</field>
     <field name="x_serial_id" ref="stock_lot_20"/>
   </record>
   <record id="x_run_time_meter_25" model="x_run_time_meter">
-    <field name="x_product_id" ref="product_product_10"/>
+    <field name="x_product_id" ref="product_product_10_product_template"/>
     <field name="x_date" eval="DateTime.today() - relativedelta(months=3, days=2)"/>
     <field name="x_run_time">120.0</field>
     <field name="x_serial_id" ref="stock_lot_15"/>
   </record>
   <record id="x_run_time_meter_26" model="x_run_time_meter">
-    <field name="x_product_id" ref="product_product_10"/>
+    <field name="x_product_id" ref="product_product_10_product_template"/>
     <field name="x_date" eval="DateTime.today() - relativedelta(months=2, days=23)"/>
     <field name="x_run_time">180.0</field>
     <field name="x_serial_id" ref="stock_lot_15"/>
   </record>
   <record id="x_run_time_meter_27" model="x_run_time_meter">
-    <field name="x_product_id" ref="product_product_10"/>
+    <field name="x_product_id" ref="product_product_10_product_template"/>
     <field name="x_date" eval="DateTime.today() - relativedelta(months=2, days=15)"/>
     <field name="x_run_time">220.0</field>
     <field name="x_serial_id" ref="stock_lot_15"/>
   </record>
   <record id="x_run_time_meter_29" model="x_run_time_meter">
-    <field name="x_product_id" ref="product_product_10"/>
+    <field name="x_product_id" ref="product_product_10_product_template"/>
     <field name="x_date" eval="DateTime.today() - relativedelta(months=1, days=8)"/>
     <field name="x_run_time">50.0</field>
     <field name="x_serial_id" ref="stock_lot_16"/>
   </record>
   <record id="x_run_time_meter_30" model="x_run_time_meter">
-    <field name="x_product_id" ref="product_product_10"/>
+    <field name="x_product_id" ref="product_product_10_product_template"/>
     <field name="x_date" eval="DateTime.today() - relativedelta(days=18)"/>
     <field name="x_run_time">100.0</field>
     <field name="x_serial_id" ref="stock_lot_16"/>

--- a/museum/data/product_product.xml
+++ b/museum/data/product_product.xml
@@ -282,7 +282,7 @@
         <field name="pos_sequence">7</field>
         <field name="service_type">manual</field>
         <field name="invoice_policy">order</field>
-        <field name="optional_product_ids" eval="[(6, 0, [ref('product_product_32')])]"/>
+        <field name="optional_product_ids" eval="[(6, 0, [ref('product_product_32_product_template')])]"/>
         <field name="website_sequence">10040</field>
     </record>
     <record id="product_product_30" model="product.product">

--- a/sport_events/data/project_task.xml
+++ b/sport_events/data/project_task.xml
@@ -4,7 +4,7 @@
     <field name="name">Request Local Permits &amp; Insurance</field>
     <field name="priority">3</field>
     <field name="project_id" ref="project_project_1"/>
-    <field name="stage_id" ref="project.project_project_stage_2"/>
+    <field name="stage_id" ref="project_task_type_3"/>
     <field name="tag_ids" eval="[(6, 0, [ref('project_tags_17'), ref('project_tags_5'), ref('project_tags_3')])]"/>
     <field name="state">1_done</field>
     <field name="user_ids" eval="[Command.set([ref('base.user_admin')])]" />
@@ -13,7 +13,7 @@
     <field name="name">Define Race Routes &amp; Distances</field>
     <field name="priority">3</field>
     <field name="project_id" ref="project_project_1"/>
-    <field name="stage_id" ref="project.project_project_stage_2"/>
+    <field name="stage_id" ref="project_task_type_3"/>
     <field name="tag_ids" eval="[(6, 0, [ref('project_tags_17'), ref('project_tags_1')])]"/>
     <field name="state">1_done</field>
     <field name="user_ids" eval="[Command.set([ref('base.user_admin')])]" />
@@ -38,7 +38,7 @@
     <field name="name">Coordinate with Sponsors</field>
     <field name="priority">1</field>
     <field name="project_id" ref="project_project_1"/>
-    <field name="stage_id" ref="project.project_project_stage_1"/>
+    <field name="stage_id" ref="project_task_type_2"/>
     <field name="tag_ids" eval="[(6, 0, [ref('project_tags_11'), ref('project_tags_10'), ref('project_tags_5')])]"/>
     <field name="state">02_changes_requested</field>
     <field name="user_ids" eval="[Command.set([ref('base.user_admin')])]" />
@@ -46,14 +46,14 @@
   <record id="project_task_6" model="project.task" context="{'mail_auto_subscribe_no_notify': True}">
     <field name="name">Order Race Materials (Bibs, Medals, T-shirts)</field>
     <field name="project_id" ref="project_project_1"/>
-    <field name="stage_id" ref="project.project_project_stage_0"/>
+    <field name="stage_id" ref="project_task_type_1"/>
     <field name="tag_ids" eval="[(6, 0, [ref('project_tags_17'), ref('project_tags_13'), ref('project_tags_14'), ref('project_tags_5')])]"/>
     <field name="user_ids" eval="[(6, 0, [])]"/>
   </record>
   <record id="project_task_7" model="project.task" context="{'mail_auto_subscribe_no_notify': True}">
     <field name="name">Organize Race Day Staff &amp; Volunteers</field>
     <field name="project_id" ref="project_project_1"/>
-    <field name="stage_id" ref="project.project_project_stage_0"/>
+    <field name="stage_id" ref="project_task_type_1"/>
     <field name="tag_ids" eval="[(6, 0, [ref('project_tags_13'), ref('project_tags_15'), ref('project_tags_16')])]"/>
     <field name="user_ids" eval="[Command.set([ref('base.user_admin')])]" />
   </record>

--- a/tests/test_3pl_logistic_company/tests/test_action_server.py
+++ b/tests/test_3pl_logistic_company/tests/test_action_server.py
@@ -27,11 +27,11 @@ class AutomationsTestCase(TransactionCase):
         so = self.env['sale.order'].create({
             'partner_id': self.partner_2.id,
             'order_line': [
-                Command.create({'product_id': self.product_template_1.id, 'product_uom_qty': 1}),
+                Command.create({'product_id': self.product_template_1.product_variant_id.id, 'product_uom_qty': 1}),
             ]
         })
         so.action_confirm()
-        move_line_owner_id = self.env['stock.move.line'].search([('product_id', '=', self.product_template_1.id)], limit=1).owner_id
+        move_line_owner_id = self.env['stock.move.line'].search([('product_id', '=', self.product_template_1.product_variant_id.id)], limit=1).owner_id
         self.assertEqual(move_line_owner_id, self.partner_1, "Move line owner should match product owner")
 
     def test_base_automation_on_stock_move_changed(self):
@@ -42,8 +42,8 @@ class AutomationsTestCase(TransactionCase):
             'location_id': self.env.ref('stock.stock_location_stock').id,
             'location_dest_id': self.env.ref('stock.stock_location_customers').id,
             'move_ids': [
-                Command.create({'product_id': self.product_template_1.id, 'product_uom_qty': 1}),
-                Command.create({'product_id': self.product_template_2.id, 'product_uom_qty': 1}),
+                Command.create({'product_id': self.product_template_1.product_variant_id.id, 'product_uom_qty': 1}),
+                Command.create({'product_id': self.product_template_2.product_variant_id.id, 'product_uom_qty': 1}),
             ]
         })
         self.assertEqual(stock_picking_1.owner_id, self.partner_1, "Picking owner should match product owner if all are same.")
@@ -56,8 +56,8 @@ class AutomationsTestCase(TransactionCase):
             'location_id': self.env.ref('stock.stock_location_stock').id,
             'location_dest_id': self.env.ref('stock.stock_location_customers').id,
             'move_ids': [
-                Command.create({'product_id': self.product_template_1.id, 'product_uom_qty': 1}),
-                Command.create({'product_id': self.product_template_2.id, 'product_uom_qty': 1}),
+                Command.create({'product_id': self.product_template_1.product_variant_id.id, 'product_uom_qty': 1}),
+                Command.create({'product_id': self.product_template_2.product_variant_id.id, 'product_uom_qty': 1}),
             ]
         })
         self.assertFalse(stock_picking_1.owner_id, "Owner should NOT be updated if products have different owners.")

--- a/tests/test_3pl_logistic_company/tests/test_computed_fields.py
+++ b/tests/test_3pl_logistic_company/tests/test_computed_fields.py
@@ -26,7 +26,7 @@ class ComputedFieldsTestCase(TransactionCase):
         })
         cls.move_line = cls.env['stock.move.line'].create({
             'picking_id': cls.stock_picking.id,
-            'product_id': cls.product.id,
+            'product_id': cls.product.product_variant_id.id,
             'quantity': 1,
         })
         cls.quality_check = cls.env['quality.check'].create({

--- a/tests/test_hvac_services/tests/test_action_server.py
+++ b/tests/test_hvac_services/tests/test_action_server.py
@@ -111,7 +111,7 @@ class AutomationsTestCase(TransactionCase):
             active_model='res.partner',
         ).create({
             'x_partner_id': self.partner.id,
-            'x_device_id': self.device_product.product_tmpl_id.id,
+            'x_product_id': self.device_product.id,
             'x_serial_number': 'DUPLICATE-001',
             'x_delivery_date': fields.Datetime.now(),
         })
@@ -124,7 +124,7 @@ class AutomationsTestCase(TransactionCase):
             active_model='res.partner',
         ).create({
             'x_partner_id': self.partner.id,
-            'x_device_id': self.device_product.product_tmpl_id.id,
+            'x_product_id': self.device_product.id,
             'x_serial_number': 'NEW-HVAC-001',
             'x_delivery_date': fields.Datetime.now(),
         })

--- a/thrift_store/demo/planning_slot.xml
+++ b/thrift_store/demo/planning_slot.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
   <record id="planning_slot_20" model="planning.slot">
-    <field name="resource_id" ref="hr_employee_4"/>
+    <field name="resource_id" model="hr.employee" eval="obj().env.ref('thrift_store.hr_employee_4').resource_id.id"/>
     <field name="company_id" ref="base.main_company"/>    
     <field name="start_datetime" model="hr.employee" eval="pytz.timezone(obj().env.user.tz or 'UTC').localize(DateTime.today().date() + relativedelta(days=9, hour=12)).astimezone(pytz.UTC).replace(tzinfo=None)"/>
     <field name="end_datetime" model="hr.employee" eval="pytz.timezone(obj().env.user.tz or 'UTC').localize(DateTime.today().date() + relativedelta(days=9, hour=16)).astimezone(pytz.UTC).replace(tzinfo=None)"/>
@@ -10,7 +10,7 @@
     <field name="previous_template_id" ref="planning_slot_template_3"/>
   </record>
   <record id="planning_slot_19" model="planning.slot">
-    <field name="resource_id" ref="hr_employee_2"/>
+    <field name="resource_id" model="hr.employee" eval="obj().env.ref('thrift_store.hr_employee_2').resource_id.id"/>
     <field name="company_id" ref="base.main_company"/>
     <field name="start_datetime" model="hr.employee" eval="pytz.timezone(obj().env.user.tz or 'UTC').localize(DateTime.today().date() + relativedelta(days=9, hour=12)).astimezone(pytz.UTC).replace(tzinfo=None)"/>
     <field name="end_datetime" model="hr.employee" eval="pytz.timezone(obj().env.user.tz or 'UTC').localize(DateTime.today().date() + relativedelta(days=9, hour=16)).astimezone(pytz.UTC).replace(tzinfo=None)"/>
@@ -19,7 +19,7 @@
     <field name="previous_template_id" ref="planning_slot_template_3"/>
   </record>
   <record id="planning_slot_22" model="planning.slot">
-    <field name="resource_id" ref="hr_employee_2"/>
+    <field name="resource_id" model="hr.employee" eval="obj().env.ref('thrift_store.hr_employee_2').resource_id.id"/>
     <field name="company_id" ref="base.main_company"/>
     <field name="start_datetime" model="hr.employee" eval="pytz.timezone(obj().env.user.tz or 'UTC').localize(DateTime.today().date() + relativedelta(days=8, hour=12)).astimezone(pytz.UTC).replace(tzinfo=None)"/>
     <field name="end_datetime" model="hr.employee" eval="pytz.timezone(obj().env.user.tz or 'UTC').localize(DateTime.today().date() + relativedelta(days=8, hour=16)).astimezone(pytz.UTC).replace(tzinfo=None)"/>
@@ -28,7 +28,7 @@
     <field name="previous_template_id" ref="planning_slot_template_3"/>
   </record>
   <record id="planning_slot_21" model="planning.slot">
-    <field name="resource_id" ref="hr_employee_4"/>
+    <field name="resource_id" model="hr.employee" eval="obj().env.ref('thrift_store.hr_employee_4').resource_id.id"/>
     <field name="company_id" ref="base.main_company"/>
     <field name="start_datetime" model="hr.employee" eval="pytz.timezone(obj().env.user.tz or 'UTC').localize(DateTime.today().date() + relativedelta(days=8, hour=12)).astimezone(pytz.UTC).replace(tzinfo=None)"/>
     <field name="end_datetime" model="hr.employee" eval="pytz.timezone(obj().env.user.tz or 'UTC').localize(DateTime.today().date() + relativedelta(days=8, hour=16)).astimezone(pytz.UTC).replace(tzinfo=None)"/>
@@ -37,7 +37,7 @@
     <field name="previous_template_id" ref="planning_slot_template_3"/>
   </record>
   <record id="planning_slot_24" model="planning.slot">
-    <field name="resource_id" ref="hr_employee_4"/>
+    <field name="resource_id" model="hr.employee" eval="obj().env.ref('thrift_store.hr_employee_4').resource_id.id"/>
     <field name="company_id" ref="base.main_company"/>
     <field name="start_datetime" model="hr.employee" eval="pytz.timezone(obj().env.user.tz or 'UTC').localize(DateTime.today().date() + relativedelta(days=8, hour=8)).astimezone(pytz.UTC).replace(tzinfo=None)"/>
     <field name="end_datetime" model="hr.employee" eval="pytz.timezone(obj().env.user.tz or 'UTC').localize(DateTime.today().date() + relativedelta(days=8, hour=12)).astimezone(pytz.UTC).replace(tzinfo=None)"/>
@@ -46,7 +46,7 @@
     <field name="previous_template_id" ref="planning_slot_template_4"/>
   </record>
   <record id="planning_slot_23" model="planning.slot">
-    <field name="resource_id" ref="hr_employee_3"/>
+    <field name="resource_id" model="hr.employee" eval="obj().env.ref('thrift_store.hr_employee_3').resource_id.id"/>
     <field name="company_id" ref="base.main_company"/>
     <field name="start_datetime" model="hr.employee" eval="pytz.timezone(obj().env.user.tz or 'UTC').localize(DateTime.today().date() + relativedelta(days=8, hour=8)).astimezone(pytz.UTC).replace(tzinfo=None)"/>
     <field name="end_datetime" model="hr.employee" eval="pytz.timezone(obj().env.user.tz or 'UTC').localize(DateTime.today().date() + relativedelta(days=8, hour=12)).astimezone(pytz.UTC).replace(tzinfo=None)"/>
@@ -55,7 +55,7 @@
     <field name="previous_template_id" ref="planning_slot_template_4"/>
   </record>
   <record id="planning_slot_26" model="planning.slot">
-    <field name="resource_id" ref="hr_employee_2"/>
+    <field name="resource_id" model="hr.employee" eval="obj().env.ref('thrift_store.hr_employee_2').resource_id.id"/>
     <field name="company_id" ref="base.main_company"/>
     <field name="start_datetime" model="hr.employee" eval="pytz.timezone(obj().env.user.tz or 'UTC').localize(DateTime.today().date() + relativedelta(days=6, hour=12)).astimezone(pytz.UTC).replace(tzinfo=None)"/>
     <field name="end_datetime" model="hr.employee" eval="pytz.timezone(obj().env.user.tz or 'UTC').localize(DateTime.today().date() + relativedelta(days=6, hour=16)).astimezone(pytz.UTC).replace(tzinfo=None)"/>
@@ -64,7 +64,7 @@
     <field name="previous_template_id" ref="planning_slot_template_3"/>
   </record>
   <record id="planning_slot_25" model="planning.slot">
-    <field name="resource_id" ref="hr_employee_3"/>
+    <field name="resource_id" model="hr.employee" eval="obj().env.ref('thrift_store.hr_employee_3').resource_id.id"/>
     <field name="company_id" ref="base.main_company"/>
     <field name="start_datetime" model="hr.employee" eval="pytz.timezone(obj().env.user.tz or 'UTC').localize(DateTime.today().date() + relativedelta(days=6, hour=12)).astimezone(pytz.UTC).replace(tzinfo=None)"/>
     <field name="end_datetime" model="hr.employee" eval="pytz.timezone(obj().env.user.tz or 'UTC').localize(DateTime.today().date() + relativedelta(days=6, hour=16)).astimezone(pytz.UTC).replace(tzinfo=None)"/>
@@ -73,7 +73,7 @@
     <field name="previous_template_id" ref="planning_slot_template_3"/>
   </record>
   <record id="planning_slot_28" model="planning.slot">
-    <field name="resource_id" ref="hr_employee_2"/>
+    <field name="resource_id" model="hr.employee" eval="obj().env.ref('thrift_store.hr_employee_2').resource_id.id"/>
     <field name="company_id" ref="base.main_company"/>
     <field name="start_datetime" model="hr.employee" eval="pytz.timezone(obj().env.user.tz or 'UTC').localize(DateTime.today().date() + relativedelta(days=6, hour=8)).astimezone(pytz.UTC).replace(tzinfo=None)"/>
     <field name="end_datetime" model="hr.employee" eval="pytz.timezone(obj().env.user.tz or 'UTC').localize(DateTime.today().date() + relativedelta(days=6, hour=12)).astimezone(pytz.UTC).replace(tzinfo=None)"/>
@@ -82,7 +82,7 @@
     <field name="previous_template_id" ref="planning_slot_template_4"/>
   </record>
   <record id="planning_slot_27" model="planning.slot">
-    <field name="resource_id" ref="hr_employee_3"/>
+    <field name="resource_id" model="hr.employee" eval="obj().env.ref('thrift_store.hr_employee_3').resource_id.id"/>
     <field name="company_id" ref="base.main_company"/>
     <field name="start_datetime" model="hr.employee" eval="pytz.timezone(obj().env.user.tz or 'UTC').localize(DateTime.today().date() + relativedelta(days=6, hour=8)).astimezone(pytz.UTC).replace(tzinfo=None)"/>
     <field name="end_datetime" model="hr.employee" eval="pytz.timezone(obj().env.user.tz or 'UTC').localize(DateTime.today().date() + relativedelta(days=6, hour=12)).astimezone(pytz.UTC).replace(tzinfo=None)"/>
@@ -91,7 +91,7 @@
     <field name="previous_template_id" ref="planning_slot_template_4"/>
   </record>
   <record id="planning_slot_30" model="planning.slot">
-    <field name="resource_id" ref="hr_employee_3"/>
+    <field name="resource_id" model="hr.employee" eval="obj().env.ref('thrift_store.hr_employee_3').resource_id.id"/>
     <field name="company_id" ref="base.main_company"/>
     <field name="start_datetime" model="hr.employee" eval="pytz.timezone(obj().env.user.tz or 'UTC').localize(DateTime.today().date() + relativedelta(days=5, hour=12)).astimezone(pytz.UTC).replace(tzinfo=None)"/>
     <field name="end_datetime" model="hr.employee" eval="pytz.timezone(obj().env.user.tz or 'UTC').localize(DateTime.today().date() + relativedelta(days=5, hour=16)).astimezone(pytz.UTC).replace(tzinfo=None)"/>
@@ -100,7 +100,7 @@
     <field name="previous_template_id" ref="planning_slot_template_3"/>
   </record>
   <record id="planning_slot_29" model="planning.slot">
-    <field name="resource_id" ref="hr_employee_2"/>
+    <field name="resource_id" model="hr.employee" eval="obj().env.ref('thrift_store.hr_employee_2').resource_id.id"/>
     <field name="company_id" ref="base.main_company"/>
     <field name="start_datetime" model="hr.employee" eval="pytz.timezone(obj().env.user.tz or 'UTC').localize(DateTime.today().date() + relativedelta(days=5, hour=12)).astimezone(pytz.UTC).replace(tzinfo=None)"/>
     <field name="end_datetime" model="hr.employee" eval="pytz.timezone(obj().env.user.tz or 'UTC').localize(DateTime.today().date() + relativedelta(days=5, hour=16)).astimezone(pytz.UTC).replace(tzinfo=None)"/>
@@ -109,7 +109,7 @@
     <field name="previous_template_id" ref="planning_slot_template_3"/>
   </record>
   <record id="planning_slot_32" model="planning.slot">
-    <field name="resource_id" ref="hr_employee_3"/>
+    <field name="resource_id" model="hr.employee" eval="obj().env.ref('thrift_store.hr_employee_3').resource_id.id"/>
     <field name="company_id" ref="base.main_company"/>
     <field name="start_datetime" model="hr.employee" eval="pytz.timezone(obj().env.user.tz or 'UTC').localize(DateTime.today().date() + relativedelta(days=4, hour=12)).astimezone(pytz.UTC).replace(tzinfo=None)"/>
     <field name="end_datetime" model="hr.employee" eval="pytz.timezone(obj().env.user.tz or 'UTC').localize(DateTime.today().date() + relativedelta(days=4, hour=16)).astimezone(pytz.UTC).replace(tzinfo=None)"/>
@@ -118,7 +118,7 @@
     <field name="previous_template_id" ref="planning_slot_template_3"/>
   </record>
   <record id="planning_slot_31" model="planning.slot">
-    <field name="resource_id" ref="hr_employee_2"/>
+    <field name="resource_id" model="hr.employee" eval="obj().env.ref('thrift_store.hr_employee_2').resource_id.id"/>
     <field name="company_id" ref="base.main_company"/>
     <field name="start_datetime" model="hr.employee" eval="pytz.timezone(obj().env.user.tz or 'UTC').localize(DateTime.today().date() + relativedelta(days=4, hour=12)).astimezone(pytz.UTC).replace(tzinfo=None)"/>
     <field name="end_datetime" model="hr.employee" eval="pytz.timezone(obj().env.user.tz or 'UTC').localize(DateTime.today().date() + relativedelta(days=4, hour=16)).astimezone(pytz.UTC).replace(tzinfo=None)"/>
@@ -127,7 +127,7 @@
     <field name="previous_template_id" ref="planning_slot_template_3"/>
   </record>
   <record id="planning_slot_34" model="planning.slot">
-    <field name="resource_id" ref="hr_employee_2"/>
+    <field name="resource_id" model="hr.employee" eval="obj().env.ref('thrift_store.hr_employee_2').resource_id.id"/>
     <field name="company_id" ref="base.main_company"/>
     <field name="start_datetime" model="hr.employee" eval="pytz.timezone(obj().env.user.tz or 'UTC').localize(DateTime.today().date() + relativedelta(days=3, hour=12)).astimezone(pytz.UTC).replace(tzinfo=None)"/>
     <field name="end_datetime" model="hr.employee" eval="pytz.timezone(obj().env.user.tz or 'UTC').localize(DateTime.today().date() + relativedelta(days=3, hour=16)).astimezone(pytz.UTC).replace(tzinfo=None)"/>
@@ -136,7 +136,7 @@
     <field name="previous_template_id" ref="planning_slot_template_3"/>
   </record>
   <record id="planning_slot_33" model="planning.slot">
-    <field name="resource_id" ref="hr_employee_4"/>
+    <field name="resource_id" model="hr.employee" eval="obj().env.ref('thrift_store.hr_employee_4').resource_id.id"/>
     <field name="company_id" ref="base.main_company"/>
     <field name="start_datetime" model="hr.employee" eval="pytz.timezone(obj().env.user.tz or 'UTC').localize(DateTime.today().date() + relativedelta(days=3, hour=12)).astimezone(pytz.UTC).replace(tzinfo=None)"/>
     <field name="end_datetime" model="hr.employee" eval="pytz.timezone(obj().env.user.tz or 'UTC').localize(DateTime.today().date() + relativedelta(days=3, hour=16)).astimezone(pytz.UTC).replace(tzinfo=None)"/>
@@ -145,7 +145,7 @@
     <field name="previous_template_id" ref="planning_slot_template_3"/>
   </record>
   <record id="planning_slot_16" model="planning.slot">
-    <field name="resource_id" ref="hr_employee_2"/>
+    <field name="resource_id" model="hr.employee" eval="obj().env.ref('thrift_store.hr_employee_2').resource_id.id"/>
     <field name="company_id" ref="base.main_company"/>
     <field name="start_datetime" model="hr.employee" eval="pytz.timezone(obj().env.user.tz or 'UTC').localize(DateTime.today().date() + relativedelta(days=2, hour=12)).astimezone(pytz.UTC).replace(tzinfo=None)"/>
     <field name="end_datetime" model="hr.employee" eval="pytz.timezone(obj().env.user.tz or 'UTC').localize(DateTime.today().date() + relativedelta(days=2, hour=16)).astimezone(pytz.UTC).replace(tzinfo=None)"/>
@@ -154,7 +154,7 @@
      <field name="previous_template_id" ref="planning_slot_template_3"/>
   </record>
   <record id="planning_slot_15" model="planning.slot">
-    <field name="resource_id" ref="hr_employee_3"/>
+    <field name="resource_id" model="hr.employee" eval="obj().env.ref('thrift_store.hr_employee_3').resource_id.id"/>
     <field name="company_id" ref="base.main_company"/>
     <field name="start_datetime" model="hr.employee" eval="pytz.timezone(obj().env.user.tz or 'UTC').localize(DateTime.today().date() + relativedelta(days=2, hour=12)).astimezone(pytz.UTC).replace(tzinfo=None)"/>
     <field name="end_datetime" model="hr.employee" eval="pytz.timezone(obj().env.user.tz or 'UTC').localize(DateTime.today().date() + relativedelta(days=2, hour=16)).astimezone(pytz.UTC).replace(tzinfo=None)"/>
@@ -163,7 +163,7 @@
      <field name="previous_template_id" ref="planning_slot_template_3"/>
   </record>
   <record id="planning_slot_14" model="planning.slot">
-    <field name="resource_id" ref="hr_employee_2"/>
+    <field name="resource_id" model="hr.employee" eval="obj().env.ref('thrift_store.hr_employee_2').resource_id.id"/>
     <field name="company_id" ref="base.main_company"/>
     <field name="start_datetime" model="hr.employee" eval="pytz.timezone(obj().env.user.tz or 'UTC').localize(DateTime.today().date() + relativedelta(days=1, hour=12)).astimezone(pytz.UTC).replace(tzinfo=None)"/>
     <field name="end_datetime" model="hr.employee" eval="pytz.timezone(obj().env.user.tz or 'UTC').localize(DateTime.today().date() + relativedelta(days=1, hour=16)).astimezone(pytz.UTC).replace(tzinfo=None)"/>
@@ -172,7 +172,7 @@
      <field name="previous_template_id" ref="planning_slot_template_3"/>
   </record>
   <record id="planning_slot_13" model="planning.slot">
-    <field name="resource_id" ref="hr_employee_3"/>
+    <field name="resource_id" model="hr.employee" eval="obj().env.ref('thrift_store.hr_employee_3').resource_id.id"/>
     <field name="company_id" ref="base.main_company"/>
     <field name="start_datetime" model="hr.employee" eval="pytz.timezone(obj().env.user.tz or 'UTC').localize(DateTime.today().date() + relativedelta(days=1, hour=12)).astimezone(pytz.UTC).replace(tzinfo=None)"/>
     <field name="end_datetime" model="hr.employee" eval="pytz.timezone(obj().env.user.tz or 'UTC').localize(DateTime.today().date() + relativedelta(days=1, hour=16)).astimezone(pytz.UTC).replace(tzinfo=None)"/>
@@ -181,7 +181,7 @@
      <field name="previous_template_id" ref="planning_slot_template_3"/>
   </record>
   <record id="planning_slot_12" model="planning.slot">
-    <field name="resource_id" ref="hr_employee_2"/>
+    <field name="resource_id" model="hr.employee" eval="obj().env.ref('thrift_store.hr_employee_2').resource_id.id"/>
     <field name="company_id" ref="base.main_company"/>
     <field name="start_datetime" model="hr.employee" eval="pytz.timezone(obj().env.user.tz or 'UTC').localize(DateTime.today().date() + relativedelta(days=1, hour=8)).astimezone(pytz.UTC).replace(tzinfo=None)"/>
     <field name="end_datetime" model="hr.employee" eval="pytz.timezone(obj().env.user.tz or 'UTC').localize(DateTime.today().date() + relativedelta(days=1, hour=12)).astimezone(pytz.UTC).replace(tzinfo=None)"/>
@@ -190,7 +190,7 @@
      <field name="previous_template_id" ref="planning_slot_template_4"/>
   </record>
   <record id="planning_slot_11" model="planning.slot">
-    <field name="resource_id" ref="hr_employee_4"/>
+    <field name="resource_id" model="hr.employee" eval="obj().env.ref('thrift_store.hr_employee_4').resource_id.id"/>
     <field name="company_id" ref="base.main_company"/>
     <field name="start_datetime" model="hr.employee" eval="pytz.timezone(obj().env.user.tz or 'UTC').localize(DateTime.today().date() + relativedelta(days=1, hour=8)).astimezone(pytz.UTC).replace(tzinfo=None)"/>
     <field name="end_datetime" model="hr.employee" eval="pytz.timezone(obj().env.user.tz or 'UTC').localize(DateTime.today().date() + relativedelta(days=1, hour=12)).astimezone(pytz.UTC).replace(tzinfo=None)"/>
@@ -199,7 +199,7 @@
      <field name="previous_template_id" ref="planning_slot_template_4"/>
   </record>
   <record id="planning_slot_10" model="planning.slot">
-    <field name="resource_id" ref="hr_employee_4"/>
+    <field name="resource_id" model="hr.employee" eval="obj().env.ref('thrift_store.hr_employee_4').resource_id.id"/>
     <field name="company_id" ref="base.main_company"/>
     <field name="start_datetime" model="hr.employee" eval="pytz.timezone(obj().env.user.tz or 'UTC').localize(DateTime.today().date() + relativedelta(days=-1, hour=12)).astimezone(pytz.UTC).replace(tzinfo=None)"/>
     <field name="end_datetime" model="hr.employee" eval="pytz.timezone(obj().env.user.tz or 'UTC').localize(DateTime.today().date() + relativedelta(days=-1, hour=16)).astimezone(pytz.UTC).replace(tzinfo=None)"/>
@@ -208,7 +208,7 @@
      <field name="previous_template_id" ref="planning_slot_template_3"/>
   </record>
   <record id="planning_slot_8" model="planning.slot">
-    <field name="resource_id" ref="hr_employee_3"/>
+    <field name="resource_id" model="hr.employee" eval="obj().env.ref('thrift_store.hr_employee_3').resource_id.id"/>
     <field name="company_id" ref="base.main_company"/>
     <field name="start_datetime" model="hr.employee" eval="pytz.timezone(obj().env.user.tz or 'UTC').localize(DateTime.today().date() + relativedelta(days=-1, hour=12)).astimezone(pytz.UTC).replace(tzinfo=None)"/>
     <field name="end_datetime" model="hr.employee" eval="pytz.timezone(obj().env.user.tz or 'UTC').localize(DateTime.today().date() + relativedelta(days=-1, hour=16)).astimezone(pytz.UTC).replace(tzinfo=None)"/>
@@ -217,7 +217,7 @@
      <field name="previous_template_id" ref="planning_slot_template_3"/>
   </record>
   <record id="planning_slot_9" model="planning.slot">
-    <field name="resource_id" ref="hr_employee_3"/>
+    <field name="resource_id" model="hr.employee" eval="obj().env.ref('thrift_store.hr_employee_3').resource_id.id"/>
     <field name="company_id" ref="base.main_company"/>
     <field name="start_datetime" model="hr.employee" eval="pytz.timezone(obj().env.user.tz or 'UTC').localize(DateTime.today().date() + relativedelta(days=-1, hour=8)).astimezone(pytz.UTC).replace(tzinfo=None)"/>
     <field name="end_datetime" model="hr.employee" eval="pytz.timezone(obj().env.user.tz or 'UTC').localize(DateTime.today().date() + relativedelta(days=-1, hour=12)).astimezone(pytz.UTC).replace(tzinfo=None)"/>
@@ -226,7 +226,7 @@
      <field name="previous_template_id" ref="planning_slot_template_4"/>
   </record>
   <record id="planning_slot_7" model="planning.slot">
-    <field name="resource_id" ref="hr_employee_2"/>
+    <field name="resource_id" model="hr.employee" eval="obj().env.ref('thrift_store.hr_employee_2').resource_id.id"/>
     <field name="company_id" ref="base.main_company"/>
     <field name="start_datetime" model="hr.employee" eval="pytz.timezone(obj().env.user.tz or 'UTC').localize(DateTime.today().date() + relativedelta(days=-1, hour=8)).astimezone(pytz.UTC).replace(tzinfo=None)"/>
     <field name="end_datetime" model="hr.employee" eval="pytz.timezone(obj().env.user.tz or 'UTC').localize(DateTime.today().date() + relativedelta(days=-1, hour=12)).astimezone(pytz.UTC).replace(tzinfo=None)"/>
@@ -235,7 +235,7 @@
      <field name="previous_template_id" ref="planning_slot_template_4"/>
   </record>
   <record id="planning_slot_6" model="planning.slot">
-    <field name="resource_id" ref="hr_employee_4"/>
+    <field name="resource_id" model="hr.employee" eval="obj().env.ref('thrift_store.hr_employee_4').resource_id.id"/>
     <field name="company_id" ref="base.main_company"/>
     <field name="start_datetime" model="hr.employee" eval="pytz.timezone(obj().env.user.tz or 'UTC').localize(DateTime.today().date() + relativedelta(days=-2, hour=12)).astimezone(pytz.UTC).replace(tzinfo=None)"/>
     <field name="end_datetime" model="hr.employee" eval="pytz.timezone(obj().env.user.tz or 'UTC').localize(DateTime.today().date() + relativedelta(days=-2, hour=16)).astimezone(pytz.UTC).replace(tzinfo=None)"/>
@@ -244,7 +244,7 @@
      <field name="previous_template_id" ref="planning_slot_template_3"/>
   </record>
   <record id="planning_slot_5" model="planning.slot">
-    <field name="resource_id" ref="hr_employee_2"/>
+    <field name="resource_id" model="hr.employee" eval="obj().env.ref('thrift_store.hr_employee_2').resource_id.id"/>
     <field name="company_id" ref="base.main_company"/>
     <field name="start_datetime" model="hr.employee" eval="pytz.timezone(obj().env.user.tz or 'UTC').localize(DateTime.today().date() + relativedelta(days=-2, hour=12)).astimezone(pytz.UTC).replace(tzinfo=None)"/>
     <field name="end_datetime" model="hr.employee" eval="pytz.timezone(obj().env.user.tz or 'UTC').localize(DateTime.today().date() + relativedelta(days=-2, hour=16)).astimezone(pytz.UTC).replace(tzinfo=None)"/>
@@ -253,7 +253,7 @@
      <field name="previous_template_id" ref="planning_slot_template_3"/>
   </record>
   <record id="planning_slot_4" model="planning.slot">
-    <field name="resource_id" ref="hr_employee_3"/>
+    <field name="resource_id" model="hr.employee" eval="obj().env.ref('thrift_store.hr_employee_3').resource_id.id"/>
     <field name="company_id" ref="base.main_company"/>
     <field name="start_datetime" model="hr.employee" eval="pytz.timezone(obj().env.user.tz or 'UTC').localize(DateTime.today().date() + relativedelta(days=-3, hour=12)).astimezone(pytz.UTC).replace(tzinfo=None)"/>
     <field name="end_datetime" model="hr.employee" eval="pytz.timezone(obj().env.user.tz or 'UTC').localize(DateTime.today().date() + relativedelta(days=-3, hour=16)).astimezone(pytz.UTC).replace(tzinfo=None)"/>
@@ -262,7 +262,7 @@
      <field name="previous_template_id" ref="planning_slot_template_3"/>
   </record>
   <record id="planning_slot_3" model="planning.slot">
-    <field name="resource_id" ref="hr_employee_2"/>
+    <field name="resource_id" model="hr.employee" eval="obj().env.ref('thrift_store.hr_employee_2').resource_id.id"/>
     <field name="company_id" ref="base.main_company"/>
     <field name="start_datetime" model="hr.employee" eval="pytz.timezone(obj().env.user.tz or 'UTC').localize(DateTime.today().date() + relativedelta(days=-3, hour=12)).astimezone(pytz.UTC).replace(tzinfo=None)"/>
     <field name="end_datetime" model="hr.employee" eval="pytz.timezone(obj().env.user.tz or 'UTC').localize(DateTime.today().date() + relativedelta(days=-3, hour=16)).astimezone(pytz.UTC).replace(tzinfo=None)"/>
@@ -271,7 +271,7 @@
      <field name="previous_template_id" ref="planning_slot_template_3"/>
   </record>
   <record id="planning_slot_18" model="planning.slot">
-    <field name="resource_id" ref="hr_employee_2"/>
+    <field name="resource_id" model="hr.employee" eval="obj().env.ref('thrift_store.hr_employee_2').resource_id.id"/>
     <field name="company_id" ref="base.main_company"/>
     <field name="start_datetime" model="hr.employee" eval="pytz.timezone(obj().env.user.tz or 'UTC').localize(DateTime.today().date() + relativedelta(days=-4, hour=12)).astimezone(pytz.UTC).replace(tzinfo=None)"/>
     <field name="end_datetime" model="hr.employee" eval="pytz.timezone(obj().env.user.tz or 'UTC').localize(DateTime.today().date() + relativedelta(days=-4, hour=16)).astimezone(pytz.UTC).replace(tzinfo=None)"/>
@@ -280,7 +280,7 @@
      <field name="previous_template_id" ref="planning_slot_template_3"/>
   </record>
   <record id="planning_slot_17" model="planning.slot">
-    <field name="resource_id" ref="hr_employee_4"/>
+    <field name="resource_id" model="hr.employee" eval="obj().env.ref('thrift_store.hr_employee_4').resource_id.id"/>
     <field name="company_id" ref="base.main_company"/>
     <field name="start_datetime" model="hr.employee" eval="pytz.timezone(obj().env.user.tz or 'UTC').localize(DateTime.today().date() + relativedelta(days=-4, hour=12)).astimezone(pytz.UTC).replace(tzinfo=None)"/>
     <field name="end_datetime" model="hr.employee" eval="pytz.timezone(obj().env.user.tz or 'UTC').localize(DateTime.today().date() + relativedelta(days=-4, hour=16)).astimezone(pytz.UTC).replace(tzinfo=None)"/>

--- a/veterinary_clinic/demo/calendar_event.xml
+++ b/veterinary_clinic/demo/calendar_event.xml
@@ -9,7 +9,7 @@
     <field name="stop" model="appointment.type" eval="pytz.timezone(obj().env.ref('veterinary_clinic.appointment_type_1').appointment_tz).localize(
                 DateTime.today().date() + relativedelta(days=2, hours=14, minutes=30)
     ).astimezone(pytz.UTC).replace(tzinfo=None)"/>
-    <field name="appointment_booker_id" ref="base.user_admin"/>
+    <field name="appointment_booker_id" ref="base.partner_admin"/>
     <field name="x_new_pet_field" eval="[(6, 0, [ref('x_pets_9')])]"/>
   </record>
   <record id="calendar_event_1" model="calendar.event" context="{'no_mail_to_attendees': True}">
@@ -23,7 +23,7 @@
                 DateTime.today().date() + relativedelta(days=4, hours=14, minutes=15)
     ).astimezone(pytz.UTC).replace(tzinfo=None)"/>
     <field name="duration">0.5</field>
-    <field name="partner_ids" eval="[(6, 0, [ref('base.user_admin'), ref('res_partner_76')])]"/>
+    <field name="partner_ids" eval="[(6, 0, [ref('base.partner_admin'), ref('res_partner_76')])]"/>
     <field name="appointment_type_id" ref="appointment_type_1"/>
     <field name="alarm_ids" eval="[(6, 0, [ref('calendar.alarm_mail_1'), ref('appointment_sms.calendar_alarm_data_1h_sms')])]"/>
     <field name="appointment_status">booked</field>
@@ -40,7 +40,7 @@
           DateTime.today().date() + relativedelta(days=4, hours=10, minutes=45)
     ).astimezone(pytz.UTC).replace(tzinfo=None)"/>
     <field name="duration">0.5</field>
-    <field name="partner_ids" eval="[(6, 0, [ref('base.user_admin'), ref('res_partner_76')])]"/>
+    <field name="partner_ids" eval="[(6, 0, [ref('base.partner_admin'), ref('res_partner_76')])]"/>
     <field name="appointment_type_id" ref="appointment_type_1"/>
     <field name="alarm_ids" eval="[(6, 0, [ref('calendar.alarm_mail_1'), ref('appointment_sms.calendar_alarm_data_1h_sms')])]"/>
     <field name="appointment_status">booked</field>

--- a/veterinary_clinic/demo/x_pets.xml
+++ b/veterinary_clinic/demo/x_pets.xml
@@ -35,7 +35,7 @@
     <field name="x_avatar_image" type="base64" file="veterinary_clinic/static/src/binary/x_pets/9-x_avatar_image"/>
     <field name="x_breed" ref="x_species_line_3"/>
     <field name="x_aggression_level">Severe</field>
-    <field name="x_owner" ref="base.user_admin"/>
+    <field name="x_owner" ref="base.main_partner"/>
   </record>
   <record id="x_pets_1" model="x_pets">
     <field name="x_name">Milos</field>
@@ -62,7 +62,7 @@
     <field name="x_reproductive_status">Neutered</field>
     <field name="x_avatar_image" type="base64" file="veterinary_clinic/static/src/binary/x_pets/12-x_avatar_image"/>
     <field name="x_breed" ref="x_species_line_3"/>
-    <field name="x_owner" ref="base.user_admin"/>
+    <field name="x_owner" ref="base.main_partner"/>
   </record>
   <record id="x_pets_3" model="x_pets">
     <field name="x_name">Marcel</field>


### PR DESCRIPTION
In several cases, there is a mismatch between compared/assigned record models, leading to erroneous behaviour. This commit ensures assignation and domain criterion is correct at the model level.

Furthermore, for HVAC, the wizard is adapted to use product.product, instead of product.template.

backport of odoo/industry#1844