### PR TITLE
[FIX] *: add context key for product variant creation

### DIFF
--- a/3pl_logistic_company/data/product_template.xml
+++ b/3pl_logistic_company/data/product_template.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-    <record id="product_template_10" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_10" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Christmas Tree Waterfall Lights</field>
         <field name="is_storable" eval="True"/>
         <field name="responsible_id" ref="base.user_admin"/>
@@ -9,7 +9,7 @@
         <field name="service_type">manual</field>
         <field name="invoice_policy">order</field>
     </record>
-    <record id="product_template_7" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_7" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Energy Bar</field>
         <field name="categ_id" ref="product_category_5"/>
         <field name="is_storable" eval="True"/>
@@ -21,7 +21,7 @@
         <field name="service_type">manual</field>
         <field name="invoice_policy">order</field>
     </record>
-    <record id="product_template_8" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_8" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Energy Pack</field>
         <field name="categ_id" ref="product_category_5"/>
         <field name="is_storable" eval="True"/>
@@ -30,7 +30,7 @@
         <field name="service_type">manual</field>
         <field name="invoice_policy">order</field>
     </record>
-    <record id="product_template_9" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_9" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Energy Packaging</field>
         <field name="categ_id" ref="product_category_5"/>
         <field name="is_storable" eval="True"/>
@@ -39,7 +39,7 @@
         <field name="service_type">manual</field>
         <field name="invoice_policy">order</field>
     </record>
-    <record id="product_template_14" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_14" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Extra Quality Check</field>
         <field name="type">service</field>
         <field name="list_price">0.1</field>
@@ -49,7 +49,7 @@
         <field name="service_type">manual</field>
         <field name="invoice_policy">order</field>
     </record>
-    <record id="product_template_17" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_17" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Extra's</field>
         <field name="type">service</field>
         <field name="responsible_id" ref="base.user_admin"/>
@@ -57,7 +57,7 @@
         <field name="service_type">manual</field>
         <field name="invoice_policy">order</field>
     </record>
-    <record id="product_template_15" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_15" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Handling Charges Input</field>
         <field name="type">service</field>
         <field name="responsible_id" ref="base.user_admin"/>
@@ -65,7 +65,7 @@
         <field name="service_type">manual</field>
         <field name="invoice_policy">order</field>
     </record>
-    <record id="product_template_16" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_16" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Handling Charges Output</field>
         <field name="type">service</field>
         <field name="responsible_id" ref="base.user_admin"/>
@@ -73,7 +73,7 @@
         <field name="service_type">manual</field>
         <field name="invoice_policy">order</field>
     </record>
-    <record id="product_template_5" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_5" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Hydrate powder</field>
         <field name="categ_id" ref="product_category_5"/>
         <field name="is_storable" eval="True"/>
@@ -85,7 +85,7 @@
         <field name="service_type">manual</field>
         <field name="invoice_policy">order</field>
     </record>
-    <record id="product_template_12" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_12" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Reserved Warehouse Space - Ground</field>
         <field name="type">service</field>
         <field name="list_price">0.35</field>
@@ -96,7 +96,7 @@
         <field name="invoice_policy">order</field>
         <field name="recurring_invoice" eval="True"/>
     </record>
-    <record id="product_template_13" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_13" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Reserved Warehouse Space - High-Bay</field>
         <field name="type">service</field>
         <field name="list_price">0.4</field>
@@ -107,7 +107,7 @@
         <field name="invoice_policy">order</field>
         <field name="recurring_invoice" eval="True"/>
     </record>
-    <record id="product_template_2" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_2" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Shampoo</field>
         <field name="uom_id" ref="uom_uom_29"/>
         <field name="is_storable" eval="True"/>
@@ -117,7 +117,7 @@
         <field name="service_type">manual</field>
         <field name="invoice_policy">order</field>
     </record>
-    <record id="product_template_3" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_3" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Soap</field>
         <field name="uom_id" ref="uom_uom_29"/>
         <field name="is_storable" eval="True"/>
@@ -127,7 +127,7 @@
         <field name="service_type">manual</field>
         <field name="invoice_policy">order</field>
     </record>
-    <record id="product_template_6" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_6" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Sports Gel</field>
         <field name="categ_id" ref="product_category_5"/>
         <field name="is_storable" eval="True"/>
@@ -139,7 +139,7 @@
         <field name="service_type">manual</field>
         <field name="invoice_policy">order</field>
     </record>
-    <record id="product_template_19" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_19" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Storage - Ground</field>
         <field name="type">service</field>
         <field name="list_price">0.35</field>
@@ -149,7 +149,7 @@
         <field name="service_type">manual</field>
         <field name="invoice_policy">order</field>
     </record>
-    <record id="product_template_20" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_20" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Storage - High-Bay</field>
         <field name="type">service</field>
         <field name="list_price">0.4</field>
@@ -159,7 +159,7 @@
         <field name="service_type">manual</field>
         <field name="invoice_policy">order</field>
     </record>
-    <record id="product_template_4" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_4" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Toothpaste</field>
         <field name="uom_id" ref="uom_uom_29"/>
         <field name="is_storable" eval="True"/>
@@ -169,7 +169,7 @@
         <field name="service_type">manual</field>
         <field name="invoice_policy">order</field>
     </record>
-    <record id="product_template_18" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_18" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Transport</field>
         <field name="type">service</field>
         <field name="responsible_id" ref="base.user_admin"/>

--- a/art_craft/data/product_template.xml
+++ b/art_craft/data/product_template.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-    <record id="product_template_10" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_10" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Bag - Shopping Bag with a Pouch</field>
         <field name="default_code">PK TOTE</field>
         <field name="list_price">25.4</field>
@@ -18,7 +18,7 @@
             Inspired by: Kashmir Jamawar Shawl (20th century)
         </field>
     </record>
-    <record id="product_template_11" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_11" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Bag - Tote Bag</field>
         <field name="default_code">DP TOTE</field>
         <field name="list_price">23.0</field>
@@ -38,7 +38,7 @@
             Inspired by: Brocade Pichwai Fragment (c.1850)
         </field>
     </record>
-    <record id="product_template_12" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_12" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Bag - Travel Bag</field>
         <field name="list_price">25.0</field>
         <field name="is_storable">True</field>
@@ -57,7 +57,7 @@
             Inspired by: Japanese Patchwork Jacket (late 19th - early 20th century)
         </field>
     </record>
-    <record id="product_template_13" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_13" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Acrylic Tray</field>
         <field name="list_price">50.0</field>
         <field name="is_storable">True</field>
@@ -76,7 +76,7 @@
             Inspired by: Painted Fabric by Jayashree Chakravarty (early 1990s)
         </field>
     </record>
-    <record id="product_template_14" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_14" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Drawing Coasters - Set of 6</field>
         <field name="list_price">15.0</field>
         <field name="is_storable">True</field>
@@ -94,7 +94,7 @@
             Inspired by: Drawing by Jogen Chowdhry (After 2000)
         </field>
     </record>
-    <record id="product_template_16" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_16" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Red Coasters - Set of 6</field>
         <field name="list_price">15.0</field>
         <field name="is_storable">True</field>
@@ -112,7 +112,7 @@
             Inspired by: Brocade Sari (20th century)
         </field>
     </record>
-    <record id="product_template_18" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_18" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Manorath Painting</field>
         <field name="default_code">ART- Khubiram Gopilal</field>
         <field name="list_price">0.0</field>
@@ -134,7 +134,7 @@
             Dimensions: Image: H. 40.5 cm, W. 53 cm
         </field>
     </record>
-    <record id="product_template_19" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_19" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">A Girl</field>
         <field name="list_price">0.0</field>
         <field name="is_storable">True</field>
@@ -148,7 +148,7 @@
             - This is saleable from physical store only. For that You need to contact Us.
         </field>
     </record>
-    <record id="product_template_20" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_20" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Naidu</field>
         <field name="default_code">ART-Anand Gadapa</field>
         <field name="list_price">0.0</field>
@@ -171,7 +171,7 @@
             Department:Modern &amp; Contemporary Art
         </field>
     </record>
-    <record id="product_template_21" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_21" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Radha and Krishna with Female Attendants and Musicians</field>
         <field name="list_price">0.0</field>
         <field name="is_storable">True</field>
@@ -192,7 +192,7 @@
             Department: Pre-Modern Art
         </field>
     </record>
-    <record id="product_template_22" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_22" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">3d Scenery Wall Painting - Set Of 5 Modern Art</field>
         <field name="list_price">50.0</field>
         <field name="is_storable">True</field>
@@ -215,7 +215,7 @@
             Country of Origin : India
         </field>
     </record>
-    <record id="product_template_23" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_23" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Stationerie Artists&#8217; Acrylic Painting Kit Combo</field>
         <field name="list_price">14.9</field>
         <field name="is_storable">True</field>
@@ -238,7 +238,7 @@
             9) Stationerie Palette Knife (Sizes May Differ)
         </field>
     </record>
-    <record id="product_template_24" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_24" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Mont Marte Acrylic Colour Paint Set Signature 36pc x 36ml (Set of 36, Multicolor)</field>
         <field name="list_price">27.0</field>
         <field name="is_storable">True</field>
@@ -255,23 +255,23 @@
             Set of 36
         </field>
     </record>
-    <record id="product_template_25" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_25" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Gold Membership - 10% off</field>
         <field name="list_price">0.0</field>
         <field name="type">service</field>
     </record>
-    <record id="product_template_26" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_26" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Silver Membership - 5% Off</field>
         <field name="list_price">0.0</field>
         <field name="type">service</field>
     </record>
-    <record id="product_template_6" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_6" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Gift Card</field>
         <field name="list_price">0.0</field>
         <field name="type">service</field>
         <field name="image_1920" type="base64" file="art_craft/static/src/binary/product_template/4-image_1920"/>
     </record>
-    <record id="product_template_8" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_8" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">3D Corrugated Nandi</field>
         <field name="list_price">100.0</field>
         <field name="is_storable">True</field>
@@ -288,7 +288,7 @@
         . Inspired by: Nandi sculpture (20th century)
         </field>
     </record>
-    <record id="product_template_9" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_9" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Aluminium - Mahatma Gandhi</field>
         <field name="default_code">SHI GDH</field>
         <field name="list_price">45.96</field>

--- a/art_craft/data/product_template_attribute_line.xml
+++ b/art_craft/data/product_template_attribute_line.xml
@@ -1,41 +1,41 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-    <record id="product_template_attribute_line_1" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_1" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_8" />
         <field name="attribute_id" ref="product_attribute_1" />
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_1'), ref('product_attribute_value_3')])]" />
     </record>
-    <record id="product_template_attribute_line_2" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_2" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_12" />
         <field name="attribute_id" ref="product_attribute_1" />
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_1'), ref('product_attribute_value_3')])]" />
     </record>
-    <record id="product_template_attribute_line_3" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_3" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_13" />
         <field name="attribute_id" ref="product_attribute_3" />
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_9'), ref('product_attribute_value_10')])]" />
     </record>
-    <record id="product_template_attribute_line_5" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_5" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_18" />
         <field name="attribute_id" ref="product_attribute_2" />
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_14')])]" />
     </record>
-    <record id="product_template_attribute_line_6" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_6" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_19" />
         <field name="attribute_id" ref="product_attribute_2" />
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_15'), ref('product_attribute_value_16')])]" />
     </record>
-    <record id="product_template_attribute_line_7" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_7" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_20" />
         <field name="attribute_id" ref="product_attribute_2" />
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_17')])]" />
     </record>
-    <record id="product_template_attribute_line_8" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_8" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_21" />
         <field name="attribute_id" ref="product_attribute_2" />
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_18')])]" />
     </record>
-    <record id="product_template_attribute_line_9" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_9" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_21" />
         <field name="attribute_id" ref="product_attribute_4" />
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_19')])]" />

--- a/automobile/data/product_template.xml
+++ b/automobile/data/product_template.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-    <record id="product_template_10" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_10" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Drum Brake</field>
         <field name="categ_id" ref="product_category_5"/>
         <field name="is_storable">True</field>
@@ -8,7 +8,7 @@
         <field name="image_1920" type="base64" file="automobile/static/src/binary/product_template/10-image_1920"/>
         <field name="available_in_pos" eval="True"/>
     </record>
-    <record id="product_template_11" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_11" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Rear Brake Pads</field>
         <field name="categ_id" ref="product_category_5"/>
         <field name="is_storable">True</field>
@@ -16,7 +16,7 @@
         <field name="image_1920" type="base64" file="automobile/static/src/binary/product_template/11-image_1920"/>
         <field name="available_in_pos" eval="True"/>
     </record>
-    <record id="product_template_12" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_12" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Filter</field>
         <field name="categ_id" ref="product_category_5"/>
         <field name="is_storable">True</field>
@@ -24,7 +24,7 @@
         <field name="image_1920" type="base64" file="automobile/static/src/binary/product_template/12-image_1920"/>
         <field name="available_in_pos" eval="True"/>
     </record>
-    <record id="product_template_13" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_13" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">AC Compressor</field>
         <field name="use_expiration_date" eval="True"/>
         <field name="tracking">serial</field>
@@ -37,14 +37,14 @@
         <field name="purchase_method">receive</field>
         <field name="categ_id" ref="product_category_6"/>
     </record>
-    <record id="product_template_8" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_8" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Gift Card</field>
         <field name="type">service</field>
         <field name="list_price" eval="False"/>
         <field name="sale_ok" eval="False"/>
         <field name="purchase_ok" eval="False"/>
     </record>
-    <record id="product_template_9" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_9" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Front Brake Pads</field>
         <field name="categ_id" ref="product_category_5"/>
         <field name="is_storable">True</field>

--- a/automobile/data/product_template_attribute_line.xml
+++ b/automobile/data/product_template_attribute_line.xml
@@ -1,11 +1,11 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-    <record id="product_template_attribute_line_1" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_1" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_12"/>
         <field name="attribute_id" ref="product_attribute_1"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_1'), ref('product_attribute_value_2'), ref('product_attribute_value_3'), ref('product_attribute_value_4'), ref('product_attribute_value_5')])]"/>
     </record>
-    <record id="product_template_attribute_line_2" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_2" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_12"/>
         <field name="attribute_id" ref="product_attribute_2"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_7'), ref('product_attribute_value_8')])]"/>

--- a/beverage_distributor/data/product_template.xml
+++ b/beverage_distributor/data/product_template.xml
@@ -78,7 +78,7 @@
         <field name="taxes_id" eval="[(6, 0, [ref('deposit_management.account_tax_24_sale')])]"/>
         <field name="supplier_taxes_id" eval="[(6, 0, [ref('deposit_management.account_tax_24_purchase')])]"/>
     </record>
-    <record id="product_template_27" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_27" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Fanta 24x33cl</field>
         <field name="categ_id" ref="product_category_12"/>
         <field name="list_price">38.0</field>
@@ -93,7 +93,7 @@
         <field name="public_categ_ids" eval="[(6, 0, [ref('product_public_category_1')])]"/>
         <field name="pos_categ_ids" eval="[(6, 0, [ref('pos_category_1')])]"/>
     </record>
-    <record id="product_template_28" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_28" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Ice Tea 24x33cl</field>
         <field name="categ_id" ref="product_category_12"/>
         <field name="list_price">38.0</field>
@@ -108,7 +108,7 @@
         <field name="public_categ_ids" eval="[(6, 0, [ref('product_public_category_1')])]"/>
         <field name="pos_categ_ids" eval="[(6, 0, [ref('pos_category_1')])]"/>
     </record>
-    <record id="product_template_29" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_29" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Schweppes 24x33cl</field>
         <field name="categ_id" ref="product_category_12"/>
         <field name="list_price">38.0</field>
@@ -123,7 +123,7 @@
         <field name="public_categ_ids" eval="[(6, 0, [ref('product_public_category_1')])]"/>
         <field name="pos_categ_ids" eval="[(6, 0, [ref('pos_category_1')])]"/>
     </record>
-    <record id="product_template_51" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_51" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Coca-cola 24x33cl</field>
         <field name="categ_id" ref="product_category_12"/>
         <field name="list_price">38.0</field>
@@ -236,7 +236,7 @@
         <field name="supplier_taxes_id" eval="[(6, 0, [ref('deposit_management.account_tax_21_purchase')])]"/>
         <field name="pos_categ_ids" eval="[(6, 0, [ref('pos_category_5')])]"/>
     </record>
-    <record id="product_template_60" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_60" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Mobius IPA 33cl</field>
         <field name="categ_id" ref="product_category_9"/>
         <field name="list_price">2.5</field>
@@ -256,7 +256,7 @@
         <field name="x_excise_quantity">0.003300</field>
         <field name="x_packaging_units">1</field>
     </record>
-    <record id="product_template_57" model="product.template"  context="{'create_product_product': False}">
+    <record id="product_template_57" model="product.template"  context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Spa Still 25cl</field>
         <field name="categ_id" ref="product_category_12"/>
         <field name="list_price">1.2</field>
@@ -272,7 +272,7 @@
         <field name="public_categ_ids" eval="[(6, 0, [ref('product_public_category_1')])]"/>
         <field name="pos_categ_ids" eval="[(6, 0, [ref('pos_category_7')])]"/>
     </record>
-    <record id="product_template_7" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_7" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Mobius Blanche 33cl</field>
         <field name="categ_id" ref="product_category_9"/>
         <field name="list_price">2.5</field>
@@ -292,7 +292,7 @@
         <field name="x_excise_quantity">0.003300</field>
         <field name="x_packaging_units">1</field>
     </record>
-    <record id="product_template_62" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_62" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Mobius Triple 33cl</field>
         <field name="categ_id" ref="product_category_9"/>
         <field name="list_price">2.5</field>
@@ -312,7 +312,7 @@
         <field name="x_excise_quantity">0.003300</field>
         <field name="x_packaging_units">1</field>
     </record>
-    <record id="product_template_64" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_64" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Lou Daro - Château de Gragnos 75cl</field>
         <field name="categ_id" ref="product_category_14"/>
         <field name="list_price">10.0</field>
@@ -326,13 +326,13 @@
         <field name="public_categ_ids" eval="[(6, 0, [ref('product_public_category_3')])]"/>
         <field name="pos_categ_ids" eval="[(6, 0, [ref('pos_category_8')])]"/>
     </record>
-    <record id="product_template_64" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_64" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="x_excise_category" ref="excise_management.x_excise_category_S101"/>
         <field name="x_excise_amount">0.64</field>
         <field name="x_excise_quantity">0.0075</field>
         <field name="x_packaging_units">1</field>
     </record>
-    <record id="product_template_66" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_66" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Rosé Cosmos - Château de Gragnos 75cl</field>
         <field name="categ_id" ref="product_category_14"/>
         <field name="list_price">10.0</field>
@@ -347,13 +347,13 @@
         <field name="public_categ_ids" eval="[(6, 0, [ref('product_public_category_3')])]"/>
         <field name="pos_categ_ids" eval="[(6, 0, [ref('pos_category_8')])]"/>
     </record>
-    <record id="product_template_66" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_66" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="x_excise_category" ref="excise_management.x_excise_category_S101"/>
         <field name="x_excise_amount">0.64</field>
         <field name="x_excise_quantity">0.0075</field>
         <field name="x_packaging_units">1</field>
     </record>
-    <record id="product_template_68" model="product.template" context="{'create_product_product': False}" >
+    <record id="product_template_68" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}" >
         <field name="name">Cava Brut Il Lusio - Josep Masachs 75cl</field>
         <field name="categ_id" ref="product_category_14"/>
         <field name="list_price">12.0</field>
@@ -368,13 +368,13 @@
         <field name="public_categ_ids" eval="[(6, 0, [ref('product_public_category_3')])]"/>
         <field name="pos_categ_ids" eval="[(6, 0, [ref('pos_category_8')])]"/>
     </record>
-    <record id="product_template_68" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_68" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="x_excise_category" ref="excise_management.x_excise_category_S135"/>
         <field name="x_excise_amount">2.0</field>
         <field name="x_excise_quantity">0.0075</field>
         <field name="x_packaging_units">1</field>
     </record>
-    <record id="product_template_70" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_70" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Cuvée Grillo - Villa Carumé 75cl</field>
         <field name="categ_id" ref="product_category_14"/>
         <field name="list_price">10.0</field>
@@ -389,13 +389,13 @@
         <field name="public_categ_ids" eval="[(6, 0, [ref('product_public_category_3')])]"/>
         <field name="pos_categ_ids" eval="[(6, 0, [ref('pos_category_8')])]"/>
     </record>
-    <record id="product_template_70" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_70" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="x_excise_category" ref="excise_management.x_excise_category_S101"/>
         <field name="x_excise_amount">0.64</field>
         <field name="x_excise_quantity">0.0075</field>
         <field name="x_packaging_units">1</field>
     </record>
-    <record id="product_template_71" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_71" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Jack Daniels 70cl</field>
         <field name="categ_id" ref="product_category_13"/>
         <field name="list_price">19.99</field>
@@ -409,7 +409,7 @@
         <field name="public_categ_ids" eval="[(6, 0, [ref('product_public_category_2')])]"/>
         <field name="pos_categ_ids" eval="[(6, 0, [ref('pos_category_3')])]"/>
     </record>
-    <record id="product_template_71" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_71" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="x_excise_category" ref="excise_management.x_excise_category_S201"/>
         <field name="x_excise_amount">0.59</field>
         <field name="x_excise_quantity">0.007</field>

--- a/beverage_distributor/data/product_template_attribute_line.xml
+++ b/beverage_distributor/data/product_template_attribute_line.xml
@@ -1,96 +1,96 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-    <record id="product_template_attribute_line_13" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_13" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="attribute_id" ref="product_attribute_13"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_15')])]"/>
         <field name="product_tmpl_id" ref="product_template_57"/>
     </record>
-    <record id="product_template_attribute_line_15" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_15" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="attribute_id" ref="product_attribute_13"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_16')])]"/>
         <field name="product_tmpl_id" ref="product_template_51"/>
     </record>
-    <record id="product_template_attribute_line_16" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_16" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="attribute_id" ref="product_attribute_11"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_8')])]"/>
         <field name="product_tmpl_id" ref="product_template_51"/>
     </record>
-    <record id="product_template_attribute_line_18" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_18" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="attribute_id" ref="product_attribute_11"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_7')])]"/>
         <field name="product_tmpl_id" ref="product_template_57"/>
     </record>
-    <record id="product_template_attribute_line_2" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_2" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="attribute_id" ref="product_attribute_10"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_1')])]"/>
         <field name="product_tmpl_id" ref="product_template_7"/>
     </record>
-    <record id="product_template_attribute_line_29" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_29" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="attribute_id" ref="product_attribute_10"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_2')])]"/>
         <field name="product_tmpl_id" ref="product_template_60"/>
     </record>
-    <record id="product_template_attribute_line_31" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_31" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="attribute_id" ref="product_attribute_13"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_15')])]"/>
         <field name="product_tmpl_id" ref="product_template_60"/>
     </record>
-    <record id="product_template_attribute_line_37" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_37" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="attribute_id" ref="product_attribute_10"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_3')])]"/>
         <field name="product_tmpl_id" ref="product_template_62"/>
     </record>
-    <record id="product_template_attribute_line_39" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_39" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="attribute_id" ref="product_attribute_13"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_15')])]"/>
         <field name="product_tmpl_id" ref="product_template_62"/>
     </record>
-    <record id="product_template_attribute_line_44" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_44" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="attribute_id" ref="product_attribute_12"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_10')])]"/>
         <field name="product_tmpl_id" ref="product_template_64"/>
     </record>
-    <record id="product_template_attribute_line_45" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_45" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="attribute_id" ref="product_attribute_13"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_16')])]"/>
         <field name="product_tmpl_id" ref="product_template_64"/>
     </record>
-    <record id="product_template_attribute_line_5" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_5" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="attribute_id" ref="product_attribute_13"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_15')])]"/>
         <field name="product_tmpl_id" ref="product_template_7"/>
     </record>
-    <record id="product_template_attribute_line_50" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_50" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="attribute_id" ref="product_attribute_12"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_11')])]"/>
         <field name="product_tmpl_id" ref="product_template_66"/>
     </record>
-    <record id="product_template_attribute_line_51" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_51" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="attribute_id" ref="product_attribute_13"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_16')])]"/>
         <field name="product_tmpl_id" ref="product_template_66"/>
     </record>
-    <record id="product_template_attribute_line_56" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_56" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="attribute_id" ref="product_attribute_12"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_22')])]"/>
         <field name="product_tmpl_id" ref="product_template_68"/>
     </record>
-    <record id="product_template_attribute_line_57" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_57" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="attribute_id" ref="product_attribute_13"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_16')])]"/>
         <field name="product_tmpl_id" ref="product_template_68"/>
     </record>
-    <record id="product_template_attribute_line_62" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_62" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="attribute_id" ref="product_attribute_12"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_9')])]"/>
         <field name="product_tmpl_id" ref="product_template_70"/>
     </record>
-    <record id="product_template_attribute_line_63" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_63" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="attribute_id" ref="product_attribute_13"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_16')])]"/>
         <field name="product_tmpl_id" ref="product_template_70"/>
     </record>
-    <record id="product_template_attribute_line_67" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_67" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="attribute_id" ref="product_attribute_13"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_16')])]"/>
         <field name="product_tmpl_id" ref="product_template_71"/>

--- a/beverage_distributor/data/product_template_package.xml
+++ b/beverage_distributor/data/product_template_package.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
     <odoo noupdate="1">
-    <record id="product_template_54" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_54" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Spa Still 24x25cl</field>
         <field name="categ_id" ref="product_category_12"/>
         <field name="list_price">28.0</field>
@@ -15,7 +15,7 @@
         <field name="public_categ_ids" eval="[(6, 0, [ref('product_public_category_1')])]"/>
         <field name="pos_categ_ids" eval="[(6, 0, [ref('pos_category_1')])]"/>
     </record>
-    <record id="product_template_attribute_line_17" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_17" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="attribute_id" ref="product_attribute_11"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_7')])]"/>
         <field name="product_tmpl_id" ref="product_template_54"/>
@@ -24,7 +24,7 @@
         <field name="attribute_line_id" ref="product_template_attribute_line_17"/>
         <field name="product_attribute_value_id" ref="product_attribute_value_7"/>
     </record>
-    <record id="product_template_attribute_line_10" model="product.template.attribute.line"  context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_10" model="product.template.attribute.line"  context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="attribute_id" ref="product_attribute_13"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_15')])]"/>
         <field name="product_tmpl_id" ref="product_template_54"/>
@@ -33,7 +33,7 @@
         <field name="attribute_line_id" ref="product_template_attribute_line_10"/>
         <field name="product_attribute_value_id" ref="product_attribute_value_15"/>
     </record>
-    <record id="product_template_attribute_line_8" model="product.template.attribute.line"  context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_8" model="product.template.attribute.line"  context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="attribute_id" ref="product_attribute_16"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_13')])]"/>
         <field name="product_tmpl_id" ref="product_template_54"/>
@@ -46,12 +46,12 @@
         <field name="product_tmpl_id" ref="product_template_54"/>
     </record>
     <!-- Done afterwards not to trigger the server action before the product exists -->
-    <record id="product_template_54" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_54" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="x_quantity_by_deposit_product">24</field>
         <field name="x_deposit_product" ref="product_template_deposit_crate_spa"/>
         <field name="x_unit_sale_product" ref="product_template_57"/>
     </record>
-    <record id="product_template_59" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_59" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Mobius IPA 24x33cl </field>
         <field name="categ_id" ref="product_category_9"/>
         <field name="list_price">48.0</field>
@@ -67,7 +67,7 @@
         <field name="public_categ_ids" eval="[(6, 0, [ref('product_public_category_4')])]"/>
         <field name="pos_categ_ids" eval="[(6, 0, [ref('pos_category_2')])]"/>
     </record>
-    <record id="product_template_attribute_line_25" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_25" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="attribute_id" ref="product_attribute_10"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_2')])]"/>
         <field name="product_tmpl_id" ref="product_template_59"/>
@@ -76,7 +76,7 @@
         <field name="attribute_line_id" ref="product_template_attribute_line_25"/>
         <field name="product_attribute_value_id" ref="product_attribute_value_2"/>
     </record>
-    <record id="product_template_attribute_line_26" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_26" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="attribute_id" ref="product_attribute_16"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_12')])]"/>
         <field name="product_tmpl_id" ref="product_template_59"/>
@@ -85,7 +85,7 @@
         <field name="attribute_line_id" ref="product_template_attribute_line_26"/>
         <field name="product_attribute_value_id" ref="product_attribute_value_12"/>
     </record>
-    <record id="product_template_attribute_line_27" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_27" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="attribute_id" ref="product_attribute_13"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_15')])]"/>
         <field name="product_tmpl_id" ref="product_template_59"/>
@@ -97,7 +97,7 @@
     <record id="product_product_36" model="product.product">
         <field name="product_tmpl_id" ref="product_template_59"/>
     </record>
-    <record id="product_template_attribute_line_28" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_28" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="attribute_id" ref="product_attribute_15"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_17')])]"/>
         <field name="product_tmpl_id" ref="product_template_59"/>
@@ -106,7 +106,7 @@
         <field name="attribute_line_id" ref="product_template_attribute_line_28"/>
         <field name="product_attribute_value_id" ref="product_attribute_value_17"/>
     </record>
-    <record id="product_template_59" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_59" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="x_deposit_product" ref="product_template_56"/>
         <field name="x_unit_sale_product" ref="product_template_60"/>
         <field name="x_quantity_by_deposit_product">24</field>
@@ -115,7 +115,7 @@
         <field name="x_excise_quantity">0.079200</field>
         <field name="x_packaging_units">24</field>
     </record>
-    <record id="product_template_6" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_6" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Mobius Blanche 24x33cl</field>
         <field name="categ_id" ref="product_category_9"/>
         <field name="list_price">48.0</field>
@@ -130,7 +130,7 @@
         <field name="public_categ_ids" eval="[(6, 0, [ref('product_public_category_4')])]"/>
         <field name="pos_categ_ids" eval="[(6, 0, [ref('pos_category_2')])]"/>
     </record>
-    <record id="product_template_attribute_line_7" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_7" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="attribute_id" ref="product_attribute_13"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_15')])]"/>
         <field name="product_tmpl_id" ref="product_template_6"/>
@@ -139,7 +139,7 @@
         <field name="attribute_line_id" ref="product_template_attribute_line_7"/>
         <field name="product_attribute_value_id" ref="product_attribute_value_15"/>
     </record>
-    <record id="product_template_attribute_line_6" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_6" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="attribute_id" ref="product_attribute_16"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_12')])]"/>
         <field name="product_tmpl_id" ref="product_template_6"/>
@@ -151,7 +151,7 @@
     <record id="product_product_6" model="product.product">
         <field name="product_tmpl_id" ref="product_template_6"/>
     </record>
-    <record id="product_template_attribute_line_1" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_1" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="attribute_id" ref="product_attribute_10"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_1')])]"/>
         <field name="product_tmpl_id" ref="product_template_6"/>
@@ -160,7 +160,7 @@
         <field name="attribute_line_id" ref="product_template_attribute_line_1"/>
         <field name="product_attribute_value_id" ref="product_attribute_value_1"/>
     </record>
-    <record id="product_template_attribute_line_19" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_19" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="attribute_id" ref="product_attribute_15"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_17')])]"/>
         <field name="product_tmpl_id" ref="product_template_6"/>
@@ -169,7 +169,7 @@
         <field name="attribute_line_id" ref="product_template_attribute_line_19"/>
         <field name="product_attribute_value_id" ref="product_attribute_value_17"/>
     </record>
-    <record id="product_template_6" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_6" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="x_quantity_by_deposit_product">24</field>
         <field name="x_deposit_product" ref="product_template_56"/>
         <field name="x_unit_sale_product" ref="product_template_7"/>
@@ -178,7 +178,7 @@
         <field name="x_excise_quantity">0.079200</field>
         <field name="x_packaging_units">24</field>
     </record>
-    <record id="product_template_61" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_61" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Mobius Triple 24x33cl</field>
         <field name="categ_id" ref="product_category_9"/>
         <field name="list_price">48.0</field>
@@ -193,7 +193,7 @@
         <field name="public_categ_ids" eval="[(6, 0, [ref('product_public_category_4')])]"/>
         <field name="pos_categ_ids" eval="[(6, 0, [ref('pos_category_2')])]"/>
     </record>
-    <record id="product_template_attribute_line_33" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_33" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="attribute_id" ref="product_attribute_10"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_3')])]"/>
         <field name="product_tmpl_id" ref="product_template_61"/>
@@ -202,7 +202,7 @@
         <field name="attribute_line_id" ref="product_template_attribute_line_33"/>
         <field name="product_attribute_value_id" ref="product_attribute_value_3"/>
     </record>
-    <record id="product_template_attribute_line_34" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_34" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="attribute_id" ref="product_attribute_16"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_12')])]"/>
         <field name="product_tmpl_id" ref="product_template_61"/>
@@ -211,7 +211,7 @@
         <field name="attribute_line_id" ref="product_template_attribute_line_34"/>
         <field name="product_attribute_value_id" ref="product_attribute_value_12"/>
     </record>
-    <record id="product_template_attribute_line_35" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_35" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="attribute_id" ref="product_attribute_13"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_15')])]"/>
         <field name="product_tmpl_id" ref="product_template_61"/>
@@ -223,7 +223,7 @@
     <record id="product_product_38" model="product.product">
         <field name="product_tmpl_id" ref="product_template_61"/>
     </record>
-    <record id="product_template_attribute_line_36" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_36" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="attribute_id" ref="product_attribute_15"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_17')])]"/>
         <field name="product_tmpl_id" ref="product_template_61"/>
@@ -232,7 +232,7 @@
         <field name="attribute_line_id" ref="product_template_attribute_line_36"/>
         <field name="product_attribute_value_id" ref="product_attribute_value_17"/>
     </record>
-    <record id="product_template_61" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_61" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="x_quantity_by_deposit_product">24</field>
         <field name="x_deposit_product" ref="product_template_56"/>
         <field name="x_unit_sale_product" ref="product_template_62"/>
@@ -241,7 +241,7 @@
         <field name="x_excise_quantity">0.079200</field>
         <field name="x_packaging_units">24</field>
     </record>
-    <record id="product_template_63" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_63" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Lou Daro - Château de Gragnos 6x75cl</field>
         <field name="categ_id" ref="product_category_14"/>
         <field name="list_price">55.0</field>
@@ -255,7 +255,7 @@
         <field name="public_categ_ids" eval="[(6, 0, [ref('product_public_category_3')])]"/>
         <field name="pos_categ_ids" eval="[(6, 0, [ref('pos_category_4')])]"/>
     </record>
-    <record id="product_template_attribute_line_41" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_41" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="attribute_id" ref="product_attribute_12"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_10')])]"/>
         <field name="product_tmpl_id" ref="product_template_63"/>
@@ -264,7 +264,7 @@
         <field name="attribute_line_id" ref="product_template_attribute_line_41"/>
         <field name="product_attribute_value_id" ref="product_attribute_value_10"/>
     </record>
-    <record id="product_template_attribute_line_42" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_42" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="attribute_id" ref="product_attribute_13"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_16')])]"/>
         <field name="product_tmpl_id" ref="product_template_63"/>
@@ -273,7 +273,7 @@
         <field name="attribute_line_id" ref="product_template_attribute_line_42"/>
         <field name="product_attribute_value_id" ref="product_attribute_value_16"/>
     </record>
-    <record id="product_template_attribute_line_43" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_43" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="attribute_id" ref="product_attribute_15"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_18')])]"/>
         <field name="product_tmpl_id" ref="product_template_63"/>
@@ -285,7 +285,7 @@
     <record id="product_product_40" model="product.product">
         <field name="product_tmpl_id" ref="product_template_63"/>
     </record>
-    <record id="product_template_63" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_63" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="x_quantity_by_deposit_product">6</field>
         <field name="x_unit_sale_product" ref="product_template_64"/>
         <field name="x_excise_category" ref="excise_management.x_excise_category_S101"/>
@@ -293,7 +293,7 @@
         <field name="x_excise_quantity">0.045</field>
         <field name="x_packaging_units">6</field>
     </record>
-    <record id="product_template_65" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_65" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Rosé Cosmos - Château de Gragnos 6x75cl</field>
         <field name="categ_id" ref="product_category_14"/>
         <field name="list_price">50.0</field>
@@ -307,7 +307,7 @@
         <field name="public_categ_ids" eval="[(6, 0, [ref('product_public_category_3')])]"/>
         <field name="pos_categ_ids" eval="[(6, 0, [ref('pos_category_4')])]"/>
     </record>
-    <record id="product_template_attribute_line_47" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_47" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="attribute_id" ref="product_attribute_12"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_11')])]"/>
         <field name="product_tmpl_id" ref="product_template_65"/>
@@ -316,7 +316,7 @@
         <field name="attribute_line_id" ref="product_template_attribute_line_47"/>
         <field name="product_attribute_value_id" ref="product_attribute_value_11"/>
     </record>
-    <record id="product_template_attribute_line_48" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_48" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="attribute_id" ref="product_attribute_13"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_16')])]"/>
         <field name="product_tmpl_id" ref="product_template_65"/>
@@ -325,7 +325,7 @@
         <field name="attribute_line_id" ref="product_template_attribute_line_48"/>
         <field name="product_attribute_value_id" ref="product_attribute_value_16"/>
     </record>
-    <record id="product_template_attribute_line_49" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_49" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="attribute_id" ref="product_attribute_15"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_18')])]"/>
         <field name="product_tmpl_id" ref="product_template_65"/>
@@ -337,7 +337,7 @@
     <record id="product_product_42" model="product.product">
         <field name="product_tmpl_id" ref="product_template_65"/>
     </record>
-    <record id="product_template_65" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_65" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="x_quantity_by_deposit_product">6</field>
         <field name="x_unit_sale_product" ref="product_template_66"/>
         <field name="x_excise_category" ref="excise_management.x_excise_category_S101"/>
@@ -345,7 +345,7 @@
         <field name="x_excise_quantity">0.045</field>
         <field name="x_packaging_units">6</field>
     </record>
-    <record id="product_template_67" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_67" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Cava Brut Il Lusio - Josep Masachs 6x75cl</field>
         <field name="categ_id" ref="product_category_14"/>
         <field name="list_price">60.0</field>
@@ -359,7 +359,7 @@
         <field name="public_categ_ids" eval="[(6, 0, [ref('product_public_category_3')])]"/>
         <field name="pos_categ_ids" eval="[(6, 0, [ref('pos_category_4')])]"/>
     </record>
-    <record id="product_template_attribute_line_53" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_53" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="attribute_id" ref="product_attribute_12"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_22')])]"/>
         <field name="product_tmpl_id" ref="product_template_67"/>
@@ -368,7 +368,7 @@
         <field name="attribute_line_id" ref="product_template_attribute_line_53"/>
         <field name="product_attribute_value_id" ref="product_attribute_value_22"/>
     </record>
-    <record id="product_template_attribute_line_54" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_54" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="attribute_id" ref="product_attribute_13"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_16')])]"/>
         <field name="product_tmpl_id" ref="product_template_67"/>
@@ -377,7 +377,7 @@
         <field name="attribute_line_id" ref="product_template_attribute_line_54"/>
         <field name="product_attribute_value_id" ref="product_attribute_value_16"/>
     </record>
-    <record id="product_template_attribute_line_55" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_55" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="attribute_id" ref="product_attribute_15"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_18')])]"/>
         <field name="product_tmpl_id" ref="product_template_67"/>
@@ -389,7 +389,7 @@
     <record id="product_product_44" model="product.product">
         <field name="product_tmpl_id" ref="product_template_67"/>
     </record>
-    <record id="product_template_67" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_67" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="x_quantity_by_deposit_product">6</field>
         <field name="x_unit_sale_product" ref="product_template_68"/>
         <field name="x_excise_category" ref="excise_management.x_excise_category_S135"/>
@@ -397,7 +397,7 @@
         <field name="x_excise_quantity">0.045</field>
         <field name="x_packaging_units">6</field>
     </record>
-    <record id="product_template_69" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_69" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Cuvée Grillo - Villa Carumé 6x75cl</field>
         <field name="categ_id" ref="product_category_14"/>
         <field name="list_price">55.0</field>
@@ -411,7 +411,7 @@
         <field name="public_categ_ids" eval="[(6, 0, [ref('product_public_category_3')])]"/>
         <field name="pos_categ_ids" eval="[(6, 0, [ref('pos_category_4')])]"/>
     </record>
-    <record id="product_template_attribute_line_59" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_59" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="attribute_id" ref="product_attribute_12"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_9')])]"/>
         <field name="product_tmpl_id" ref="product_template_69"/>
@@ -420,7 +420,7 @@
         <field name="attribute_line_id" ref="product_template_attribute_line_59"/>
         <field name="product_attribute_value_id" ref="product_attribute_value_9"/>
     </record>
-    <record id="product_template_attribute_line_60" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_60" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="attribute_id" ref="product_attribute_13"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_16')])]"/>
         <field name="product_tmpl_id" ref="product_template_69"/>
@@ -429,7 +429,7 @@
         <field name="attribute_line_id" ref="product_template_attribute_line_60"/>
         <field name="product_attribute_value_id" ref="product_attribute_value_16"/>
     </record>
-    <record id="product_template_attribute_line_61" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_61" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="attribute_id" ref="product_attribute_15"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_18')])]"/>
         <field name="product_tmpl_id" ref="product_template_69"/>
@@ -441,7 +441,7 @@
     <record id="product_product_46" model="product.product">
         <field name="product_tmpl_id" ref="product_template_69"/>
     </record>
-    <record id="product_template_69" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_69" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="x_quantity_by_deposit_product">6</field>
         <field name="x_unit_sale_product" ref="product_template_70"/>
         <field name="x_excise_category" ref="excise_management.x_excise_category_S101"/>

--- a/beverage_distributor/data/ptal.xml
+++ b/beverage_distributor/data/ptal.xml
@@ -1,76 +1,76 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-    <record id="product_template_attribute_line_71" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_71" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="attribute_id" ref="product_attribute_14"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_25')])]"/>
         <field name="product_tmpl_id" ref="product_template_60"/>
     </record>
-    <record id="product_template_attribute_line_40" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_40" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="attribute_id" ref="product_attribute_15"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_17')])]"/>
         <field name="product_tmpl_id" ref="product_template_62"/>
     </record>
-    <record id="product_template_attribute_line_32" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_32" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="attribute_id" ref="product_attribute_15"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_17')])]"/>
         <field name="product_tmpl_id" ref="product_template_60"/>
     </record>
-    <record id="product_template_attribute_line_20" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_20" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="attribute_id" ref="product_attribute_15"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_17')])]"/>
         <field name="product_tmpl_id" ref="product_template_7"/>
     </record>
-    <record id="product_template_attribute_line_46" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_46" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="attribute_id" ref="product_attribute_15"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_18')])]"/>
         <field name="product_tmpl_id" ref="product_template_64"/>
     </record>
-    <record id="product_template_attribute_line_66" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_66" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="attribute_id" ref="product_attribute_15"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_18')])]"/>
         <field name="product_tmpl_id" ref="product_template_71"/>
     </record>
-    <record id="product_template_attribute_line_64" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_64" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="attribute_id" ref="product_attribute_15"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_18')])]"/>
         <field name="product_tmpl_id" ref="product_template_70"/>
     </record>
-    <record id="product_template_attribute_line_58" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_58" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="attribute_id" ref="product_attribute_15"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_18')])]"/>
         <field name="product_tmpl_id" ref="product_template_68"/>
     </record>
-    <record id="product_template_attribute_line_52" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_52" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="attribute_id" ref="product_attribute_15"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_18')])]"/>
         <field name="product_tmpl_id" ref="product_template_66"/>
     </record>
-    <record id="product_template_attribute_line_38" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_38" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="attribute_id" ref="product_attribute_16"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_12')])]"/>
         <field name="product_tmpl_id" ref="product_template_62"/>
     </record>
-    <record id="product_template_attribute_line_30" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_30" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="attribute_id" ref="product_attribute_16"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_12')])]"/>
         <field name="product_tmpl_id" ref="product_template_60"/>
     </record>
-    <record id="product_template_attribute_line_11" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_11" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="attribute_id" ref="product_attribute_16"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_13')])]"/>
         <field name="product_tmpl_id" ref="product_template_57"/>
     </record>
-    <record id="product_template_attribute_line_14" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_14" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="attribute_id" ref="product_attribute_16"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_14')])]"/>
         <field name="product_tmpl_id" ref="product_template_51"/>
     </record>
-    <record id="product_template_attribute_line_4" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_4" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="attribute_id" ref="product_attribute_16"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_12')])]"/>
         <field name="product_tmpl_id" ref="product_template_7"/>
     </record>
-    <record id="product_template_attribute_line_65" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_65" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="attribute_id" ref="product_attribute_16"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_23')])]"/>
         <field name="product_tmpl_id" ref="product_template_71"/>

--- a/bike_leasing/data/product_template.xml
+++ b/bike_leasing/data/product_template.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-    <record id="product_template_10" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_10" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Assistance</field>
         <field name="image_1920" type="base64" file="bike_leasing/static/src/binary/product_template/10-image_1920"/>
         <field name="service_type">manual</field>
@@ -9,7 +9,7 @@
         <field name="purchase_method">purchase</field>
         <field name="description_sale">24/7 assistance: help@qfr-bike-leasing.odoo.com</field>
     </record>
-    <record id="product_template_7" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_7" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Bench</field>
         <field name="image_1920" type="base64" file="bike_leasing/static/src/binary/product_template/7-image_1920"/>
         <field name="service_type">manual</field>
@@ -17,7 +17,7 @@
         <field name="purchase_method">receive</field>
         <field name="list_price">480.0</field>
     </record>
-    <record id="product_template_9" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_9" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Front Basket</field>
         <field name="image_1920" type="base64" file="bike_leasing/static/src/binary/product_template/9-image_1920"/>
         <field name="service_type">manual</field>
@@ -25,14 +25,14 @@
         <field name="purchase_method">receive</field>
         <field name="list_price">125.0</field>
     </record>
-    <record id="product_template_8" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_8" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Rain Canopy</field>
         <field name="image_1920" type="base64" file="bike_leasing/static/src/binary/product_template/8-image_1920"/>
         <field name="service_type">manual</field>
         <field name="purchase_method">receive</field>
         <field name="list_price">360.0</field>
     </record>
-    <record id="product_template_6" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_6" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Bike 43</field>
         <field name="optional_product_ids" eval="[(6, 0, [ref('product_template_10'), ref('product_template_7'), ref('product_template_9'), ref('product_template_8')])]"/>
         <field name="image_1920" type="base64" file="bike_leasing/static/src/binary/product_template/6-image_1920"/>

--- a/bike_leasing/data/product_template_attribute_line.xml
+++ b/bike_leasing/data/product_template_attribute_line.xml
@@ -1,11 +1,11 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-    <record id="product_template_attribute_line_3" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_3" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_6"/>
         <field name="attribute_id" ref="product_attribute_1"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_2'), ref('product_attribute_value_3'), ref('product_attribute_value_4'), ref('product_attribute_value_1')])]"/>
     </record>
-    <record id="product_template_attribute_line_4" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_4" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_6"/>
         <field name="attribute_id" ref="product_attribute_2"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_5'), ref('product_attribute_value_6')])]"/>

--- a/bike_shop/data/product_template.xml
+++ b/bike_shop/data/product_template.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-    <record id="product_template_22" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_22" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="image_1920" type="base64" file="bike_shop/static/src/binary/product_template/22-image_1920" />
         <field name="name">Bike Chain – 11-Speed</field>
         <field name="description"><![CDATA[<div data-oe-version="1.2">Durable 11-speed chain with quick-link. Ideal for road and gravel bikes.</div>]]></field>
@@ -12,7 +12,7 @@
         <field name="invoice_policy">order</field>
         <field name="allow_out_of_stock_order" eval="False" />
     </record>
-    <record id="product_template_21" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_21" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="image_1920" type="base64" file="bike_shop/static/src/binary/product_template/21-image_1920" />
         <field name="name">Brake Pads – Shimano Resin</field>
         <field name="description"><![CDATA[<div data-oe-version="1.2">Compatible with most Shimano calipers. Quiet, effective stopping power.</div>]]></field>
@@ -25,7 +25,7 @@
         <field name="invoice_policy">order</field>
         <field name="allow_out_of_stock_order" eval="False" />
     </record>
-    <record id="product_template_24" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_24" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="image_1920" type="base64" file="bike_shop/static/src/binary/product_template/24-image_1920" />
         <field name="name">Inner Tube – 700x25 Presta Valve</field>
         <field name="description"><![CDATA[<div data-oe-version="1.2">Lightweight but durable inner tube for 700c road tires. 42mm Presta valve.</div>]]></field>
@@ -37,7 +37,7 @@
         <field name="invoice_policy">order</field>
         <field name="allow_out_of_stock_order" eval="False" />
     </record>
-    <record id="product_template_18" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_18" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="image_1920" type="base64" file="bike_shop/static/src/binary/product_template/18-image_1920" />
         <field name="name">Bike Maintenance – Non-Electric</field>
         <field name="description">
@@ -55,7 +55,7 @@
         <field name="project_id" ref="project_project_4" />
         <field name="worksheet_template_id" ref="worksheet_template" />
     </record>
-    <record id="product_template_16" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_16" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="image_1920" type="base64" file="bike_shop/static/src/binary/product_template/16-image_1920" />
         <field name="name">LED Light Set</field>
         <field name="list_price">12.0</field>
@@ -68,7 +68,7 @@
         <field name="public_categ_ids" eval="[(6, 0, [ref('product_public_category_5')])]" />
         <field name="allow_out_of_stock_order" eval="False" />
     </record>
-    <record id="product_template_15" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_15" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="image_1920" type="base64" file="bike_shop/static/src/binary/product_template/15-image_1920" />
         <field name="name">Pannier Bag 20L</field>
         <field name="list_price">30.0</field>
@@ -80,7 +80,7 @@
         <field name="public_categ_ids" eval="[(6, 0, [ref('product_public_category_5')])]" />
         <field name="allow_out_of_stock_order" eval="False" />
     </record>
-    <record id="product_template_17" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_17" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="image_1920" type="base64" file="bike_shop/static/src/binary/product_template/17-image_1920" />
         <field name="name">Quad Lock</field>
         <field name="list_price">65.0</field>
@@ -93,7 +93,7 @@
         <field name="public_categ_ids" eval="[(6, 0, [ref('product_public_category_5')])]" />
         <field name="allow_out_of_stock_order" eval="False" />
     </record>
-    <record id="product_template_11" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_11" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="image_1920" type="base64" file="bike_shop/static/src/binary/product_template/11-image_1920" />
         <field name="name">Brompton C Line Explore</field>
         <field name="description"><![CDATA[<div data-oe-version="1.2">CEXP-6S</div>]]></field>
@@ -114,7 +114,7 @@
             availability.</em></em></em></em></em></em></em></em></em></em><br></div>]]>
         </field>
     </record>
-    <record id="product_template_13" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_13" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="image_1920" type="base64" file="bike_shop/static/src/binary/product_template/13-image_1920" />
         <field name="name">Canyon Neuron AL 6</field>
         <field name="description"><![CDATA[<div data-oe-version="1.2">NAL6-29</div>]]></field>
@@ -137,7 +137,7 @@
             availability.</em></em></em></em></em></em></em></em></em></em></em></em></em></em></em></em></em></em></em></em><br></div>]]>
         </field>
     </record>
-    <record id="product_template_10" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_10" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="image_1920" type="base64" file="bike_shop/static/src/binary/product_template/10-image_1920" />
         <field name="name">Canyon Roadlite 7 </field>
         <field name="description"><![CDATA[<div data-oe-version="1.2">RL7-2023</div>]]></field>
@@ -156,7 +156,7 @@
             <![CDATA[<div data-oe-version="1.2"><em><em><em><em><em><em><em><em>This product is currently out of stock. Please check back soon or contact us for availability.</em></em></em></em></em></em></em></em></div>]]>
         </field>
     </record>
-    <record id="product_template_20" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_20" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="image_1920" type="base64" file="bike_shop/static/src/binary/product_template/20-image_1920" />
         <field name="name">Cargo or Speed Pedelec Maintenance</field>
         <field name="description">
@@ -176,7 +176,7 @@
         <field name="worksheet_template_id" ref="worksheet_template" />
         <field name="is_published" eval="False" />
     </record>
-    <record id="product_template_12" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_12" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="image_1920" type="base64" file="bike_shop/static/src/binary/product_template/12-image_1920" />
         <field name="name">Cube Kathmandu Hybrid</field>
         <field name="description"><![CDATA[<div data-oe-version="1.2">KH-500-E</div>]]></field>
@@ -197,7 +197,7 @@
             availability.</em></em></em></em></em></em></em></em></em></em><br></div>]]>
         </field>
     </record>
-    <record id="product_template_9" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_9" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="image_1920" type="base64" file="bike_shop/static/src/binary/product_template/9-image_1920" />
         <field name="name">Cube Reaction Pro </field>
         <field name="description"><![CDATA[<div data-oe-version="1.2">CRP-2023</div>]]></field>
@@ -215,7 +215,7 @@
         <field name="allow_out_of_stock_order" eval="False" />
         <field name="out_of_stock_message"><![CDATA[<div data-oe-version="1.2"><em><em>This product is currently out of stock. Please check back soon or contact us for availability.</em></em></div>]]></field>
     </record>
-    <record id="product_template_19" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_19" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="image_1920" type="base64" file="bike_shop/static/src/binary/product_template/19-image_1920" />
         <field name="name">E-Bike / Brompton Maintenance </field>
         <field name="description">
@@ -235,7 +235,7 @@
         <field name="worksheet_template_id" ref="worksheet_template" />
         <field name="is_published" eval="False" />
     </record>
-    <record id="product_template_25" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_25" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="image_1920" type="base64" file="bike_shop/static/src/binary/product_template/25-image_1920" />
         <field name="name">E-Bike Battery Diagnostic + Firmware Update </field>
         <field name="description">
@@ -249,7 +249,7 @@
         <field name="service_type">timesheet</field>
         <field name="invoice_policy">order</field>
     </record>
-    <record id="product_template_27" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_27" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="image_1920" type="base64" file="bike_shop/static/src/binary/product_template/27-image_1920" />
         <field name="name">Specific Reparation</field>
         <field name="type">service</field>
@@ -262,7 +262,7 @@
         <field name="project_id" ref="project_project_4" />
         <field name="worksheet_template_id" ref="worksheet_template" />
     </record>
-    <record id="product_template_26" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_26" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="image_1920" type="base64" file="bike_shop/static/src/binary/product_template/26-image_1920" />
         <field name="name">Tern GSD S10 LX</field>
         <field name="description"><![CDATA[<div data-oe-version="1.2">GSD S10 LX</div>]]></field>

--- a/bike_shop/data/product_template_attribute_line.xml
+++ b/bike_shop/data/product_template_attribute_line.xml
@@ -1,26 +1,26 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-    <record id="product_template_attribute_line_3" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_3" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_11" />
         <field name="attribute_id" ref="product_barcodelookup.product_attribute_lookup_1" />
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_4'), ref('product_attribute_value_5'), ref('product_attribute_value_6')])]" />
     </record>
-    <record id="product_template_attribute_line_5" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_5" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_13" />
         <field name="attribute_id" ref="product_barcodelookup.product_attribute_lookup_1" />
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_7'), ref('product_attribute_value_8')])]" />
     </record>
-    <record id="product_template_attribute_line_8" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_8" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_26" />
         <field name="attribute_id" ref="product_barcodelookup.product_attribute_lookup_1" />
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_14'), ref('product_attribute_value_15')])]" />
     </record>
-    <record id="product_template_attribute_line_4" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_4" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_10" />
         <field name="attribute_id" ref="product_barcodelookup.product_attribute_lookup_7" />
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_1'), ref('product_attribute_value_2'), ref('product_attribute_value_3')])]" />
     </record>
-    <record id="product_template_attribute_line_6" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_6" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_17" />
         <field name="attribute_id" ref="product_attribute_10" />
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_9'), ref('product_attribute_value_10'), ref('product_attribute_value_11'), ref('product_attribute_value_12'), ref('product_attribute_value_13')])]" />

--- a/cake_shop/data/product_template.xml
+++ b/cake_shop/data/product_template.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-    <record id="product_template_39" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_39" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="image_1920" type="base64" file="cake_shop/static/src/binary/product_template/39-image_1920"/>
         <field name="name">Birthday Cake</field>
         <field name="list_price">15.0</field>

--- a/cake_shop/data/product_template_attribute_line.xml
+++ b/cake_shop/data/product_template_attribute_line.xml
@@ -1,17 +1,17 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-  <record id="product_template_attribute_line_1" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_1" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_39"/>
     <field name="attribute_id" ref="product_barcodelookup.product_attribute_lookup_7"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_1'), ref('product_attribute_value_2'), ref('product_attribute_value_3')])]"/>
   </record>
-  <record id="product_template_attribute_line_3" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_3" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_39"/>
     <field name="sequence">11</field>
     <field name="attribute_id" ref="product_attribute_10"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_4'), ref('product_attribute_value_5'), ref('product_attribute_value_6')])]"/>
   </record>
-  <record id="product_template_attribute_line_10" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_10" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_39"/>
     <field name="sequence">12</field>
     <field name="attribute_id" ref="product_attribute_14"/>

--- a/campsite/data/product_template.xml
+++ b/campsite/data/product_template.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-  <record id="product_template_9" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_9" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="image_1920" type="base64" file="campsite/static/src/binary/product_template/9-image_1920"/>
     <field name="name">Fan</field>
     <field name="sale_ok" eval="False"/>
@@ -9,7 +9,7 @@
     <field name="invoice_policy">order</field>
     <field name="rent_ok" eval="True"/>
   </record>
-  <record id="product_template_10" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_10" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="image_1920" type="base64" file="campsite/static/src/binary/product_template/10-image_1920"/>
     <field name="name">Free Cancellation</field>
     <field name="type">service</field>
@@ -18,7 +18,7 @@
     <field name="service_type">manual</field>
     <field name="invoice_policy">order</field>
   </record>
-  <record id="product_template_8" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_8" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="image_1920" type="base64" file="campsite/static/src/binary/product_template/8-image_1920"/>
     <field name="name">Plancha</field>
     <field name="sale_ok" eval="False"/>
@@ -27,7 +27,7 @@
     <field name="invoice_policy">order</field>
     <field name="rent_ok" eval="True"/>
   </record>
-  <record id="product_template_7" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_7" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="image_1920" type="base64" file="campsite/static/src/binary/product_template/7-image_1920"/>
     <field name="name">Large Bungalow (up to 6 pers.)</field>
     <field name="type">service</field>
@@ -45,7 +45,7 @@
     <field name="x_has_city_tax" eval="True"/> 
     <field name="x_offer_type">STD</field>
   </record>
-  <record id="product_template_4" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_4" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="image_1920" type="base64" file="campsite/static/src/binary/product_template/4-image_1920"/>
     <field name="name">Large Pitch</field>
     <field name="type">service</field>
@@ -63,7 +63,7 @@
     <field name="x_has_city_tax" eval="True"/> 
     <field name="x_offer_type">STD</field>
   </record>
-  <record id="product_template_6" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_6" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="image_1920" type="base64" file="campsite/static/src/binary/product_template/6-image_1920"/>
     <field name="name">Small Bungalow (up to 4 pers.)</field>
     <field name="type">service</field>
@@ -81,7 +81,7 @@
     <field name="x_has_city_tax" eval="True"/> 
     <field name="x_offer_type">STD</field>
   </record>
-  <record id="product_template_3" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_3" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="image_1920" type="base64" file="campsite/static/src/binary/product_template/3-image_1920"/>
     <field name="name">Small Pitch</field>
     <field name="type">service</field>
@@ -99,7 +99,7 @@
     <field name="x_has_city_tax" eval="True"/> 
     <field name="x_offer_type">STD</field>
   </record>
-  <record id="product_template_5" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_5" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="image_1920" type="base64" file="campsite/static/src/binary/product_template/5-image_1920"/>
     <field name="name">Tentalo</field>
     <field name="type">service</field>

--- a/campsite/data/product_template_attribute_line.xml
+++ b/campsite/data/product_template_attribute_line.xml
@@ -1,26 +1,26 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-  <record id="product_template_attribute_line_3" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_3" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_4"/>
     <field name="attribute_id" ref="booking_engine.product_attribute_22"/>
     <field name="value_ids" eval="[(6, 0, [ref('booking_engine.product_attribute_guest1'), ref('booking_engine.product_attribute_guest2'), ref('booking_engine.product_attribute_guest3'), ref('booking_engine.product_attribute_guest4'), ref('booking_engine.product_attribute_guest1_1'), ref('booking_engine.product_attribute_guest2_1'), ref('booking_engine.product_attribute_guest2_2')])]"/>
   </record>
-  <record id="product_template_attribute_line_4" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_4" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_3"/>
     <field name="attribute_id" ref="booking_engine.product_attribute_22"/>
     <field name="value_ids" eval="[(6, 0, [ref('booking_engine.product_attribute_guest1'), ref('booking_engine.product_attribute_guest2'), ref('booking_engine.product_attribute_guest3'), ref('booking_engine.product_attribute_guest4'), ref('booking_engine.product_attribute_guest1_1'), ref('booking_engine.product_attribute_guest2_1'), ref('booking_engine.product_attribute_guest2_2')])]"/>
   </record>
-  <record id="product_template_attribute_line_5" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_5" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_5"/>
     <field name="attribute_id" ref="booking_engine.product_attribute_22"/>
     <field name="value_ids" eval="[(6, 0, [ref('booking_engine.product_attribute_guest1'), ref('booking_engine.product_attribute_guest2'), ref('booking_engine.product_attribute_guest1_1')])]"/>
   </record>
-  <record id="product_template_attribute_line_1" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_1" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_7"/>
     <field name="attribute_id" ref="booking_engine.product_attribute_11"/>
     <field name="value_ids" eval="[(6, 0, [ref('booking_engine.product_attribute_value_3')])]"/>
   </record>
-  <record id="product_template_attribute_line_2" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_2" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_6"/>
     <field name="attribute_id" ref="booking_engine.product_attribute_11"/>
     <field name="value_ids" eval="[(6, 0, [ref('booking_engine.product_attribute_value_3')])]"/>

--- a/candy_shop/data/product_template.xml
+++ b/candy_shop/data/product_template.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-  <record id="product_template_1" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_1" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="name">Caramel Fudge Bites</field>
     <field name="image_1920" type="base64" file="candy_shop/static/src/binary/product_template/59-image_1920.jpeg"/>
     <field name="description"><![CDATA[<p>A delicious candy treat. Perfect for any occasion!</p>]]></field>
@@ -20,7 +20,7 @@
     <field name="public_categ_ids" eval="[(6, 0, [ref('product_public_category_4')])]"/>
     <field name="allow_out_of_stock_order" eval="False"/>
   </record>
-  <record id="product_template_2" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_2" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="name">Cheddar Popcorn</field>
     <field name="image_1920" type="base64" file="candy_shop/static/src/binary/product_template/60-image_1920.jpeg"/>
     <field name="description"><![CDATA[<p>A delicious snacks treat. Perfect for any occasion!</p>]]></field>
@@ -39,7 +39,7 @@
     <field name="public_categ_ids" eval="[(6, 0, [ref('product_public_category_3')])]"/>
     <field name="allow_out_of_stock_order" eval="False"/>
   </record>
-  <record id="product_template_3" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_3" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="name">Cola 300ml</field>
     <field name="image_1920" type="base64" file="candy_shop/static/src/binary/product_template/49-image_1920.jpeg"/>
     <field name="description"><![CDATA[<p>A delicious drinks treat. Perfect for any occasion!</p>]]></field>
@@ -56,7 +56,7 @@
     <field name="public_categ_ids" eval="[(6, 0, [ref('product_public_category_1')])]"/>
     <field name="allow_out_of_stock_order" eval="False"/>
   </record>
-  <record id="product_template_4" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_4" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="name">Crispy Pretzel Sticks</field>
     <field name="image_1920" type="base64" file="candy_shop/static/src/binary/product_template/50-image_1920.jpeg"/>
     <field name="description"><![CDATA[<p>A delicious snacks treat. Perfect for any occasion!</p>]]></field>
@@ -75,7 +75,7 @@
     <field name="public_categ_ids" eval="[(6, 0, [ref('product_public_category_3')])]"/>
     <field name="allow_out_of_stock_order" eval="False"/>
   </record>
-  <record id="product_template_5" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_5" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="name">Dark Chocolate Truffles</field>
     <field name="image_1920" type="base64" file="candy_shop/static/src/binary/product_template/66-image_1920.jpeg"/>
     <field name="description"><![CDATA[<p>A delicious candy treat. Perfect for any occasion!</p>]]></field>
@@ -93,7 +93,7 @@
     <field name="description_ecommerce"><![CDATA[Our Dark Chocolate Truffles is a must-try! Enjoy a burst of flavor with every bite or sip.]]></field>
     <field name="allow_out_of_stock_order" eval="False"/>
   </record>
-  <record id="product_template_6" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_6" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="name">Grape Soda 355ml</field>
     <field name="image_1920" type="base64" file="candy_shop/static/src/binary/product_template/54-image_1920.jpeg"/>
     <field name="description"><![CDATA[<p>A delicious drinks treat. Perfect for any occasion!</p>]]></field>
@@ -111,7 +111,7 @@
     <field name="public_categ_ids" eval="[(6, 0, [ref('product_public_category_1')])]"/>
     <field name="allow_out_of_stock_order" eval="False"/>
   </record>
-  <record id="product_template_7" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_7" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="name">Gummy Bears</field>
     <field name="image_1920" type="base64" file="candy_shop/static/src/binary/product_template/58-image_1920.jpeg"/>
     <field name="description"><![CDATA[<p>A delicious candy treat. Perfect for any occasion!</p>]]></field>
@@ -129,7 +129,7 @@
     <field name="public_categ_ids" eval="[(6, 0, [ref('product_public_category_4')])]"/>
     <field name="allow_out_of_stock_order" eval="False"/>
   </record>
-  <record id="product_template_8" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_8" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="name">Honey Roasted Nuts</field>
     <field name="image_1920" type="base64" file="candy_shop/static/src/binary/product_template/63-image_1920.jpeg"/>
     <field name="description"><![CDATA[<p>A delicious snacks treat. Perfect for any occasion!</p>]]></field>
@@ -148,7 +148,7 @@
     <field name="public_categ_ids" eval="[(6, 0, [ref('product_public_category_3'), ref('product_public_category_4')])]"/>
     <field name="allow_out_of_stock_order" eval="False"/>
   </record>
-  <record id="product_template_9" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_9" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="name">Iced Coffee 250ml</field>
     <field name="image_1920" type="base64" file="candy_shop/static/src/binary/product_template/62-image_1920.jpeg"/>
     <field name="description"><![CDATA[<p>A delicious drinks treat. Perfect for any occasion!</p>]]></field>
@@ -166,7 +166,7 @@
     <field name="public_categ_ids" eval="[(6, 0, [ref('product_public_category_1')])]"/>
     <field name="allow_out_of_stock_order" eval="False"/>
   </record>
-  <record id="product_template_10" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_10" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="name">Mango Smoothie 400ml</field>
     <field name="image_1920" type="base64" file="candy_shop/static/src/binary/product_template/57-image_1920.jpeg"/>
     <field name="description"><![CDATA[<p>A delicious drinks treat. Perfect for any occasion!</p>]]></field>
@@ -184,7 +184,7 @@
     <field name="public_categ_ids" eval="[(6, 0, [ref('product_public_category_1')])]"/>
     <field name="allow_out_of_stock_order" eval="False"/>
   </record>
-  <record id="product_template_11" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_11" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="name">Matcha Green Tea 500ml</field>
     <field name="image_1920" type="base64" file="candy_shop/static/src/binary/product_template/51-image_1920.jpeg"/>
     <field name="description"><![CDATA[<p>A delicious drinks treat. Perfect for any occasion!</p>]]></field>
@@ -202,7 +202,7 @@
     <field name="public_categ_ids" eval="[(6, 0, [ref('product_public_category_1')])]"/>
     <field name="allow_out_of_stock_order" eval="False"/>
   </record>
-  <record id="product_template_12" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_12" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="name">Milk Chocolate Bar</field>
     <field name="image_1920" type="base64" file="candy_shop/static/src/binary/product_template/47-image_1920.jpeg"/>
     <field name="description"><![CDATA[<p>A delicious candy treat. Perfect for any occasion!</p>]]></field>
@@ -221,7 +221,7 @@
     <field name="public_categ_ids" eval="[(6, 0, [ref('product_public_category_4')])]"/>
     <field name="allow_out_of_stock_order" eval="False"/>
   </record>
-  <record id="product_template_13" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_13" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="name">Mint Chocolate Squares</field>
     <field name="image_1920" type="base64" file="candy_shop/static/src/binary/product_template/48-image_1920.jpeg"/>
     <field name="description"><![CDATA[<p>A delicious candy treat. Perfect for any occasion!</p>]]></field>
@@ -240,7 +240,7 @@
     <field name="public_categ_ids" eval="[(6, 0, [ref('product_public_category_4')])]"/>
     <field name="allow_out_of_stock_order" eval="False"/>
   </record>
-  <record id="product_template_14" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_14" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="name">Peanut Butter Cookies</field>
     <field name="image_1920" type="base64" file="candy_shop/static/src/binary/product_template/53-image_1920.jpeg"/>
     <field name="description"><![CDATA[<p>A delicious snacks treat. Perfect for any occasion!</p>]]></field>
@@ -259,7 +259,7 @@
     <field name="public_categ_ids" eval="[(6, 0, [ref('product_public_category_4')])]"/>
     <field name="allow_out_of_stock_order" eval="False"/>
   </record>
-  <record id="product_template_15" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_15" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="name">Seaweed Rice Crackers</field>
     <field name="image_1920" type="base64" file="candy_shop/static/src/binary/product_template/64-image_1920.jpeg"/>
     <field name="description"><![CDATA[<p>A delicious snacks treat. Perfect for any occasion!</p>]]></field>
@@ -278,7 +278,7 @@
     <field name="public_categ_ids" eval="[(6, 0, [ref('product_public_category_3')])]"/>
     <field name="allow_out_of_stock_order" eval="False"/>
   </record>
-  <record id="product_template_67" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_67" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="name">Self-Service Candy</field>
     <field name="list_price">0.04</field>
     <field name="pos_categ_ids" eval="[(6, 0, [ref('pos_category_5')])]"/>
@@ -287,7 +287,7 @@
     <field name="service_type">manual</field>
     <field name="invoice_policy">order</field>
   </record>
-  <record id="product_template_16" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_16" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="name">Sour Apple Chews</field>
     <field name="image_1920" type="base64" file="candy_shop/static/src/binary/product_template/61-image_1920.jpeg"/>
     <field name="description"><![CDATA[<p>A delicious candy treat. Perfect for any occasion!</p>]]></field>
@@ -306,7 +306,7 @@
     <field name="public_categ_ids" eval="[(6, 0, [ref('product_public_category_4')])]"/>
     <field name="allow_out_of_stock_order" eval="False"/>
   </record>
-  <record id="product_template_17" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_17" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="name">Sparkling Lemonade 330ml</field>
     <field name="image_1920" type="base64" file="candy_shop/static/src/binary/product_template/56-image_1920.jpeg"/>
     <field name="description"><![CDATA[<p>A delicious drinks treat. Perfect for any occasion!</p>]]></field>
@@ -324,7 +324,7 @@
     <field name="public_categ_ids" eval="[(6, 0, [ref('product_public_category_1')])]"/>
     <field name="allow_out_of_stock_order" eval="False"/>
   </record>
-  <record id="product_template_18" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_18" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="name">Spicy Cheese Puffs</field>
     <field name="image_1920" type="base64" file="candy_shop/static/src/binary/product_template/55-image_1920.jpeg"/>
     <field name="description"><![CDATA[<p>A delicious snacks treat. Perfect for any occasion!</p>]]></field>
@@ -343,7 +343,7 @@
     <field name="public_categ_ids" eval="[(6, 0, [ref('product_public_category_3')])]"/>
     <field name="allow_out_of_stock_order" eval="False"/>
   </record>
-  <record id="product_template_19" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_19" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="name">Strawberry Jelly Cubes</field>
     <field name="image_1920" type="base64" file="candy_shop/static/src/binary/product_template/52-image_1920.jpeg"/>
     <field name="description"><![CDATA[<p>A delicious candy treat. Perfect for any occasion!</p>]]></field>
@@ -362,7 +362,7 @@
     <field name="public_categ_ids" eval="[(6, 0, [ref('product_public_category_4')])]"/>
     <field name="allow_out_of_stock_order" eval="False"/>
   </record>
-  <record id="product_template_20" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_20" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="name">Wasabi Peas</field>
     <field name="image_1920" type="base64" file="candy_shop/static/src/binary/product_template/65-image_1920.jpeg"/>
     <field name="description"><![CDATA[<p>A delicious snacks treat. Perfect for any occasion!</p>]]></field>

--- a/candy_shop/data/product_template_attribute_line.xml
+++ b/candy_shop/data/product_template_attribute_line.xml
@@ -1,206 +1,206 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo auto_sequence="1" noupdate="1">
-  <record id="product_template_attribute_line_11" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_11" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_9"/>
     <field name="attribute_id" ref="website_sale.product_attribute_brand"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_8')])]"/>
   </record>
-  <record id="product_template_attribute_line_25" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_25" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_11"/>
     <field name="attribute_id" ref="website_sale.product_attribute_brand"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_8')])]"/>
   </record>
-  <record id="product_template_attribute_line_27" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_27" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_12"/>
     <field name="attribute_id" ref="website_sale.product_attribute_brand"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_4')])]"/>
   </record>
-  <record id="product_template_attribute_line_29" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_29" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_13"/>
     <field name="attribute_id" ref="website_sale.product_attribute_brand"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_4')])]"/>
   </record>
-  <record id="product_template_attribute_line_33" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_33" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_15"/>
     <field name="attribute_id" ref="website_sale.product_attribute_brand"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_5')])]"/>
   </record>
-  <record id="product_template_attribute_line_35" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_35" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_16"/>
     <field name="attribute_id" ref="website_sale.product_attribute_brand"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_4')])]"/>
   </record>
-  <record id="product_template_attribute_line_37" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_37" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_17"/>
     <field name="attribute_id" ref="website_sale.product_attribute_brand"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_8')])]"/>
   </record>
-  <record id="product_template_attribute_line_39" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_39" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_18"/>
     <field name="attribute_id" ref="website_sale.product_attribute_brand"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_5')])]"/>
   </record>
-  <record id="product_template_attribute_line_41" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_41" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_19"/>
     <field name="attribute_id" ref="website_sale.product_attribute_brand"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_4')])]"/>
   </record>
-  <record id="product_template_attribute_line_1" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_1" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_1"/>
     <field name="attribute_id" ref="product_attribute_10"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_1')])]"/>
   </record>
-  <record id="product_template_attribute_line_2" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_2" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_2"/>
     <field name="attribute_id" ref="product_attribute_10"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_3')])]"/>
   </record>
-  <record id="product_template_attribute_line_3" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_3" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_3"/>
     <field name="attribute_id" ref="product_attribute_10"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_2')])]"/>
   </record>
-  <record id="product_template_attribute_line_4" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_4" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_4"/>
     <field name="attribute_id" ref="product_attribute_10"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_2')])]"/>
   </record>
-  <record id="product_template_attribute_line_5" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_5" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_5"/>
     <field name="attribute_id" ref="product_attribute_10"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_1')])]"/>
   </record>
-  <record id="product_template_attribute_line_7" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_7" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_6"/>
     <field name="attribute_id" ref="product_attribute_10"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_3')])]"/>
   </record>
-  <record id="product_template_attribute_line_8" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_8" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_10"/>
     <field name="attribute_id" ref="product_attribute_10"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_3')])]"/>
   </record>
-  <record id="product_template_attribute_line_19" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_19" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_7"/>
     <field name="attribute_id" ref="product_attribute_10"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_1')])]"/>
   </record>
-  <record id="product_template_attribute_line_21" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_21" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_8"/>
     <field name="attribute_id" ref="product_attribute_10"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_3')])]"/>
   </record>
-  <record id="product_template_attribute_line_31" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_31" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_14"/>
     <field name="attribute_id" ref="product_attribute_10"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_1')])]"/>
   </record>
-  <record id="product_template_attribute_line_43" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_43" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_20"/>
     <field name="attribute_id" ref="product_attribute_10"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_2')])]"/>
   </record>
-  <record id="product_template_attribute_line_10" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_10" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_2"/>
     <field name="attribute_id" ref="website_sale.product_attribute_brand"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_5')])]"/>
   </record>
-  <record id="product_template_attribute_line_12" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_12" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_6"/>
     <field name="attribute_id" ref="website_sale.product_attribute_brand"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_8')])]"/>
   </record>
-  <record id="product_template_attribute_line_15" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_15" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_1"/>
     <field name="attribute_id" ref="website_sale.product_attribute_brand"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_4')])]"/>
   </record>
-  <record id="product_template_attribute_line_16" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_16" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_3"/>
     <field name="attribute_id" ref="website_sale.product_attribute_brand"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_8')])]"/>
   </record>
-  <record id="product_template_attribute_line_17" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_17" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_4"/>
     <field name="attribute_id" ref="website_sale.product_attribute_brand"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_5')])]"/>
   </record>
-  <record id="product_template_attribute_line_18" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_18" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_5"/>
     <field name="attribute_id" ref="website_sale.product_attribute_brand"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_4')])]"/>
   </record>
-  <record id="product_template_attribute_line_20" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_20" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_7"/>
     <field name="attribute_id" ref="website_sale.product_attribute_brand"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_4')])]"/>
   </record>
-  <record id="product_template_attribute_line_22" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_22" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_8"/>
     <field name="attribute_id" ref="website_sale.product_attribute_brand"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_4')])]"/>
   </record>
-  <record id="product_template_attribute_line_24" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_24" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_10"/>
     <field name="attribute_id" ref="website_sale.product_attribute_brand"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_8')])]"/>
   </record>
-  <record id="product_template_attribute_line_32" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_32" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_14"/>
     <field name="attribute_id" ref="website_sale.product_attribute_brand"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_4')])]"/>
   </record>
-  <record id="product_template_attribute_line_44" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_44" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_20"/>
     <field name="attribute_id" ref="website_sale.product_attribute_brand"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_5')])]"/>
   </record>
-  <record id="product_template_attribute_line_23" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_23" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_9"/>
     <field name="attribute_id" ref="product_attribute_10"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_3')])]"/>
   </record>
-  <record id="product_template_attribute_line_26" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_26" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_11"/>
     <field name="attribute_id" ref="product_attribute_10"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_2')])]"/>
   </record>
-  <record id="product_template_attribute_line_28" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_28" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_12"/>
     <field name="attribute_id" ref="product_attribute_10"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_3')])]"/>
   </record>
-  <record id="product_template_attribute_line_30" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_30" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_13"/>
     <field name="attribute_id" ref="product_attribute_10"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_3')])]"/>
   </record>
-  <record id="product_template_attribute_line_34" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_34" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_15"/>
     <field name="attribute_id" ref="product_attribute_10"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_3')])]"/>
   </record>
-  <record id="product_template_attribute_line_36" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_36" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_16"/>
     <field name="attribute_id" ref="product_attribute_10"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_3')])]"/>
   </record>
-  <record id="product_template_attribute_line_38" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_38" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_17"/>
     <field name="attribute_id" ref="product_attribute_10"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_3')])]"/>
   </record>
-  <record id="product_template_attribute_line_40" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_40" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_18"/>
     <field name="attribute_id" ref="product_attribute_10"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_1')])]"/>
   </record>
-  <record id="product_template_attribute_line_42" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_42" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_19"/>
     <field name="attribute_id" ref="product_attribute_10"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_1')])]"/>
   </record>
-  <record id="product_template_attribute_line_45" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_45" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_7"/>
     <field name="attribute_id" ref="product_attribute_11"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_9'), ref('product_attribute_value_10'), ref('product_attribute_value_11')])]"/>

--- a/climbing_gym/data/product_template.xml
+++ b/climbing_gym/data/product_template.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-    <record id="product_template_16" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_16" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="image_1920" type="base64" file="climbing_gym/static/src/binary/product_template/16-image_1920"/>
         <field name="name">1 Entrance Happy Hour</field>
         <field name="type">service</field>
@@ -14,7 +14,7 @@
         <field name="invoice_policy">order</field>
         <field name="x_is_base_entrance" eval="True"/>
     </record>
-    <record id="product_template_17" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_17" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="image_1920" type="base64" file="climbing_gym/static/src/binary/product_template/17-image_1920"/>
         <field name="name">1 Entrance Unlimited</field>
         <field name="type">service</field>
@@ -28,7 +28,7 @@
         <field name="invoice_policy">order</field>
         <field name="x_is_base_entrance" eval="True"/>
     </record>
-    <record id="product_template_11" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_11" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="image_1920" type="base64" file="climbing_gym/static/src/binary/product_template/11-image_1920"/>
         <field name="name">10 Entrances Happy Hour</field>
         <field name="type">service</field>
@@ -41,7 +41,7 @@
         <field name="service_type">manual</field>
         <field name="invoice_policy">order</field>
     </record>
-    <record id="product_template_10" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_10" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="image_1920" type="base64" file="climbing_gym/static/src/binary/product_template/10-image_1920"/>
         <field name="name">10 Entrances Unlimited</field>
         <field name="type">service</field>
@@ -54,7 +54,7 @@
         <field name="service_type">manual</field>
         <field name="invoice_policy">order</field>
     </record>
-    <record id="product_template_21" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_21" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="image_1920" type="base64" file="climbing_gym/static/src/binary/product_template/21-image_1920"/>
         <field name="name">Liquid Chalk</field>
         <field name="categ_id" ref="product.product_category_goods"/>
@@ -68,7 +68,7 @@
         <field name="service_type">manual</field>
         <field name="invoice_policy">order</field>
     </record>
-    <record id="product_template_9" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_9" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="image_1920" type="base64" file="climbing_gym/static/src/binary/product_template/9-image_1920"/>
         <field name="name">Subscription Happy Hour</field>
         <field name="type">service</field>
@@ -84,7 +84,7 @@
         <field name="grade_id" ref="res_partner_grade_data_happy_hour"/>
         <field name="subscription_rule_ids" eval="[(6,0,[ref('sale_subscription_pricing_1'),ref('sale_subscription_pricing_2')])]"/>
     </record>
-    <record id="product_template_8" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_8" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="image_1920" type="base64" file="climbing_gym/static/src/binary/product_template/8-image_1920"/>
         <field name="name">Subscription Unlimited</field>
         <field name="type">service</field>
@@ -100,7 +100,7 @@
         <field name="grade_id" ref="res_partner_grade_data_unlimited"/>
         <field name="subscription_rule_ids" eval="[(6,0,[ref('sale_subscription_pricing_3'),ref('sale_subscription_pricing_4')])]"/>
     </record>
-    <record id="product_template_22" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_22" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="image_1920" type="base64" file="climbing_gym/static/src/binary/product_template/22-image_1920"/>
         <field name="name">Tape</field>
         <field name="categ_id" ref="product.product_category_goods"/>

--- a/clothing_boutique/data/product_template.xml
+++ b/clothing_boutique/data/product_template.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-    <record id="product_template_10" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_10" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Black Leather Wide Leg trouser</field>
         <field name="is_storable">True</field>
         <field name="categ_id" ref="product_category_12" />
@@ -13,7 +13,7 @@
         <field name="website_sequence">10045</field>
         <field name="image_1920" type="base64" file="clothing_boutique/static/src/binary/product_template/10-image_1920" />
     </record>
-    <record id="product_template_11" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_11" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Black Top</field>
         <field name="is_storable">True</field>
         <field name="categ_id" ref="product_category_17" />
@@ -26,7 +26,7 @@
         <field name="website_sequence">10050</field>
         <field name="image_1920" type="base64" file="clothing_boutique/static/src/binary/product_template/11-image_1920" />
     </record>
-    <record id="product_template_12" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_12" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Blue Solid Pants</field>
         <field name="is_storable">True</field>
         <field name="categ_id" ref="product_category_12" />
@@ -40,7 +40,7 @@
         <field name="website_sequence">10055</field>
         <field name="image_1920" type="base64" file="clothing_boutique/static/src/binary/product_template/12-image_1920" />
     </record>
-    <record id="product_template_13" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_13" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Chiffon Jumpsuit</field>
         <field name="is_storable">True</field>
         <field name="categ_id" ref="product_category_15" />
@@ -53,7 +53,7 @@
         <field name="website_sequence">10060</field>
         <field name="image_1920" type="base64" file="clothing_boutique/static/src/binary/product_template/13-image_1920" />
     </record>
-    <record id="product_template_14" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_14" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Cream Oversized T-Shirt</field>
         <field name="is_storable">True</field>
         <field name="categ_id" ref="product_category_16" />
@@ -66,7 +66,7 @@
         <field name="website_sequence">10065</field>
         <field name="image_1920" type="base64" file="clothing_boutique/static/src/binary/product_template/14-image_1920" />
     </record>
-    <record id="product_template_15" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_15" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Blue Sequin Suit (Set of 3)</field>
         <field name="is_storable">True</field>
         <field name="categ_id" ref="product_category_9" />
@@ -79,7 +79,7 @@
         <field name="website_sequence">10070</field>
         <field name="image_1920" type="base64" file="clothing_boutique/static/src/binary/product_template/15-image_1920" />
     </record>
-    <record id="product_template_16" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_16" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Denim Jacket</field>
         <field name="is_storable">True</field>
         <field name="categ_id" ref="product_category_14" />
@@ -92,7 +92,7 @@
         <field name="website_sequence">10075</field>
         <field name="image_1920" type="base64" file="clothing_boutique/static/src/binary/product_template/16-image_1920" />
     </record>
-    <record id="product_template_17" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_17" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Designer Kurti</field>
         <field name="is_storable">True</field>
         <field name="categ_id" ref="product_category_10" />
@@ -105,7 +105,7 @@
         <field name="website_sequence">10080</field>
         <field name="image_1920" type="base64" file="clothing_boutique/static/src/binary/product_template/17-image_1920" />
     </record>
-    <record id="product_template_18" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_18" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Ruffle Floral Print Top</field>
         <field name="is_storable">True</field>
         <field name="categ_id" ref="product_category_17" />
@@ -118,7 +118,7 @@
         <field name="website_sequence">10085</field>
         <field name="image_1920" type="base64" file="clothing_boutique/static/src/binary/product_template/18-image_1920" />
     </record>
-    <record id="product_template_20" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_20" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">T-shirt </field>
         <field name="is_storable">True</field>
         <field name="categ_id" ref="product_category_16" />
@@ -131,7 +131,7 @@
         <field name="website_sequence">10090</field>
         <field name="image_1920" type="base64" file="clothing_boutique/static/src/binary/product_template/20-image_1920" />
     </record>
-    <record id="product_template_21" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_21" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Full sleeve jumpsuit</field>
         <field name="is_storable">True</field>
         <field name="categ_id" ref="product_category_15" />
@@ -144,7 +144,7 @@
         <field name="website_sequence">10095</field>
         <field name="image_1920" type="base64" file="clothing_boutique/static/src/binary/product_template/21-image_1920" />
     </record>
-    <record id="product_template_22" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_22" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Heart T -shirt</field>
         <field name="is_storable">True</field>
         <field name="categ_id" ref="product_category_16" />
@@ -157,7 +157,7 @@
         <field name="website_sequence">10100</field>
         <field name="image_1920" type="base64" file="clothing_boutique/static/src/binary/product_template/22-image_1920" />
     </record>
-    <record id="product_template_23" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_23" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Linen Wide Leg Pant</field>
         <field name="is_storable">True</field>
         <field name="categ_id" ref="product_category_12" />
@@ -170,7 +170,7 @@
         <field name="website_sequence">10105</field>
         <field name="image_1920" type="base64" file="clothing_boutique/static/src/binary/product_template/23-image_1920" />
     </record>
-    <record id="product_template_24" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_24" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Mustard yellow Kurta with Net Dupatta</field>
         <field name="is_storable">True</field>
         <field name="categ_id" ref="product_category_9" />
@@ -183,7 +183,7 @@
         <field name="website_sequence">10110</field>
         <field name="image_1920" type="base64" file="clothing_boutique/static/src/binary/product_template/24-image_1920" />
     </record>
-    <record id="product_template_25" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_25" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Pink Floral Print Top</field>
         <field name="is_storable">True</field>
         <field name="categ_id" ref="product_category_10" />
@@ -196,7 +196,7 @@
         <field name="website_sequence">10115</field>
         <field name="image_1920" type="base64" file="clothing_boutique/static/src/binary/product_template/25-image_1920" />
     </record>
-    <record id="product_template_26" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_26" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Kurta set</field>
         <field name="is_storable">True</field>
         <field name="categ_id" ref="product_category_9" />
@@ -209,7 +209,7 @@
         <field name="website_sequence">10120</field>
         <field name="image_1920" type="base64" file="clothing_boutique/static/src/binary/product_template/26-image_1920" />
     </record>
-    <record id="product_template_27" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_27" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Pink Round Neck Printed T-shirt</field>
         <field name="is_storable">True</field>
         <field name="categ_id" ref="product_category_16" />
@@ -222,7 +222,7 @@
         <field name="website_sequence">10125</field>
         <field name="image_1920" type="base64" file="clothing_boutique/static/src/binary/product_template/27-image_1920" />
     </record>
-    <record id="product_template_28" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_28" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Red Striped Jumpsuit</field>
         <field name="is_storable">True</field>
         <field name="categ_id" ref="product_category_15" />
@@ -235,7 +235,7 @@
         <field name="website_sequence">10130</field>
         <field name="image_1920" type="base64" file="clothing_boutique/static/src/binary/product_template/28-image_1920" />
     </record>
-    <record id="product_template_29" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_29" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">White Flared Dress</field>
         <field name="is_storable">True</field>
         <field name="categ_id" ref="product_category_8" />
@@ -248,7 +248,7 @@
         <field name="website_sequence">10135</field>
         <field name="image_1920" type="base64" file="clothing_boutique/static/src/binary/product_template/29-image_1920" />
     </record>
-    <record id="product_template_30" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_30" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">White Kurta set with Heavy Thread Work Dupatta (Set Of 3)</field>
         <field name="is_storable">True</field>
         <field name="categ_id" ref="product_category_9" />
@@ -261,7 +261,7 @@
         <field name="website_sequence">10140</field>
         <field name="image_1920" type="base64" file="clothing_boutique/static/src/binary/product_template/30-image_1920" />
     </record>
-    <record id="product_template_31" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_31" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Women Solid Black Casual Jacket</field>
         <field name="is_storable">True</field>
         <field name="categ_id" ref="product_category_14" />
@@ -274,7 +274,7 @@
         <field name="website_sequence">10145</field>
         <field name="image_1920" type="base64" file="clothing_boutique/static/src/binary/product_template/31-image_1920" />
     </record>
-    <record id="product_template_32" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_32" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Assymetric kurta With Inner And Trousers</field>
         <field name="is_storable">True</field>
         <field name="categ_id" ref="product_category_8" />
@@ -287,7 +287,7 @@
         <field name="website_sequence">10150</field>
         <field name="image_1920" type="base64" file="clothing_boutique/static/src/binary/product_template/32-image_1920" />
     </record>
-    <record id="product_template_33" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_33" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Designer Ethnic wear</field>
         <field name="is_storable">True</field>
         <field name="categ_id" ref="product_category_8" />
@@ -301,7 +301,7 @@
         <field name="image_1920" type="base64" file="clothing_boutique/static/src/binary/product_template/33-image_1920" />
         <field name="service_type">manual</field>
     </record>
-    <record id="product_template_34" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_34" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Red Suit Set</field>
         <field name="is_storable">True</field>
         <field name="categ_id" ref="product_category_9" />
@@ -313,7 +313,7 @@
         <field name="image_1920" type="base64" file="clothing_boutique/static/src/binary/product_template/34-image_1920" />
         <field name="service_type">manual</field>
     </record>
-    <record id="product_template_35" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_35" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Tunic Top</field>
         <field name="is_storable">True</field>
         <field name="categ_id" ref="product_category_10" />
@@ -325,7 +325,7 @@
         <field name="website_sequence">10165</field>
         <field name="image_1920" type="base64" file="clothing_boutique/static/src/binary/product_template/35-image_1920" />
     </record>
-    <record id="product_template_50" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_50" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">20% on your order</field>
         <field name="type">service</field>
         <field name="service_type">manual</field>
@@ -337,7 +337,7 @@
         <field name="base_unit_count">1.0</field>
         <field name="website_sequence">10235</field>
     </record>
-    <record id="product_template_51" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_51" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">10% on your NEXT ORDER !!</field>
         <field name="type">service</field>
         <field name="service_type">manual</field>
@@ -349,7 +349,7 @@
         <field name="base_unit_count">1.0</field>
         <field name="website_sequence">10240</field>
     </record>
-    <record id="product_template_52" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_52" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">15% on your order</field>
         <field name="type">service</field>
         <field name="service_type">manual</field>
@@ -361,7 +361,7 @@
         <field name="base_unit_count">1.0</field>
         <field name="website_sequence">10245</field>
     </record>
-    <record id="product_template_53" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_53" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">High Waist Jeans</field>
         <field name="is_storable">True</field>
         <field name="categ_id" ref="product_category_18" />
@@ -374,7 +374,7 @@
         <field name="website_sequence">10250</field>
         <field name="image_1920" type="base64" file="clothing_boutique/static/src/binary/product_template/53-image_1920" />
     </record>
-    <record id="product_template_54" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_54" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Loose Jeans</field>
         <field name="is_storable">True</field>
         <field name="categ_id" ref="product_category_18" />
@@ -387,7 +387,7 @@
         <field name="website_sequence">10255</field>
         <field name="image_1920" type="base64" file="clothing_boutique/static/src/binary/product_template/54-image_1920" />
     </record>
-    <record id="product_template_55" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_55" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Skinny Jeans</field>
         <field name="is_storable">True</field>
         <field name="categ_id" ref="product_category_18" />
@@ -400,7 +400,7 @@
         <field name="image_1920" type="base64" file="clothing_boutique/static/src/binary/product_template/55-image_1920" />
         <field name="service_type">manual</field>
     </record>
-    <record id="product_template_56" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_56" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">5% on your order for the loyalty points earned.</field>
         <field name="type">service</field>
         <field name="service_type">manual</field>
@@ -412,7 +412,7 @@
         <field name="base_unit_count">1.0</field>
         <field name="website_sequence">10265</field>
     </record>
-    <record id="product_template_57" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_57" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Free shipping</field>
         <field name="type">service</field>
         <field name="service_type">manual</field>
@@ -424,7 +424,7 @@
         <field name="base_unit_count">1.0</field>
         <field name="website_sequence">10265</field>
     </record>
-    <record id="product_template_58" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_58" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Free Product - T-shirt </field>
         <field name="type">service</field>
         <field name="service_type">manual</field>
@@ -436,7 +436,7 @@
         <field name="base_unit_count">1.0</field>
         <field name="website_sequence">10270</field>
     </record>
-    <record id="product_template_59" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_59" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Free Product - Discount</field>
         <field name="type">service</field>
         <field name="service_type">manual</field>
@@ -448,7 +448,7 @@
         <field name="base_unit_count">1.0</field>
         <field name="website_sequence">10275</field>
     </record>
-    <record id="product_template_60" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_60" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Free Product - T-shirt </field>
         <field name="type">service</field>
         <field name="service_type">manual</field>
@@ -460,7 +460,7 @@
         <field name="base_unit_count">1.0</field>
         <field name="website_sequence">10280</field>
     </record>
-    <record id="product_template_61" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_61" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">5% on your order Loyalty</field>
         <field name="type">service</field>
         <field name="service_type">manual</field>
@@ -472,7 +472,7 @@
         <field name="base_unit_count">1.0</field>
         <field name="website_sequence">10285</field>
     </record>
-    <record id="product_template_8" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_8" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Baby Pink Printed Maxi Dress</field>
         <field name="is_storable">True</field>
         <field name="categ_id" ref="product_category_8" />
@@ -485,7 +485,7 @@
         <field name="website_sequence">10035</field>
         <field name="image_1920" type="base64" file="clothing_boutique/static/src/binary/product_template/8-image_1920" />
     </record>
-    <record id="product_template_9" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_9" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Aqua Blue Top and Skirt</field>
         <field name="is_storable">True</field>
         <field name="categ_id" ref="product_category_13" />

--- a/clothing_boutique/data/product_template_attribute_line.xml
+++ b/clothing_boutique/data/product_template_attribute_line.xml
@@ -1,121 +1,121 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-    <record id="product_template_attribute_line_1" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_1" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_17"/>
         <field name="attribute_id" ref="product_attribute_2"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_1'), ref('product_attribute_value_2')])]"/>
     </record>
-    <record id="product_template_attribute_line_10" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_10" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_16"/>
         <field name="attribute_id" ref="product_attribute_3"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_8'), ref('product_attribute_value_9')])]"/>
     </record>
-    <record id="product_template_attribute_line_11" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_11" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_23"/>
         <field name="attribute_id" ref="product_attribute_3"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_9')])]"/>
     </record>
-    <record id="product_template_attribute_line_12" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_12" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_9"/>
         <field name="attribute_id" ref="product_attribute_3"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_8'), ref('product_attribute_value_9')])]"/>
     </record>
-    <record id="product_template_attribute_line_13" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_13" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_27"/>
         <field name="attribute_id" ref="product_attribute_3"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_8'), ref('product_attribute_value_9')])]"/>
     </record>
-    <record id="product_template_attribute_line_14" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_14" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_20"/>
         <field name="attribute_id" ref="product_attribute_3"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_9')])]"/>
     </record>
-    <record id="product_template_attribute_line_2" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_2" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_16"/>
         <field name="attribute_id" ref="product_attribute_2"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_4'), ref('product_attribute_value_pink')])]"/>
     </record>
-    <record id="product_template_attribute_line_4" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_4" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_20"/>
         <field name="attribute_id" ref="product_attribute_2"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_yellow'), ref('product_attribute_value_5')])]"/>
     </record>
-    <record id="product_template_attribute_line_5" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_5" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_22"/>
         <field name="attribute_id" ref="product_attribute_2"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_5'), ref('product_attribute_value_4')])]"/>
     </record>
-    <record id="product_template_attribute_line_6" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_6" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_14"/>
         <field name="attribute_id" ref="product_attribute_3"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_8'), ref('product_attribute_value_9')])]"/>
     </record>
-    <record id="product_template_attribute_line_7" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_7" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_23"/>
         <field name="attribute_id" ref="product_attribute_2"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_light_blue'), ref('product_attribute_value_dark_pink')])]"/>
     </record>
-    <record id="product_template_attribute_line_8" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_8" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_35"/>
         <field name="attribute_id" ref="product_attribute_2"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_2'), ref('product_attribute_value_dark_pink')])]"/>
     </record>
-    <record id="product_template_attribute_line_9" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_9" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_55"/>
         <field name="attribute_id" ref="product_attribute_2"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_dark_blue'), ref('product_attribute_value_light_blue')])]"/>
     </record>
-    <record id="product_template_attribute_line_100" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_100" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_14"/>
         <field name="attribute_id" ref="product_attribute_2"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_pink')])]"/>
     </record>
-    <record id="product_template_attribute_line_101" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_101" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_9"/>
         <field name="attribute_id" ref="product_attribute_2"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_light_blue')])]"/>
     </record>
-    <record id="product_template_attribute_line_102" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_102" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_8"/>
         <field name="attribute_id" ref="product_attribute_2"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_pink')])]"/>
     </record>
-    <record id="product_template_attribute_line_103" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_103" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_10"/>
         <field name="attribute_id" ref="product_attribute_2"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_black')])]"/>
     </record>
-    <record id="product_template_attribute_line_104" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_104" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_11"/>
         <field name="attribute_id" ref="product_attribute_2"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_black')])]"/>
     </record>
-    <record id="product_template_attribute_line_105" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_105" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_15"/>
         <field name="attribute_id" ref="product_attribute_2"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_dark_blue')])]"/>
     </record>
-    <record id="product_template_attribute_line_106" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_106" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_12"/>
         <field name="attribute_id" ref="product_attribute_2"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_blue')])]"/>
     </record>
-    <record id="product_template_attribute_line_107" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_107" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_21"/>
         <field name="attribute_id" ref="product_attribute_2"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_blue')])]"/>
     </record>
-    <record id="product_template_attribute_line_108" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_108" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_53"/>
         <field name="attribute_id" ref="product_attribute_2"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_dark_blue')])]"/>
     </record>
-    <record id="product_template_attribute_line_109" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_109" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_54"/>
         <field name="attribute_id" ref="product_attribute_2"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_blue')])]"/>
     </record>
-    <record id="product_template_attribute_line_110" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_110" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_24"/>
         <field name="attribute_id" ref="product_attribute_2"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_yellow')])]"/>

--- a/coal_petroleum/data/product_template.xml
+++ b/coal_petroleum/data/product_template.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-    <record id="product_template_1" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_1" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Anthracite</field>
         <field name="is_storable">True</field>
         <field name="list_price">160.0</field>
@@ -10,7 +10,7 @@
         <field name="image_1920" type="base64" file="coal_petroleum/static/src/binary/product_template/1-image_1920"/>
     </record>
 
-    <record id="product_template_2" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_2" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Bituminous</field>
         <field name="is_storable">True</field>
         <field name="list_price">160.0</field>
@@ -20,7 +20,7 @@
         <field name="image_1920" type="base64" file="coal_petroleum/static/src/binary/product_template/2-image_1920"/>
     </record>
 
-    <record id="product_template_3" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_3" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Peat Coal</field>
         <field name="is_storable">True</field>
         <field name="list_price">90.0</field>
@@ -30,7 +30,7 @@
         <field name="image_1920" type="base64" file="coal_petroleum/static/src/binary/product_template/3-image_1920"/>
     </record>
 
-    <record id="product_template_4" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_4" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Diesel</field>
         <field name="is_storable">True</field>
         <field name="list_price">4.8</field>
@@ -40,7 +40,7 @@
         <field name="image_1920" type="base64" file="coal_petroleum/static/src/binary/product_template/4-image_1920"/>
     </record>
 
-    <record id="product_template_5" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_5" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Gasoline fuel</field>
         <field name="is_storable">True</field>
         <field name="list_price">4.9</field>

--- a/coal_petroleum/data/product_template_attribute_line.xml
+++ b/coal_petroleum/data/product_template_attribute_line.xml
@@ -1,36 +1,36 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-    <record id="product_template_attribute_line_1" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_1" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_1"/>
         <field name="attribute_id" ref="product_attribute_1"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_1'), ref('product_attribute_value_2'), ref('product_attribute_value_3'), ref('product_attribute_value_4')])]"/>
     </record>
 
-    <record id="product_template_attribute_line_2" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_2" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_1"/>
         <field name="attribute_id" ref="product_attribute_2"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_5'), ref('product_attribute_value_6'), ref('product_attribute_value_7')])]"/>
     </record>
 
-    <record id="product_template_attribute_line_3" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_3" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_2"/>
         <field name="attribute_id" ref="product_attribute_1"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_1'), ref('product_attribute_value_2'), ref('product_attribute_value_3'), ref('product_attribute_value_4')])]"/>
     </record>
 
-    <record id="product_template_attribute_line_4" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_4" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_2"/>
         <field name="attribute_id" ref="product_attribute_2"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_5'), ref('product_attribute_value_6'), ref('product_attribute_value_7')])]"/>
     </record>
 
-    <record id="product_template_attribute_line_5" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_5" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_4"/>
         <field name="attribute_id" ref="product_attribute_3"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_11'), ref('product_attribute_value_12'), ref('product_attribute_value_13')])]"/>
     </record>
 
-    <record id="product_template_attribute_line_6" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_6" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_5"/>
         <field name="attribute_id" ref="product_attribute_3"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_8'), ref('product_attribute_value_9'), ref('product_attribute_value_10')])]"/>

--- a/construction/data/product_template.xml
+++ b/construction/data/product_template.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-    <record id="product_template_54" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_54" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Acoustic insulation</field>
         <field name="categ_id" ref="product_category_36"/>
         <field name="list_price">25.0</field>
@@ -10,7 +10,7 @@
         <field name="service_type">manual</field>
         <field name="invoice_policy">order</field>
     </record>
-    <record id="product_template_14" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_14" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Adapted WC</field>
         <field name="categ_id" ref="product_category_38"/>
         <field name="list_price">1000.0</field>
@@ -19,7 +19,7 @@
         <field name="service_type">manual</field>
         <field name="invoice_policy">order</field>
     </record>
-    <record id="product_template_34" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_34" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Bathrooms</field>
         <field name="categ_id" ref="product_category_38"/>
         <field name="list_price">1500.0</field>
@@ -28,7 +28,7 @@
         <field name="service_type">manual</field>
         <field name="invoice_policy">order</field>
     </record>
-    <record id="product_template_16" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_16" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Cooking line</field>
         <field name="categ_id" ref="product_category_41"/>
         <field name="list_price">10000.0</field>
@@ -37,7 +37,7 @@
         <field name="service_type">manual</field>
         <field name="invoice_policy">order</field>
     </record>
-    <record id="product_template_19" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_19" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Dishwasher station</field>
         <field name="categ_id" ref="product_category_41"/>
         <field name="list_price">2000.0</field>
@@ -46,7 +46,7 @@
         <field name="service_type">manual</field>
         <field name="invoice_policy">order</field>
     </record>
-    <record id="product_template_12" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_12" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Door adjustments</field>
         <field name="categ_id" ref="product_category_37"/>
         <field name="list_price">500.0</field>
@@ -55,7 +55,7 @@
         <field name="service_type">manual</field>
         <field name="invoice_policy">order</field>
     </record>
-    <record id="product_template_32" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_32" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Emergency lights</field>
         <field name="categ_id" ref="product_category_39"/>
         <field name="list_price">90.0</field>
@@ -64,7 +64,7 @@
         <field name="service_type">manual</field>
         <field name="invoice_policy">order</field>
     </record>
-    <record id="product_template_11" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_11" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Exterior lighting</field>
         <field name="categ_id" ref="product_category_39"/>
         <field name="list_price">300.0</field>
@@ -73,7 +73,7 @@
         <field name="service_type">manual</field>
         <field name="invoice_policy">order</field>
     </record>
-    <record id="product_template_28" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_28" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Extraction hood</field>
         <field name="categ_id" ref="product_category_41"/>
         <field name="list_price">4500.0</field>
@@ -82,7 +82,7 @@
         <field name="service_type">manual</field>
         <field name="invoice_policy">order</field>
     </record>
-    <record id="product_template_20" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_20" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Extraction system</field>
         <field name="categ_id" ref="product_category_41"/>
         <field name="list_price">6000.0</field>
@@ -91,7 +91,7 @@
         <field name="service_type">manual</field>
         <field name="invoice_policy">order</field>
     </record>
-    <record id="product_template_55" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_55" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Fire-rated partitions</field>
         <field name="categ_id" ref="product_category_36"/>
         <field name="list_price">2000.0</field>
@@ -100,7 +100,7 @@
         <field name="service_type">manual</field>
         <field name="invoice_policy">order</field>
     </record>
-    <record id="product_template_10" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_10" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Garden cleanup</field>
         <field name="categ_id" ref="product_category_52"/>
         <field name="list_price">1000.0</field>
@@ -109,7 +109,7 @@
         <field name="service_type">manual</field>
         <field name="invoice_policy">order</field>
     </record>
-    <record id="product_template_9" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_9" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Gravel parking</field>
         <field name="categ_id" ref="product_category_47"/>
         <field name="list_price">200.0</field>
@@ -118,7 +118,7 @@
         <field name="service_type">manual</field>
         <field name="invoice_policy">order</field>
     </record>
-    <record id="product_template_35" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_35" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Guest WCs</field>
         <field name="categ_id" ref="product_category_38"/>
         <field name="list_price">1000.0</field>
@@ -127,7 +127,7 @@
         <field name="service_type">manual</field>
         <field name="invoice_policy">order</field>
     </record>
-    <record id="product_template_25" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_25" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Heat pump</field>
         <field name="categ_id" ref="product_category_40"/>
         <field name="list_price">8000.0</field>
@@ -136,7 +136,7 @@
         <field name="service_type">manual</field>
         <field name="invoice_policy">order</field>
     </record>
-    <record id="product_template_37" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_37" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Hot water system</field>
         <field name="categ_id" ref="product_category_40"/>
         <field name="list_price">2000.0</field>
@@ -145,7 +145,7 @@
         <field name="service_type">manual</field>
         <field name="invoice_policy">order</field>
     </record>
-    <record id="product_template_33" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_33" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Installation Labour</field>
         <field name="categ_id" ref="product_category_25"/>
         <field name="type">service</field>
@@ -156,7 +156,7 @@
         <field name="service_type">timesheet</field>
         <field name="invoice_policy">order</field>
     </record>
-    <record id="product_template_36" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_36" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Kitchen plumbing</field>
         <field name="categ_id" ref="product_category_40"/>
         <field name="list_price">1500.0</field>
@@ -165,7 +165,7 @@
         <field name="service_type">manual</field>
         <field name="invoice_policy">order</field>
     </record>
-    <record id="product_template_46" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_46" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Labour &amp; site management</field>
         <field name="categ_id" ref="product_category_19"/>
         <field name="type">service</field>
@@ -176,7 +176,7 @@
         <field name="service_type">timesheet</field>
         <field name="invoice_policy">order</field>
     </record>
-    <record id="product_template_41" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_41" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Labour &amp; supervision</field>
         <field name="categ_id" ref="product_category_19"/>
         <field name="type">service</field>
@@ -187,7 +187,7 @@
         <field name="service_type">timesheet</field>
         <field name="invoice_policy">order</field>
     </record>
-    <record id="product_template_56" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_56" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">General Labour</field>
         <field name="categ_id" ref="product_category_25"/>
         <field name="type">service</field>
@@ -198,7 +198,7 @@
         <field name="service_type">timesheet</field>
         <field name="invoice_policy">delivery</field>
     </record>
-    <record id="product_template_30" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_30" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Lighting</field>
         <field name="categ_id" ref="product_category_39"/>
         <field name="list_price">60.0</field>
@@ -207,7 +207,7 @@
         <field name="service_type">manual</field>
         <field name="invoice_policy">order</field>
     </record>
-    <record id="product_template_43" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_43" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">New openings</field>
         <field name="categ_id" ref="product_category_45"/>
         <field name="list_price">850.0</field>
@@ -216,7 +216,7 @@
         <field name="service_type">manual</field>
         <field name="invoice_policy">order</field>
     </record>
-    <record id="product_template_29" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_29" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">New panel</field>
         <field name="categ_id" ref="product_category_39"/>
         <field name="list_price">2000.0</field>
@@ -225,7 +225,7 @@
         <field name="service_type">manual</field>
         <field name="invoice_policy">order</field>
     </record>
-    <record id="product_template_23" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_23" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Painting</field>
         <field name="categ_id" ref="product_category_37"/>
         <field name="list_price">20.0</field>
@@ -235,7 +235,7 @@
         <field name="service_type">manual</field>
         <field name="invoice_policy">order</field>
     </record>
-    <record id="product_template_22" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_22" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Parquet</field>
         <field name="categ_id" ref="product_category_37"/>
         <field name="list_price">40.0</field>
@@ -245,7 +245,7 @@
         <field name="service_type">manual</field>
         <field name="invoice_policy">order</field>
     </record>
-    <record id="product_template_53" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_53" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Plasterboard walls</field>
         <field name="categ_id" ref="product_category_36"/>
         <field name="list_price">30.0</field>
@@ -255,7 +255,7 @@
         <field name="service_type">manual</field>
         <field name="invoice_policy">order</field>
     </record>
-    <record id="product_template_57" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_57" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Project Management</field>
         <field name="categ_id" ref="product_category_19"/>
         <field name="type">service</field>
@@ -267,7 +267,7 @@
         <field name="invoice_policy">order</field>
         <field name="project_template_id" ref="project_project_3"/>
     </record>
-    <record id="product_template_58" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_58" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Purchase Management</field>
         <field name="categ_id" ref="product_category_19"/>
         <field name="type">service</field>
@@ -278,7 +278,7 @@
         <field name="service_type">timesheet</field>
         <field name="invoice_policy">order</field>
     </record>
-    <record id="product_template_15" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_15" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Ramp</field>
         <field name="categ_id" ref="product_category_41"/>
         <field name="list_price">1200.0</field>
@@ -287,7 +287,7 @@
         <field name="service_type">manual</field>
         <field name="invoice_policy">order</field>
     </record>
-    <record id="product_template_17" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_17" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Refrigeration</field>
         <field name="categ_id" ref="product_category_41"/>
         <field name="list_price">7000.0</field>
@@ -296,7 +296,7 @@
         <field name="service_type">manual</field>
         <field name="invoice_policy">order</field>
     </record>
-    <record id="product_template_42" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_42" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Reinforcement beams</field>
         <field name="categ_id" ref="product_category_46"/>
         <field name="list_price">1800.0</field>
@@ -305,7 +305,7 @@
         <field name="service_type">manual</field>
         <field name="invoice_policy">order</field>
     </record>
-    <record id="product_template_49" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_49" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Roof insulation</field>
         <field name="categ_id" ref="product_category_36"/>
         <field name="list_price">40.0</field>
@@ -315,7 +315,7 @@
         <field name="service_type">manual</field>
         <field name="invoice_policy">order</field>
     </record>
-    <record id="product_template_48" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_48" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Roof structure repair</field>
         <field name="categ_id" ref="product_category_42"/>
         <field name="list_price">3000.0</field>
@@ -324,7 +324,7 @@
         <field name="service_type">manual</field>
         <field name="invoice_policy">order</field>
     </record>
-    <record id="product_template_26" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_26" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Room radiators</field>
         <field name="categ_id" ref="product_category_40"/>
         <field name="list_price">350.0</field>
@@ -333,7 +333,7 @@
         <field name="service_type">manual</field>
         <field name="invoice_policy">order</field>
     </record>
-    <record id="product_template_45" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_45" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Screed</field>
         <field name="categ_id" ref="product_category_45"/>
         <field name="list_price">45.0</field>
@@ -343,7 +343,7 @@
         <field name="service_type">manual</field>
         <field name="invoice_policy">order</field>
     </record>
-    <record id="product_template_13" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_13" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Signage</field>
         <field name="categ_id" ref="product_category_41"/>
         <field name="list_price">800.0</field>
@@ -352,7 +352,7 @@
         <field name="service_type">manual</field>
         <field name="invoice_policy">order</field>
     </record>
-    <record id="product_template_40" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_40" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Site protection</field>
         <field name="categ_id" ref="product_category_50"/>
         <field name="list_price">800.0</field>
@@ -361,7 +361,7 @@
         <field name="service_type">manual</field>
         <field name="invoice_policy">order</field>
     </record>
-    <record id="product_template_24" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_24" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Skirting &amp; details</field>
         <field name="categ_id" ref="product_category_37"/>
         <field name="list_price">6500.0</field>
@@ -370,7 +370,7 @@
         <field name="service_type">manual</field>
         <field name="invoice_policy">order</field>
     </record>
-    <record id="product_template_51" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_51" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Sliding doors</field>
         <field name="categ_id" ref="product_category_44"/>
         <field name="list_price">3000.0</field>
@@ -379,7 +379,7 @@
         <field name="service_type">manual</field>
         <field name="invoice_policy">order</field>
     </record>
-    <record id="product_template_31" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_31" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Sockets &amp; cabling</field>
         <field name="categ_id" ref="product_category_39"/>
         <field name="list_price">50.0</field>
@@ -388,7 +388,7 @@
         <field name="service_type">manual</field>
         <field name="invoice_policy">order</field>
     </record>
-    <record id="product_template_18" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_18" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Stainless prep</field>
         <field name="categ_id" ref="product_category_41"/>
         <field name="list_price">3000.0</field>
@@ -397,7 +397,7 @@
         <field name="service_type">manual</field>
         <field name="invoice_policy">order</field>
     </record>
-    <record id="product_template_44" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_44" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Stone repair</field>
         <field name="categ_id" ref="product_category_45"/>
         <field name="list_price">40.0</field>
@@ -407,7 +407,7 @@
         <field name="service_type">manual</field>
         <field name="invoice_policy">order</field>
     </record>
-    <record id="product_template_47" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_47" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Tile supply &amp; install</field>
         <field name="categ_id" ref="product_category_42"/>
         <field name="list_price">40.0</field>
@@ -417,7 +417,7 @@
         <field name="service_type">manual</field>
         <field name="invoice_policy">order</field>
     </record>
-    <record id="product_template_21" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_21" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Tiling</field>
         <field name="categ_id" ref="product_category_37"/>
         <field name="list_price">50.0</field>
@@ -427,7 +427,7 @@
         <field name="service_type">manual</field>
         <field name="invoice_policy">order</field>
     </record>
-    <record id="product_template_27" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_27" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">VMC</field>
         <field name="categ_id" ref="product_category_40"/>
         <field name="list_price">3200.0</field>
@@ -436,7 +436,7 @@
         <field name="service_type">manual</field>
         <field name="invoice_policy">order</field>
     </record>
-    <record id="product_template_38" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_38" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Wall &amp; floor removal</field>
         <field name="categ_id" ref="product_category_29"/>
         <field name="list_price">10.0</field>
@@ -446,7 +446,7 @@
         <field name="service_type">manual</field>
         <field name="invoice_policy">order</field>
     </record>
-    <record id="product_template_39" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_39" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Waste disposal</field>
         <field name="categ_id" ref="product_category_52"/>
         <field name="list_price">800.0</field>
@@ -455,7 +455,7 @@
         <field name="service_type">manual</field>
         <field name="invoice_policy">order</field>
     </record>
-    <record id="product_template_50" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_50" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Windows</field>
         <field name="categ_id" ref="product_category_44"/>
         <field name="list_price">600.0</field>
@@ -464,7 +464,7 @@
         <field name="service_type">manual</field>
         <field name="invoice_policy">order</field>
     </record>
-    <record id="product_template_8" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_8" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Wooden terrace</field>
         <field name="categ_id" ref="product_category_34"/>
         <field name="list_price">50.0</field>
@@ -474,7 +474,7 @@
         <field name="service_type">manual</field>
         <field name="invoice_policy">order</field>
     </record>
-    <record id="product_template_79" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_79" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Excavator</field>
         <field name="categ_id" ref="product_category_10"/>
         <field name="list_price">600.0</field>

--- a/construction_developer/data/product_template.xml
+++ b/construction_developer/data/product_template.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-    <record id="product_template_66" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_66" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Drainage System</field>
         <field name="type">service</field>
         <field name="list_price">27.0</field>
@@ -11,7 +11,7 @@
         <field name="service_policy">delivered_manual</field>
         <field name="categ_id" ref="construction.product_category_48"/>
     </record>
-    <record id="product_template_67" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_67" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Foundation Footing</field>
         <field name="type">service</field>
         <field name="list_price">130.0</field>
@@ -21,7 +21,7 @@
         <field name="service_policy">delivered_manual</field>
         <field name="categ_id" ref="construction.product_category_49"/>
     </record>
-    <record id="product_template_62" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_62" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Ground Preparation</field>
         <field name="type">service</field>
         <field name="list_price">73.25</field>
@@ -32,7 +32,7 @@
         <field name="service_policy">delivered_manual</field>
         <field name="categ_id" ref="construction.product_category_47"/>
     </record>
-    <record id="product_template_68" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_68" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Gutter</field>
         <field name="type">service</field>
         <field name="list_price">25.25</field>
@@ -43,7 +43,7 @@
         <field name="service_policy">delivered_manual</field>
         <field name="categ_id" ref="construction.product_category_43"/>
     </record>
-    <record id="product_template_69" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_69" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Roofing</field>
         <field name="type">service</field>
         <field name="list_price">35.8</field>
@@ -54,7 +54,7 @@
         <field name="service_policy">delivered_manual</field>
         <field name="categ_id" ref="construction.product_category_42"/>
     </record>
-    <record id="product_template_70" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_70" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Structure</field>
         <field name="type">service</field>
         <field name="list_price">421.2</field>
@@ -65,7 +65,7 @@
         <field name="service_policy">delivered_manual</field>
         <field name="categ_id" ref="construction.product_category_45"/>
     </record>
-    <record id="product_template_77" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_77" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Anti-corrosion protective coat</field>
         <field name="list_price">12.0</field>
         <field name="uom_id" ref="uom.product_uom_litre"/>
@@ -73,7 +73,7 @@
         <field name="service_type">manual</field>
         <field name="categ_id" ref="construction.product_category_46"/>
     </record>
-    <record id="product_template_65" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_65" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Compacted sand</field>
         <field name="list_price">25.0</field>
         <field name="uom_id" ref="uom.product_uom_ton"/>
@@ -82,7 +82,7 @@
         <field name="invoice_policy">order</field>
         <field name="categ_id" ref="construction.product_category_47"/>
     </record>
-    <record id="product_template_80" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_80" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Concrete</field>
         <field name="list_price">125.0</field>
         <field name="uom_id" ref="uom.product_uom_ton"/>
@@ -90,7 +90,7 @@
         <field name="service_type">manual</field>
         <field name="categ_id" ref="construction.product_category_45"/>
     </record>
-    <record id="product_template_79" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_79" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Connection pipe</field>
         <field name="list_price">4.0</field>
         <field name="uom_id" ref="uom.product_uom_meter"/>
@@ -98,7 +98,7 @@
         <field name="service_type">manual</field>
         <field name="categ_id" ref="construction.product_category_48"/>
     </record>
-    <record id="product_template_73" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_73" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Corrugated metal sheet</field>
         <field name="list_price">20.0</field>
         <field name="uom_id" ref="uom.product_uom_square_meter"/>
@@ -106,14 +106,14 @@
         <field name="service_type">manual</field>
         <field name="categ_id" ref="construction.product_category_42"/>
     </record>
-    <record id="product_template_72" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_72" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Downspout accessory</field>
         <field name="list_price">5.0</field>
         <field name="default_code">08.6.25.030</field>
         <field name="service_type">manual</field>
         <field name="categ_id" ref="construction.product_category_43"/>
     </record>
-    <record id="product_template_78" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_78" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Drain channel with grid</field>
         <field name="list_price">8.0</field>
         <field name="uom_id" ref="uom.product_uom_meter"/>
@@ -121,7 +121,7 @@
         <field name="service_type">manual</field>
         <field name="categ_id" ref="construction.product_category_48"/>
     </record>
-    <record id="product_template_63" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_63" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Geotextile fabric</field>
         <field name="list_price">2.0</field>
         <field name="uom_id" ref="uom.product_uom_square_meter"/>
@@ -130,7 +130,7 @@
         <field name="invoice_policy">order</field>
         <field name="categ_id" ref="construction.product_category_47"/>
     </record>
-    <record id="product_template_64" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_64" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Gravel 0.25</field>
         <field name="list_price">35.0</field>
         <field name="uom_id" ref="uom.product_uom_ton"/>
@@ -139,7 +139,7 @@
         <field name="invoice_policy">order</field>
         <field name="categ_id" ref="construction.product_category_47"/>
     </record>
-    <record id="product_template_71" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_71" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">PVC gutter</field>
         <field name="list_price">12.0</field>
         <field name="uom_id" ref="uom.product_uom_meter"/>
@@ -147,28 +147,28 @@
         <field name="service_type">manual</field>
         <field name="categ_id" ref="construction.product_category_43"/>
     </record>
-    <record id="product_template_74" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_74" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Roofing fixation screws</field>
         <field name="list_price">0.1</field>
         <field name="default_code">08.9.10.015</field>
         <field name="service_type">manual</field>
         <field name="categ_id" ref="construction.product_category_42"/>
     </record>
-    <record id="product_template_76" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_76" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Steel beam (matching profile)</field>
         <field name="list_price">125.0</field>
         <field name="default_code">05.2.20.045</field>
         <field name="service_type">manual</field>
         <field name="categ_id" ref="construction.product_category_46"/>
     </record>
-    <record id="product_template_75" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_75" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Steel post (galvanized, coated)</field>
         <field name="list_price">80.0</field>
         <field name="default_code">05.2.10.020</field>
         <field name="service_type">manual</field>
         <field name="categ_id" ref="construction.product_category_46"/>
     </record>
-    <record id="product_template_81" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_81" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Steel reinforcement mesh</field>
         <field name="list_price">15.0</field>
         <field name="uom_id" ref="uom.product_uom_square_meter"/>

--- a/corporate_gifts/data/product_template.xml
+++ b/corporate_gifts/data/product_template.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-    <record id="product_template_5" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_5" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Serigraphy: Back Printing</field>
         <field name="list_price">3.0</field>
         <field name="type">service</field>
@@ -8,7 +8,7 @@
         <field name="service_tracking">task_global_project</field>
         <field name="website_sequence">10020</field>
         </record>
-    <record id="product_template_4" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_4" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Serigraphy: Pocket Printing</field>
         <field name="list_price">3.0</field>
         <field name="type">service</field>
@@ -16,7 +16,7 @@
         <field name="service_tracking">task_global_project</field>
         <field name="website_sequence">10015</field>
         </record>
-    <record id="product_template_2" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_2" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">B&amp;C Inspire Women</field>
         <field name="list_price">15.0</field>
         <field name="is_storable">True</field>
@@ -95,7 +95,7 @@
         ]]>
         </field>
     </record>
-    <record id="product_template_3" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_3" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Serigraphy: Logo Frame Creation</field>
         <field name="list_price">250.0</field>
         <field name="type">service</field>
@@ -103,14 +103,14 @@
         <field name="service_tracking">task_global_project</field>
         <field name="website_sequence">10010</field>
     </record>
-    <record id="product_template_6" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_6" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Customized Keyring</field>
         <field name="is_storable">True</field>
         <field name="public_categ_ids" eval="[(6, 0, [ref('product_public_category_1')])]" />
         <field name="website_sequence">10025</field>
         <field name="image_1920" type="base64" file="corporate_gifts/static/src/binary/product_template/6-image_1920" />
     </record>
-    <record id="product_template_7" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_7" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Mug</field>
         <field name="list_price">4.0</field>
         <field name="is_storable">True</field>
@@ -118,14 +118,14 @@
         <field name="website_sequence">10030</field>
         <field name="image_1920" type="base64" file="corporate_gifts/static/src/binary/product_template/7-image_1920" />
     </record>
-    <record id="product_template_8" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_8" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Bottle Opener Keying</field>
         <field name="is_storable">True</field>
         <field name="public_categ_ids" eval="[(6, 0, [ref('product_public_category_1')])]" />
         <field name="website_sequence">10035</field>
         <field name="image_1920" type="base64" file="corporate_gifts/static/src/binary/product_template/8-image_1920" />
     </record>
-    <record id="product_template_9" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_9" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">USB Sticks</field>
         <field name="list_price">2.5</field>
         <field name="is_storable">True</field>

--- a/corporate_gifts/data/product_template_attribute_line.xml
+++ b/corporate_gifts/data/product_template_attribute_line.xml
@@ -1,21 +1,21 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-    <record id="product_template_attribute_line_1" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_1" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_2" />
         <field name="attribute_id" ref="product_attribute_2" />
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_5'), ref('product_attribute_value_2'), ref('product_attribute_value_4'), ref('product_attribute_value_3'), ref('product_attribute_value_1')])]" />
     </record>
-    <record id="product_template_attribute_line_3" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_3" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_2" />
         <field name="attribute_id" ref="product_attribute_3" />
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_6'), ref('product_attribute_value_7'), ref('product_attribute_value_8'), ref('product_attribute_value_9')])]" />
     </record>
-    <record id="product_template_attribute_line_4" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_4" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_4" />
         <field name="attribute_id" ref="product_attribute_4" />
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_10'), ref('product_attribute_value_11'), ref('product_attribute_value_12')])]" />
     </record>
-    <record id="product_template_attribute_line_5" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_5" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_5" />
         <field name="attribute_id" ref="product_attribute_4" />
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_10'), ref('product_attribute_value_11'), ref('product_attribute_value_12')])]" />

--- a/cosmetics_store/data/product_template.xml
+++ b/cosmetics_store/data/product_template.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-  <record id="product_template_26" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_26" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="name">5 € on your order</field>
     <field name="type">service</field>
     <field name="sale_ok" eval="False"/>
@@ -10,7 +10,7 @@
     <field name="service_type">manual</field>
     <field name="invoice_policy">order</field>
   </record>
-  <record id="product_template_8" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_8" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="image_1920" type="base64" file="cosmetics_store/static/src/binary/product_template/product_template_8"/>
     <field name="name">Gentle Cleansing Milk</field>
     <field name="description"><![CDATA[<div>A soft, milky cleanser for daily use</div>]]></field>
@@ -29,7 +29,7 @@
 </ul><p><strong>Use</strong>: Massage into dry skin, then rinse or remove with a damp cloth. Use morning and/or night.</p>]]></field>
     <field name="public_categ_ids" eval="[(6, 0, [ref('product_public_category_22')])]"/>
   </record>
-  <record id="product_template_9" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_9" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="image_1920" type="base64" file="cosmetics_store/static/src/binary/product_template/product_template_9"/>
     <field name="name">Botanical Face Mist</field>
     <field name="description"><![CDATA[<div>Hydrating spray with lavender and rose hydrosols</div>]]></field>
@@ -48,7 +48,7 @@
 </ul><p><strong>Use</strong>: Spray directly onto the face after cleansing or whenever your skin needs a fresh boost.</p>]]></field>
     <field name="public_categ_ids" eval="[(6, 0, [ref('product_public_category_22')])]"/>
   </record>
-  <record id="product_template_10" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_10" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="image_1920" type="base64" file="cosmetics_store/static/src/binary/product_template/product_template_10"/>
     <field name="name">Balancing Facial Oil	</field>
     <field name="description"><![CDATA[<div>Light blend of jojoba, squalane, and vitamin E</div>]]></field>
@@ -67,7 +67,7 @@
 </ul><p><strong>Use</strong>: Warm 2–3 drops between palms and press gently into skin as the final step of your routine.</p>]]></field>
     <field name="public_categ_ids" eval="[(6, 0, [ref('product_public_category_22')])]"/>
   </record>
-  <record id="product_template_19" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_19" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="image_1920" type="base64" file="cosmetics_store/static/src/binary/product_template/product_template_19"/>
     <field name="name">Soothing Body Cream</field>
     <field name="list_price">12.0</field>
@@ -84,7 +84,7 @@
 </ul><p><strong>Use</strong>: Apply generously after bathing or as needed.</p>]]></field>
     <field name="public_categ_ids" eval="[(6, 0, [ref('product_public_category_20')])]"/>
   </record>
-  <record id="product_template_18" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_18" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="image_1920" type="base64" file="cosmetics_store/static/src/binary/product_template/product_template_18"/>
     <field name="name">Exfoliating Oat Scrub</field>
     <field name="list_price">18.0</field>
@@ -117,7 +117,7 @@
     <field name="invoice_policy">order</field>
     <field name="public_categ_ids" eval="[(6, 0, [ref('product_public_category_25')])]"/>
   </record>
-  <record id="product_template_16" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_16" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="image_1920" type="base64" file="cosmetics_store/static/src/binary/product_template/product_template_16"/>
     <field name="name">Mascara - Volume &amp; Care Black</field>
     <field name="description"><![CDATA[<div>Volumizing black mascara with castor oil for lash strengthening.</div>]]></field>
@@ -136,7 +136,7 @@
 </ul><p><strong>Use</strong>: Apply from root to tip. Layer for more volume if desired.</p>]]></field>
     <field name="public_categ_ids" eval="[(6, 0, [ref('product_public_category_2'), ref('product_public_category_22')])]"/>
   </record>
-  <record id="product_template_11" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_11" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="image_1920" type="base64" file="cosmetics_store/static/src/binary/product_template/product_template_11"/>
     <field name="name">Multi-use Repair Balm</field>
     <field name="description"><![CDATA[<div>Skin support for lips, elbows, and dry patches</div>]]></field>
@@ -154,7 +154,7 @@
 </ul><p><strong>Use</strong>: Apply a small amount to dry or irritated areas. Melts into the skin without residue.</p>]]></field>
     <field name="public_categ_ids" eval="[(6, 0, [ref('product_public_category_20')])]"/>
   </record>
-  <record id="product_template_17" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_17" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="image_1920" type="base64" file="cosmetics_store/static/src/binary/product_template/product_template_17"/>
     <field name="name">Organic Blush</field>
     <field name="categ_id" ref="product_category_6"/>
@@ -172,7 +172,7 @@
 </ul><p><strong>Use</strong>: Dab onto cheeks with fingertips or brush. Blend gently into skin.</p>]]></field>
     <field name="public_categ_ids" eval="[(6, 0, [ref('product_public_category_2'), ref('product_public_category_22')])]"/>
   </record>
-  <record id="product_template_27" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_27" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="name">Pick up in store</field>
     <field name="type">service</field>
     <field name="sale_ok" eval="False"/>
@@ -182,7 +182,7 @@
     <field name="service_type">manual</field>
     <field name="invoice_policy">order</field>
   </record>
-  <record id="product_template_20" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_20" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="image_1920" type="base64" file="cosmetics_store/static/src/binary/product_template/product_template_20"/>
     <field name="name">Conditioner</field>
     <field name="description"><![CDATA[<p><br></p>]]></field>
@@ -200,7 +200,7 @@
 </ul><p><strong>Use</strong>: Glide the bar over wet lengths after shampooing. Leave on for 1–2 minutes, then rinse thoroughly.</p>]]></field>
     <field name="public_categ_ids" eval="[(6, 0, [ref('product_public_category_21')])]"/>
   </record>
-  <record id="product_template_15" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_15" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="image_1920" type="base64" file="cosmetics_store/static/src/binary/product_template/product_template_15"/>
     <field name="name">Natural Matte Lipstick</field>
     <field name="description"><![CDATA[<div><br></div>]]></field>
@@ -219,7 +219,7 @@
 </ul><p><strong>Use</strong>: Apply directly to lips as needed. Can be layered for more color.</p>]]></field>
     <field name="public_categ_ids" eval="[(6, 0, [ref('product_public_category_2'), ref('product_public_category_22')])]"/>
   </record>
-  <record id="product_template_13" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_13" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="image_1920" type="base64" file="cosmetics_store/static/src/binary/product_template/product_template_13"/>
     <field name="name">Solid Shampoo</field>
     <field name="categ_id" ref="product_category_8"/>
@@ -237,7 +237,7 @@
 </ul><p><strong>Use</strong>: Rub between hands or directly on wet hair. Lather, massage, and rinse.</p>]]></field>
     <field name="public_categ_ids" eval="[(6, 0, [ref('product_public_category_21')])]"/>
   </record>
-  <record id="product_template_14" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_14" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="image_1920" type="base64" file="cosmetics_store/static/src/binary/product_template/product_template_14"/>
     <field name="name">Soap Block</field>
     <field name="list_price">6.0</field>

--- a/cosmetics_store/data/product_template_attribute_line.xml
+++ b/cosmetics_store/data/product_template_attribute_line.xml
@@ -1,16 +1,16 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-  <record id="product_template_attribute_line_6" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_6" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_17"/>
     <field name="attribute_id" ref="product_barcodelookup.product_attribute_lookup_1"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_6'), ref('product_attribute_value_7'), ref('product_attribute_value_8')])]"/>
   </record>
-  <record id="product_template_attribute_line_1" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_1" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_13"/>
     <field name="attribute_id" ref="product_attribute_10"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_1'), ref('product_attribute_value_2')])]"/>
   </record>
-  <record id="product_template_attribute_line_5" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_5" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_14"/>
     <field name="attribute_id" ref="product_attribute_10"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_9'), ref('product_attribute_value_10'), ref('product_attribute_value_11')])]"/>

--- a/custom_furniture/data/product_template.xml
+++ b/custom_furniture/data/product_template.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-    <record id="product_template_19" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_19" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Conference Table Metal Legs</field>
         <field name="categ_id" ref="product_category_8"/>
         <field name="sale_ok" eval="False"/>
@@ -11,7 +11,7 @@
         <field name="invoice_policy">order</field>
         <field name="image_1920" type="base64" file="custom_furniture/static/src/binary/product_template/18-image_1920"/>
     </record>
-    <record id="product_template_21" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_21" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Polyurethane Finish 10L</field>
         <field name="sale_ok" eval="False"/>
         <field name="route_ids" eval="[(6, 0, [ref('purchase_stock.route_warehouse0_buy')])]"/>
@@ -20,7 +20,7 @@
         <field name="invoice_policy">order</field>
         <field name="image_1920" type="base64" file="custom_furniture/static/src/binary/product_template/18-image_1920"/>
     </record>
-    <record id="product_template_8" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_8" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Custom conference table</field>
         <field name="categ_id" ref="product_category_7"/>
         <field name="list_price">8000.0</field>

--- a/custom_furniture/data/product_template_attribute_line.xml
+++ b/custom_furniture/data/product_template_attribute_line.xml
@@ -1,21 +1,21 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-    <record id="product_template_attribute_line_1" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_1" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="attribute_id" ref="product_barcodelookup.product_attribute_lookup_1"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_1'), ref('product_attribute_value_2'), ref('product_attribute_value_3'), ref('product_attribute_value_4')])]"/>
         <field name="product_tmpl_id" ref="product_template_19"/>
     </record>
-    <record id="product_template_attribute_line_2" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_2" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="attribute_id" ref="product_barcodelookup.product_attribute_lookup_1"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_5'), ref('product_attribute_value_6')])]"/>
         <field name="product_tmpl_id" ref="product_template_21"/>
     </record>
-    <record id="product_template_attribute_line_3" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_3" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="attribute_id" ref="product_barcodelookup.product_attribute_lookup_1"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_1'), ref('product_attribute_value_2'), ref('product_attribute_value_3'), ref('product_attribute_value_4')])]"/>
         <field name="product_tmpl_id" ref="product_template_8"/>
     </record>
-    <record id="product_template_attribute_line_4" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_4" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="attribute_id" ref="product_barcodelookup.product_attribute_lookup_1"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_5')])]"/>
         <field name="product_tmpl_id" ref="product_template_8"/>

--- a/driving_school/data/product_template.xml
+++ b/driving_school/data/product_template.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-    <record id="product_template_30" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_30" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">A Practice Pack : Lessons + Exam</field>
         <field name="image_1920" type="base64" file="driving_school/static/src/binary/appointment_type/4-image_1920"/>
         <field name="type">service</field>
@@ -12,7 +12,7 @@
         <field name="description_ecommerce"><![CDATA[<div data-oe-version="2.0">25 sessions of 1h practical lesson with an instructor by group of 2 learners</div><div>1 exam included</div><div><strong><br></strong></div><div><strong>We are proud to reach 95% pass rate with this format!</strong></div>]]></field>
         <field name="website_sequence">10165</field>
     </record>
-    <record id="product_template_2" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_2" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">A Theory Pack : Lessons + Exam</field>
         <field name="image_1920" type="base64" file="driving_school/static/src/binary/appointment_type/1-image_1920"/>
         <field name="type">service</field>
@@ -24,7 +24,7 @@
         <field name="description_ecommerce"><![CDATA[<div data-oe-version="2.0">12 sessions of 1h theory lesson in our projection room with an instructor available to further exchange on challenging cases to wrap up the lesson</div><div>1 exam included</div><div><strong><br></strong></div><div><strong>We are proud to reach 95% pass rate with this format!</strong></div>]]></field>
         <field name="website_sequence">10175</field>
     </record>
-    <record id="product_template_31" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_31" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">B Practice Pack : Lessons + Exam</field>
         <field name="image_1920" type="base64" file="driving_school/static/src/binary/appointment_type/5-image_1920.jpeg"/>
         <field name="type">service</field>
@@ -36,7 +36,7 @@
         <field name="description_ecommerce"><![CDATA[<div data-oe-version="2.0">25 sessions of 1h practical lesson with a dedicated&nbsp;instructor</div><div>1 exam included</div><div><strong><br></strong></div><div><strong>We are proud to reach 95% pass rate with this format!</strong></div>]]></field>
         <field name="website_sequence">10035</field>
     </record>
-    <record id="product_template_14" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_14" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">B Theory Pack : Lessons + Exam</field>
         <field name="image_1920" type="base64" file="driving_school/static/src/binary/appointment_type/1-image_1920"/>
         <field name="type">service</field>
@@ -48,7 +48,7 @@
         <field name="description_ecommerce"><![CDATA[<div data-oe-version="2.0">12 sessions of 1h theory lesson in our projection room with an instructor available to further exchange on challenging cases to wrap up the lesson</div><div>1 exam included</div><div><strong><br></strong></div><div><strong>We are proud to reach 95% pass rate with this format!</strong></div>]]></field>
         <field name="website_sequence">10040</field>
     </record>
-    <record id="product_template_32" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_32" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">C Practice Pack : Lessons + Exam</field>
         <field name="image_1920" type="base64" file="driving_school/static/src/binary/product_template/24-image_1920.jpg"/>
         <field name="type">service</field>
@@ -60,7 +60,7 @@
         <field name="description_ecommerce"><![CDATA[<div data-oe-version="2.0">25 sessions of 1h practical lesson with a dedicated instructor</div><div>1 exam included</div><div><strong><br></strong></div><div><strong>We are proud to reach 95% pass rate with this format!</strong></div>]]></field>
         <field name="website_sequence">10045</field>
     </record>
-    <record id="product_template_17" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_17" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">C+D Theory Pack : Lessons + Exam</field>
         <field name="image_1920" type="base64" file="driving_school/static/src/binary/appointment_type/1-image_1920"/>
         <field name="type">service</field>
@@ -72,7 +72,7 @@
         <field name="description_ecommerce"><![CDATA[<div data-oe-version="2.0">12 sessions of 1h theory lesson in our projection room with an instructor available to further exchange on challenging cases to wrap up the lesson</div><div>1 exam included</div><div><strong><br></strong></div><div><strong>We are proud to reach 95% pass rate with this format!</strong></div>]]></field>
         <field name="website_sequence">10170</field>
     </record>
-    <record id="product_template_46" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_46" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">10% discount on Practical Lessons</field>
         <field name="type">service</field>
         <field name="sale_ok" eval="False"/>
@@ -82,7 +82,7 @@
         <field name="invoice_policy">order</field>
         <field name="website_sequence">10190</field>
     </record>
-    <record id="product_template_45" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_45" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">10% discount on Practical Lessons</field>
         <field name="type">service</field>
         <field name="sale_ok" eval="False"/>
@@ -92,7 +92,7 @@
         <field name="invoice_policy">order</field>
         <field name="website_sequence">10185</field>
     </record>
-    <record id="product_template_47" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_47" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">20% discount on Theory Lessons</field>
         <field name="type">service</field>
         <field name="sale_ok" eval="False"/>
@@ -102,7 +102,7 @@
         <field name="invoice_policy">order</field>
         <field name="website_sequence">10195</field>
     </record>
-    <record id="product_template_22" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_22" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">A Practical Exam</field>
         <field name="image_1920" type="base64" file="driving_school/static/src/binary/appointment_type/4-image_1920"/>
         <field name="type">service</field>
@@ -112,7 +112,7 @@
         <field name="invoice_policy">order</field>
         <field name="website_sequence">10050</field>
     </record>
-    <record id="product_template_26" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_26" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">A Practical Lesson</field>
         <field name="image_1920" type="base64" file="driving_school/static/src/binary/appointment_type/4-image_1920"/>
         <field name="type">service</field>
@@ -121,7 +121,7 @@
         <field name="invoice_policy">order</field>
         <field name="website_sequence">10065</field>
     </record>
-    <record id="product_template_7" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_7" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">A Theory Exam</field>
         <field name="image_1920" type="base64" file="driving_school/static/src/binary/appointment_type/1-image_1920"/>
         <field name="type">service</field>
@@ -131,7 +131,7 @@
         <field name="invoice_policy">order</field>
         <field name="website_sequence">10100</field>
     </record>
-    <record id="product_template_18" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_18" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">A Theory Lesson</field>
         <field name="image_1920" type="base64" file="driving_school/static/src/binary/appointment_type/1-image_1920"/>
         <field name="type">service</field>
@@ -140,7 +140,7 @@
         <field name="invoice_policy">order</field>
         <field name="website_sequence">10150</field>
     </record>
-    <record id="product_template_23" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_23" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">B Practical Exam</field>
         <field name="image_1920" type="base64" file="driving_school/static/src/binary/appointment_type/5-image_1920.jpeg"/>
         <field name="type">service</field>
@@ -150,7 +150,7 @@
         <field name="invoice_policy">order</field>
         <field name="website_sequence">10075</field>
     </record>
-    <record id="product_template_27" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_27" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">B Practical Lesson</field>
         <field name="image_1920" type="base64" file="driving_school/static/src/binary/appointment_type/5-image_1920.jpeg"/>
         <field name="type">service</field>
@@ -159,7 +159,7 @@
         <field name="invoice_policy">order</field>
         <field name="website_sequence">10090</field>
     </record>
-    <record id="product_template_12" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_12" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">B Theory Exam</field>
         <field name="image_1920" type="base64" file="driving_school/static/src/binary/appointment_type/1-image_1920"/>
         <field name="type">service</field>
@@ -169,7 +169,7 @@
         <field name="invoice_policy">order</field>
         <field name="website_sequence">10140</field>
     </record>
-    <record id="product_template_8" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_8" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">B Theory Lesson</field>
         <field name="image_1920" type="base64" file="driving_school/static/src/binary/appointment_type/1-image_1920"/>
         <field name="type">service</field>
@@ -178,7 +178,7 @@
         <field name="invoice_policy">order</field>
         <field name="website_sequence">10155</field>
     </record>
-    <record id="product_template_24" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_24" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">C Practical Exam</field>
         <field name="image_1920" type="base64" file="driving_school/static/src/binary/product_template/24-image_1920.jpg"/>
         <field name="type">service</field>
@@ -188,7 +188,7 @@
         <field name="invoice_policy">order</field>
         <field name="website_sequence">10080</field>
     </record>
-    <record id="product_template_28" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_28" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">C Practical Lesson</field>
         <field name="image_1920" type="base64" file="driving_school/static/src/binary/product_template/24-image_1920.jpg"/>
         <field name="type">service</field>
@@ -197,7 +197,7 @@
         <field name="invoice_policy">order</field>
         <field name="website_sequence">10055</field>
     </record>
-    <record id="product_template_15" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_15" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">C+D Theory Exam</field>
         <field name="image_1920" type="base64" file="driving_school/static/src/binary/appointment_type/1-image_1920"/>
         <field name="type">service</field>
@@ -207,7 +207,7 @@
         <field name="invoice_policy">order</field>
         <field name="website_sequence">10145</field>
     </record>
-    <record id="product_template_13" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_13" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">C+D Theory Lesson</field>
         <field name="image_1920" type="base64" file="driving_school/static/src/binary/appointment_type/1-image_1920"/>
         <field name="type">service</field>
@@ -216,7 +216,7 @@
         <field name="invoice_policy">order</field>
         <field name="website_sequence">10160</field>
     </record>
-    <record id="product_template_5" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_5" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Gift Card</field>
         <field name="type">service</field>
         <field name="sale_ok" eval="False"/>
@@ -226,7 +226,7 @@
         <field name="invoice_policy">order</field>
         <field name="website_sequence">10010</field>
     </record>
-    <record id="product_template_11" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_11" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Learner magnet</field>
         <field name="image_1920" type="base64" file="driving_school/static/src/binary/product_template/11-image_1920"/>
         <field name="list_price">16.0</field>
@@ -234,7 +234,7 @@
         <field name="invoice_policy">order</field>
         <field name="website_sequence">10025</field>
     </record>
-    <record id="product_template_10" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_10" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Learner sticker</field>
         <field name="image_1920" type="base64" file="driving_school/static/src/binary/product_template/10-image_1920"/>
         <field name="list_price">9.0</field>
@@ -242,7 +242,7 @@
         <field name="invoice_policy">order</field>
         <field name="website_sequence">10005</field>
     </record>
-    <record id="product_template_34" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_34" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Prepaid Practical Exam A</field>
         <field name="type">service</field>
         <field name="sale_ok" eval="False"/>
@@ -252,7 +252,7 @@
         <field name="invoice_policy">order</field>
         <field name="website_sequence">10110</field>
     </record>
-    <record id="product_template_38" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_38" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Prepaid Practical Exam B</field>
         <field name="type">service</field>
         <field name="sale_ok" eval="False"/>
@@ -262,7 +262,7 @@
         <field name="invoice_policy">order</field>
         <field name="website_sequence">10085</field>
     </record>
-    <record id="product_template_42" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_42" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Prepaid Practical Exam C</field>
         <field name="type">service</field>
         <field name="sale_ok" eval="False"/>
@@ -272,7 +272,7 @@
         <field name="invoice_policy">order</field>
         <field name="website_sequence">10130</field>
     </record>
-    <record id="product_template_35" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_35" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Prepaid Practical Lesson A</field>
         <field name="type">service</field>
         <field name="sale_ok" eval="False"/>
@@ -282,7 +282,7 @@
         <field name="invoice_policy">order</field>
         <field name="website_sequence">10115</field>
     </record>
-    <record id="product_template_39" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_39" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Prepaid Practical Lesson B</field>
         <field name="type">service</field>
         <field name="sale_ok" eval="False"/>
@@ -292,7 +292,7 @@
         <field name="invoice_policy">order</field>
         <field name="website_sequence">10095</field>
     </record>
-    <record id="product_template_43" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_43" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Prepaid Practical Lesson C</field>
         <field name="type">service</field>
         <field name="sale_ok" eval="False"/>
@@ -302,7 +302,7 @@
         <field name="invoice_policy">order</field>
         <field name="website_sequence">10135</field>
     </record>
-    <record id="product_template_6" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_6" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Prepaid Theory Exam A</field>
         <field name="type">service</field>
         <field name="sale_ok" eval="False"/>
@@ -312,7 +312,7 @@
         <field name="invoice_policy">order</field>
         <field name="website_sequence">10060</field>
     </record>
-    <record id="product_template_36" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_36" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Prepaid Theory Exam B</field>
         <field name="type">service</field>
         <field name="sale_ok" eval="False"/>
@@ -322,7 +322,7 @@
         <field name="invoice_policy">order</field>
         <field name="website_sequence">10030</field>
     </record>
-    <record id="product_template_40" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_40" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Prepaid Theory Exam C+D</field>
         <field name="type">service</field>
         <field name="sale_ok" eval="False"/>
@@ -332,7 +332,7 @@
         <field name="invoice_policy">order</field>
         <field name="website_sequence">10120</field>
     </record>
-    <record id="product_template_9" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_9" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Prepaid Theory Lesson A</field>
         <field name="type">service</field>
         <field name="sale_ok" eval="False"/>
@@ -342,7 +342,7 @@
         <field name="invoice_policy">order</field>
         <field name="website_sequence">10105</field>
     </record>
-    <record id="product_template_37" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_37" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Prepaid Theory Lesson B</field>
         <field name="type">service</field>
         <field name="sale_ok" eval="False"/>
@@ -352,7 +352,7 @@
         <field name="invoice_policy">order</field>
         <field name="website_sequence">10070</field>
     </record>
-    <record id="product_template_41" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_41" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Prepaid Theory Lesson C+D</field>
         <field name="type">service</field>
         <field name="sale_ok" eval="False"/>

--- a/driving_school/data/product_template_attribute_line.xml
+++ b/driving_school/data/product_template_attribute_line.xml
@@ -1,181 +1,181 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo auto_sequence="1" noupdate="1">
-  <record id="product_template_attribute_line_12" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_12" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_30"/>
     <field name="attribute_id" ref="product_attribute_10"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_1')])]"/>
   </record>
-  <record id="product_template_attribute_line_14" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_14" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_2"/>
     <field name="attribute_id" ref="product_attribute_10"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_1')])]"/>
   </record>
-  <record id="product_template_attribute_line_16" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_16" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_31"/>
     <field name="attribute_id" ref="product_attribute_10"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_2')])]"/>
   </record>
-  <record id="product_template_attribute_line_18" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_18" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_14"/>
     <field name="attribute_id" ref="product_attribute_10"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_2')])]"/>
   </record>
-  <record id="product_template_attribute_line_20" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_20" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_32"/>
     <field name="attribute_id" ref="product_attribute_10"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_3')])]"/>
   </record>
-  <record id="product_template_attribute_line_22" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_22" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_17"/>
     <field name="attribute_id" ref="product_attribute_10"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_3'), ref('product_attribute_value_4')])]"/>
   </record>
-  <record id="product_template_attribute_line_24" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_24" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_22"/>
     <field name="attribute_id" ref="product_attribute_10"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_1')])]"/>
   </record>
-  <record id="product_template_attribute_line_26" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_26" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_26"/>
     <field name="attribute_id" ref="product_attribute_10"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_1')])]"/>
   </record>
-  <record id="product_template_attribute_line_28" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_28" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_7"/>
     <field name="attribute_id" ref="product_attribute_10"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_1')])]"/>
   </record>
-  <record id="product_template_attribute_line_30" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_30" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_18"/>
     <field name="attribute_id" ref="product_attribute_10"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_1')])]"/>
   </record>
-  <record id="product_template_attribute_line_32" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_32" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_23"/>
     <field name="attribute_id" ref="product_attribute_10"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_2')])]"/>
   </record>
-  <record id="product_template_attribute_line_34" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_34" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_27"/>
     <field name="attribute_id" ref="product_attribute_10"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_2')])]"/>
   </record>
-  <record id="product_template_attribute_line_36" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_36" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_12"/>
     <field name="attribute_id" ref="product_attribute_10"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_2')])]"/>
   </record>
-  <record id="product_template_attribute_line_38" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_38" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_8"/>
     <field name="attribute_id" ref="product_attribute_10"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_2')])]"/>
   </record>
-  <record id="product_template_attribute_line_40" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_40" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_24"/>
     <field name="attribute_id" ref="product_attribute_10"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_3')])]"/>
   </record>
-  <record id="product_template_attribute_line_42" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_42" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_28"/>
     <field name="attribute_id" ref="product_attribute_10"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_3')])]"/>
   </record>
-  <record id="product_template_attribute_line_44" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_44" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_15"/>
     <field name="attribute_id" ref="product_attribute_10"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_3'), ref('product_attribute_value_4')])]"/>
   </record>
-  <record id="product_template_attribute_line_46" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_46" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_13"/>
     <field name="attribute_id" ref="product_attribute_10"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_3'), ref('product_attribute_value_4')])]"/>
   </record>
-  <record id="product_template_attribute_line_13" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_13" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_30"/>
     <field name="attribute_id" ref="product_attribute_11"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_5')])]"/>
   </record>
-  <record id="product_template_attribute_line_15" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_15" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_2"/>
     <field name="attribute_id" ref="product_attribute_11"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_6')])]"/>
   </record>
-  <record id="product_template_attribute_line_17" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_17" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_31"/>
     <field name="attribute_id" ref="product_attribute_11"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_5')])]"/>
   </record>
-  <record id="product_template_attribute_line_19" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_19" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_14"/>
     <field name="attribute_id" ref="product_attribute_11"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_6')])]"/>
   </record>
-  <record id="product_template_attribute_line_21" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_21" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_32"/>
     <field name="attribute_id" ref="product_attribute_11"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_5')])]"/>
   </record>
-  <record id="product_template_attribute_line_23" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_23" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_17"/>
     <field name="attribute_id" ref="product_attribute_11"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_6')])]"/>
   </record>
-  <record id="product_template_attribute_line_25" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_25" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_22"/>
     <field name="attribute_id" ref="product_attribute_11"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_5')])]"/>
   </record>
-  <record id="product_template_attribute_line_27" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_27" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_26"/>
     <field name="attribute_id" ref="product_attribute_11"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_5')])]"/>
   </record>
-  <record id="product_template_attribute_line_29" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_29" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_7"/>
     <field name="attribute_id" ref="product_attribute_11"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_6')])]"/>
   </record>
-  <record id="product_template_attribute_line_31" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_31" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_18"/>
     <field name="attribute_id" ref="product_attribute_11"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_6')])]"/>
   </record>
-  <record id="product_template_attribute_line_33" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_33" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_23"/>
     <field name="attribute_id" ref="product_attribute_11"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_5')])]"/>
   </record>
-  <record id="product_template_attribute_line_35" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_35" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_27"/>
     <field name="attribute_id" ref="product_attribute_11"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_5')])]"/>
   </record>
-  <record id="product_template_attribute_line_37" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_37" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_12"/>
     <field name="attribute_id" ref="product_attribute_11"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_6')])]"/>
   </record>
-  <record id="product_template_attribute_line_39" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_39" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_8"/>
     <field name="attribute_id" ref="product_attribute_11"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_6')])]"/>
   </record>
-  <record id="product_template_attribute_line_41" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_41" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_24"/>
     <field name="attribute_id" ref="product_attribute_11"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_5')])]"/>
   </record>
-  <record id="product_template_attribute_line_43" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_43" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_28"/>
     <field name="attribute_id" ref="product_attribute_11"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_5')])]"/>
   </record>
-  <record id="product_template_attribute_line_45" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_45" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_15"/>
     <field name="attribute_id" ref="product_attribute_11"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_6')])]"/>
   </record>
-  <record id="product_template_attribute_line_47" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_47" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_13"/>
     <field name="attribute_id" ref="product_attribute_11"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_6')])]"/>

--- a/dropshipping/data/product_template.xml
+++ b/dropshipping/data/product_template.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-  <record id="product_template_1" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_1" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="image_1920" type="base64" file="dropshipping/static/src/binary/product_template/56-image_1920"/>
     <field name="name">Aegis Flex</field>
     <field name="description"><![CDATA[<p>Premium phone case with wallet, shockproof features.</p>]]></field>
@@ -15,7 +15,7 @@
     <field name="invoice_policy">order</field>
     <field name="website_sequence">10010</field>
   </record>
-  <record id="product_template_2" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_2" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="image_1920" type="base64" file="dropshipping/static/src/binary/product_template/49-image_1920"/>
     <field name="name">Aurora Shield</field>
     <field name="description"><![CDATA[<p>Premium phone case with kickstand, eco-friendly features.</p>]]></field>
@@ -30,7 +30,7 @@
     <field name="invoice_policy">order</field>
     <field name="website_sequence">10010</field>
   </record>
-  <record id="product_template_3" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_3" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="image_1920" type="base64" file="dropshipping/static/src/binary/product_template/62-image_1920"/>
     <field name="name">Crystal Grip</field>
     <field name="description"><![CDATA[<p>Premium phone case with slim, eco-friendly features.</p>]]></field>
@@ -45,7 +45,7 @@
     <field name="invoice_policy">order</field>
     <field name="website_sequence">10010</field>
   </record>
-  <record id="product_template_4" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_4" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="image_1920" type="base64" file="dropshipping/static/src/binary/product_template/52-image_1920"/>
     <field name="name">Eclipse Shell</field>
     <field name="description"><![CDATA[<p>Premium phone case with eco-friendly, wallet features.</p>]]></field>
@@ -60,7 +60,7 @@
     <field name="invoice_policy">order</field>
     <field name="website_sequence">10010</field>
   </record>
-  <record id="product_template_63" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_63" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="name">Express Delivery</field>
     <field name="type">service</field>
     <field name="sale_ok" eval="False"/>
@@ -73,7 +73,7 @@
     <field name="website_sequence">10015</field>
     <field name="base_unit_count">1.0</field>
   </record>
-  <record id="product_template_5" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_5" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="image_1920" type="base64" file="dropshipping/static/src/binary/product_template/54-image_1920"/>
     <field name="name">Fortress Max</field>
     <field name="description"><![CDATA[<p>Premium phone case with kickstand, shockproof features.</p>]]></field>
@@ -88,7 +88,7 @@
     <field name="invoice_policy">order</field>
     <field name="website_sequence">10010</field>
   </record>
-  <record id="product_template_6" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_6" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="image_1920" type="base64" file="dropshipping/static/src/binary/product_template/55-image_1920"/>
     <field name="name">Infinity Edge</field>
     <field name="description"><![CDATA[<p>Premium phone case with kickstand, eco-friendly features.</p>]]></field>
@@ -103,7 +103,7 @@
     <field name="invoice_policy">order</field>
     <field name="website_sequence">10010</field>
   </record>
-  <record id="product_template_7" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_7" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="image_1920" type="base64" file="dropshipping/static/src/binary/product_template/50-image_1920"/>
     <field name="name">Nebula Grip</field>
     <field name="description"><![CDATA[<p>Premium phone case with shockproof, kickstand features.</p>]]></field>
@@ -118,7 +118,7 @@
     <field name="invoice_policy">order</field>
     <field name="website_sequence">10010</field>
   </record>
-  <record id="product_template_8" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_8" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="image_1920" type="base64" file="dropshipping/static/src/binary/product_template/58-image_1920"/>
     <field name="name">Nimbus Case</field>
     <field name="description"><![CDATA[<p>Premium phone case with eco-friendly, slim features.</p>]]></field>
@@ -133,7 +133,7 @@
     <field name="invoice_policy">order</field>
     <field name="website_sequence">10010</field>
   </record>
-  <record id="product_template_9" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_9" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="image_1920" type="base64" file="dropshipping/static/src/binary/product_template/61-image_1920"/>
     <field name="name">Obsidian Frame</field>
     <field name="description"><![CDATA[<p>Premium phone case with wireless charging compatible, eco-friendly features.</p>]]></field>
@@ -148,7 +148,7 @@
     <field name="invoice_policy">order</field>
     <field name="website_sequence">10010</field>
   </record>
-  <record id="product_template_10" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_10" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="image_1920" type="base64" file="dropshipping/static/src/binary/product_template/59-image_1920"/>
     <field name="name">Pulse Guard</field>
     <field name="description"><![CDATA[<p>Premium phone case with wallet, wireless charging compatible features.</p>]]></field>
@@ -163,7 +163,7 @@
     <field name="invoice_policy">order</field>
     <field name="website_sequence">10010</field>
   </record>
-  <record id="product_template_11" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_11" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="image_1920" type="base64" file="dropshipping/static/src/binary/product_template/57-image_1920"/>
     <field name="name">Quantum Cover</field>
     <field name="description"><![CDATA[<p>Premium phone case with wallet, kickstand features.</p>]]></field>
@@ -178,7 +178,7 @@
     <field name="invoice_policy">order</field>
     <field name="website_sequence">10010</field>
   </record>
-  <record id="product_template_12" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_12" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="image_1920" type="base64" file="dropshipping/static/src/binary/product_template/51-image_1920"/>
     <field name="name">Stealth Armor</field>
     <field name="description"><![CDATA[<p>Premium phone case with shockproof, slim features.</p>]]></field>
@@ -193,7 +193,7 @@
     <field name="invoice_policy">order</field>
     <field name="website_sequence">10010</field>
   </record>
-  <record id="product_template_13" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_13" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="image_1920" type="base64" file="dropshipping/static/src/binary/product_template/48-image_1920"/>
     <field name="name">Titan Guard</field>
     <field name="description"><![CDATA[<p>Premium phone case with wallet, eco-friendly features.</p>]]></field>
@@ -208,7 +208,7 @@
     <field name="invoice_policy">order</field>
     <field name="website_sequence">10010</field>
   </record>
-  <record id="product_template_14" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_14" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="image_1920" type="base64" file="dropshipping/static/src/binary/product_template/60-image_1920"/>
     <field name="name">Vortex Shield</field>
     <field name="description"><![CDATA[<p>Premium phone case with wireless charging compatible, shockproof features.</p>]]></field>
@@ -224,7 +224,7 @@
     <field name="invoice_policy">order</field>
     <field name="website_sequence">10010</field>
   </record>
-  <record id="product_template_15" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_15" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="image_1920" type="base64" file="dropshipping/static/src/binary/product_template/53-image_1920"/>
     <field name="name">Zenith Wrap</field>
     <field name="description"><![CDATA[<p>Premium phone case with kickstand, wallet features.</p>]]></field>

--- a/dropshipping/data/product_template_attribute_line.xml
+++ b/dropshipping/data/product_template_attribute_line.xml
@@ -1,301 +1,301 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1" auto_sequence="1">
-  <record id="product_template_attribute_line_1" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_1" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_1"/>
     <field name="attribute_id" ref="website_sale.product_attribute_brand"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_9')])]"/>
   </record>
-  <record id="product_template_attribute_line_5" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_5" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_2"/>
     <field name="attribute_id" ref="website_sale.product_attribute_brand"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_16')])]"/>
   </record>
-  <record id="product_template_attribute_line_9" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_9" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_3"/>
     <field name="attribute_id" ref="website_sale.product_attribute_brand"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_18')])]"/>
   </record>
-  <record id="product_template_attribute_line_13" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_13" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_4"/>
     <field name="attribute_id" ref="website_sale.product_attribute_brand"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_16')])]"/>
   </record>
-  <record id="product_template_attribute_line_17" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_17" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_5"/>
     <field name="attribute_id" ref="website_sale.product_attribute_brand"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_20')])]"/>
   </record>
-  <record id="product_template_attribute_line_21" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_21" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_6"/>
     <field name="attribute_id" ref="website_sale.product_attribute_brand"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_18')])]"/>
   </record>
-  <record id="product_template_attribute_line_25" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_25" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_7"/>
     <field name="attribute_id" ref="website_sale.product_attribute_brand"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_23')])]"/>
   </record>
-  <record id="product_template_attribute_line_29" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_29" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_8"/>
     <field name="attribute_id" ref="website_sale.product_attribute_brand"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_23')])]"/>
   </record>
-  <record id="product_template_attribute_line_33" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_33" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_9"/>
     <field name="attribute_id" ref="website_sale.product_attribute_brand"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_16')])]"/>
   </record>
-  <record id="product_template_attribute_line_37" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_37" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_10"/>
     <field name="attribute_id" ref="website_sale.product_attribute_brand"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_20')])]"/>
   </record>
-  <record id="product_template_attribute_line_41" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_41" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_11"/>
     <field name="attribute_id" ref="website_sale.product_attribute_brand"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_20')])]"/>
   </record>
-  <record id="product_template_attribute_line_45" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_45" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_12"/>
     <field name="attribute_id" ref="website_sale.product_attribute_brand"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_18')])]"/>
   </record>
-  <record id="product_template_attribute_line_49" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_49" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_13"/>
     <field name="attribute_id" ref="website_sale.product_attribute_brand"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_9')])]"/>
   </record>
-  <record id="product_template_attribute_line_53" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_53" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_14"/>
     <field name="attribute_id" ref="website_sale.product_attribute_brand"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_9')])]"/>
   </record>
-  <record id="product_template_attribute_line_57" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_57" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_15"/>
     <field name="attribute_id" ref="website_sale.product_attribute_brand"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_9')])]"/>
   </record>
-  <record id="product_template_attribute_line_2" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_2" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_1"/>
     <field name="attribute_id" ref="product_barcodelookup.product_attribute_lookup_1"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_10')])]"/>
   </record>
-  <record id="product_template_attribute_line_6" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_6" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_2"/>
     <field name="attribute_id" ref="product_barcodelookup.product_attribute_lookup_1"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_17')])]"/>
   </record>
-  <record id="product_template_attribute_line_10" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_10" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_3"/>
     <field name="attribute_id" ref="product_barcodelookup.product_attribute_lookup_1"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_2')])]"/>
   </record>
-  <record id="product_template_attribute_line_14" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_14" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_4"/>
     <field name="attribute_id" ref="product_barcodelookup.product_attribute_lookup_1"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_19')])]"/>
   </record>
-  <record id="product_template_attribute_line_18" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_18" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_5"/>
     <field name="attribute_id" ref="product_barcodelookup.product_attribute_lookup_1"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_21')])]"/>
   </record>
-  <record id="product_template_attribute_line_22" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_22" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_6"/>
     <field name="attribute_id" ref="product_barcodelookup.product_attribute_lookup_1"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_4')])]"/>
   </record>
-  <record id="product_template_attribute_line_26" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_26" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_7"/>
     <field name="attribute_id" ref="product_barcodelookup.product_attribute_lookup_1"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_24')])]"/>
   </record>
-  <record id="product_template_attribute_line_30" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_30" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_8"/>
     <field name="attribute_id" ref="product_barcodelookup.product_attribute_lookup_1"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_25')])]"/>
   </record>
-  <record id="product_template_attribute_line_34" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_34" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_9"/>
     <field name="attribute_id" ref="product_barcodelookup.product_attribute_lookup_1"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_10')])]"/>
   </record>
-  <record id="product_template_attribute_line_38" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_38" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_10"/>
     <field name="attribute_id" ref="product_barcodelookup.product_attribute_lookup_1"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_1')])]"/>
   </record>
-  <record id="product_template_attribute_line_42" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_42" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_11"/>
     <field name="attribute_id" ref="product_barcodelookup.product_attribute_lookup_1"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_10')])]"/>
   </record>
-  <record id="product_template_attribute_line_46" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_46" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_12"/>
     <field name="attribute_id" ref="product_barcodelookup.product_attribute_lookup_1"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_10')])]"/>
   </record>
-  <record id="product_template_attribute_line_50" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_50" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_13"/>
     <field name="attribute_id" ref="product_barcodelookup.product_attribute_lookup_1"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_21')])]"/>
   </record>
-  <record id="product_template_attribute_line_54" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_54" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_14"/>
     <field name="attribute_id" ref="product_barcodelookup.product_attribute_lookup_1"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_10')])]"/>
   </record>
-  <record id="product_template_attribute_line_58" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_58" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_15"/>
     <field name="attribute_id" ref="product_barcodelookup.product_attribute_lookup_1"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_1')])]"/>
   </record>
-  <record id="product_template_attribute_line_3" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_3" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_1"/>
     <field name="attribute_id" ref="product_barcodelookup.product_attribute_lookup_3"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_6')])]"/>
   </record>
-  <record id="product_template_attribute_line_7" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_7" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_2"/>
     <field name="attribute_id" ref="product_barcodelookup.product_attribute_lookup_3"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_8')])]"/>
   </record>
-  <record id="product_template_attribute_line_11" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_11" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_3"/>
     <field name="attribute_id" ref="product_barcodelookup.product_attribute_lookup_3"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_6')])]"/>
   </record>
-  <record id="product_template_attribute_line_15" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_15" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_4"/>
     <field name="attribute_id" ref="product_barcodelookup.product_attribute_lookup_3"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_8')])]"/>
   </record>
-  <record id="product_template_attribute_line_19" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_19" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_5"/>
     <field name="attribute_id" ref="product_barcodelookup.product_attribute_lookup_3"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_22')])]"/>
   </record>
-  <record id="product_template_attribute_line_23" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_23" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_6"/>
     <field name="attribute_id" ref="product_barcodelookup.product_attribute_lookup_3"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_6')])]"/>
   </record>
-  <record id="product_template_attribute_line_27" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_27" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_7"/>
     <field name="attribute_id" ref="product_barcodelookup.product_attribute_lookup_3"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_8')])]"/>
   </record>
-  <record id="product_template_attribute_line_31" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_31" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_8"/>
     <field name="attribute_id" ref="product_barcodelookup.product_attribute_lookup_3"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_8')])]"/>
   </record>
-  <record id="product_template_attribute_line_35" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_35" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_9"/>
     <field name="attribute_id" ref="product_barcodelookup.product_attribute_lookup_3"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_6')])]"/>
   </record>
-  <record id="product_template_attribute_line_39" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_39" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_10"/>
     <field name="attribute_id" ref="product_barcodelookup.product_attribute_lookup_3"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_22')])]"/>
   </record>
-  <record id="product_template_attribute_line_43" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_43" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_11"/>
     <field name="attribute_id" ref="product_barcodelookup.product_attribute_lookup_3"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_22')])]"/>
   </record>
-  <record id="product_template_attribute_line_47" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_47" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_12"/>
     <field name="attribute_id" ref="product_barcodelookup.product_attribute_lookup_3"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_22')])]"/>
   </record>
-  <record id="product_template_attribute_line_51" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_51" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_13"/>
     <field name="attribute_id" ref="product_barcodelookup.product_attribute_lookup_3"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_8')])]"/>
   </record>
-  <record id="product_template_attribute_line_55" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_55" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_14"/>
     <field name="attribute_id" ref="product_barcodelookup.product_attribute_lookup_3"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_22')])]"/>
   </record>
-  <record id="product_template_attribute_line_59" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_59" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_15"/>
     <field name="attribute_id" ref="product_barcodelookup.product_attribute_lookup_3"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_8')])]"/>
   </record>
-  <record id="product_template_attribute_line_4" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_4" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_1"/>
     <field name="attribute_id" ref="product_attribute_10"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_15'), ref('product_attribute_value_14'), ref('product_attribute_value_11'), ref('product_attribute_value_12'), ref('product_attribute_value_13')])]"/>
   </record>
-  <record id="product_template_attribute_line_8" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_8" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_2"/>
     <field name="attribute_id" ref="product_attribute_10"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_12'), ref('product_attribute_value_13')])]"/>
   </record>
-  <record id="product_template_attribute_line_12" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_12" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_3"/>
     <field name="attribute_id" ref="product_attribute_10"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_11'), ref('product_attribute_value_12'), ref('product_attribute_value_13')])]"/>
   </record>
-  <record id="product_template_attribute_line_16" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_16" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_4"/>
     <field name="attribute_id" ref="product_attribute_10"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_11'), ref('product_attribute_value_12'), ref('product_attribute_value_13')])]"/>
   </record>
-  <record id="product_template_attribute_line_20" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_20" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_5"/>
     <field name="attribute_id" ref="product_attribute_10"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_12'), ref('product_attribute_value_13')])]"/>
   </record>
-  <record id="product_template_attribute_line_24" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_24" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_6"/>
     <field name="attribute_id" ref="product_attribute_10"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_15'), ref('product_attribute_value_14'), ref('product_attribute_value_11'), ref('product_attribute_value_12')])]"/>
   </record>
-  <record id="product_template_attribute_line_28" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_28" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_7"/>
     <field name="attribute_id" ref="product_attribute_10"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_12'), ref('product_attribute_value_13')])]"/>
   </record>
-  <record id="product_template_attribute_line_32" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_32" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_8"/>
     <field name="attribute_id" ref="product_attribute_10"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_11'), ref('product_attribute_value_12'), ref('product_attribute_value_13')])]"/>
   </record>
-  <record id="product_template_attribute_line_36" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_36" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_9"/>
     <field name="attribute_id" ref="product_attribute_10"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_12'), ref('product_attribute_value_13')])]"/>
   </record>
-  <record id="product_template_attribute_line_40" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_40" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_10"/>
     <field name="attribute_id" ref="product_attribute_10"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_11'), ref('product_attribute_value_12'), ref('product_attribute_value_13')])]"/>
   </record>
-  <record id="product_template_attribute_line_44" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_44" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_11"/>
     <field name="attribute_id" ref="product_attribute_10"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_14'), ref('product_attribute_value_11'), ref('product_attribute_value_12'), ref('product_attribute_value_13')])]"/>
   </record>
-  <record id="product_template_attribute_line_48" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_48" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_12"/>
     <field name="attribute_id" ref="product_attribute_10"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_12'), ref('product_attribute_value_13')])]"/>
   </record>
-  <record id="product_template_attribute_line_52" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_52" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_13"/>
     <field name="attribute_id" ref="product_attribute_10"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_12'), ref('product_attribute_value_13')])]"/>
   </record>
-  <record id="product_template_attribute_line_56" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_56" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_14"/>
     <field name="attribute_id" ref="product_attribute_10"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_13')])]"/>
   </record>
-  <record id="product_template_attribute_line_60" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_60" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_15"/>
     <field name="attribute_id" ref="product_attribute_10"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_13')])]"/>

--- a/elearning_platform/data/product_template.xml
+++ b/elearning_platform/data/product_template.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-  <record id="product_template_67" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_67" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="image_1920" type="base64" file="elearning_platform/static/src/binary/product_template/67-image_1920"/>
     <field name="name">Furniture Workshop Essentials</field>
     <field name="description_sale"><![CDATA[Turn your ideas into beautiful, functional furniture.]]></field>
@@ -22,7 +22,7 @@
 <p>Build confidence. Build furniture. Build your future. 🪚</p>]]></field>
     <field name="website_sequence">10230</field>
   </record>
-  <record id="product_template_73" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_73" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="image_1920" type="base64" file="elearning_platform/static/src/binary/product_template/73-image_1920"/>
     <field name="name">Intro to IT</field>
     <field name="description_sale"><![CDATA[Your first step into the world of IT]]></field>
@@ -44,7 +44,7 @@
 <p>Your gateway to the digital world starts here. 💻</p>]]></field>
     <field name="website_ribbon_id" ref="website_sale.new_ribbon"/>
   </record>
-  <record id="website_sale_slides.default_product_course_product_template" model="product.template" context="{'create_product_product': False}" forcecreate="0">
+  <record id="website_sale_slides.default_product_course_product_template" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}" forcecreate="0">
     <field name="image_1920" type="base64" file="elearning_platform/static/src/binary/product_template/66-image_1920"/>
     <field name="name">Gardening from A to Z</field>
     <field name="description_sale"><![CDATA[Your Complete Gardening Guide, for Life]]></field>

--- a/elearning_platform/data/product_template_attribute_line.xml
+++ b/elearning_platform/data/product_template_attribute_line.xml
@@ -1,11 +1,11 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-    <record id="product_template_attribute_line_10" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_10" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="website_sale_slides.default_product_course_product_template"/>
         <field name="attribute_id" ref="product_attribute_20"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_102')])]"/>
     </record>
-    <record id="product_template_attribute_line_11" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_11" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="website_sale_slides.default_product_course_product_template"/>
         <field name="attribute_id" ref="product.pa_duration"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_103')])]"/>

--- a/elearning_platform/demo/product_template.xml
+++ b/elearning_platform/demo/product_template.xml
@@ -1,12 +1,12 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-    <record id="product_template_67" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_67" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="is_published" eval="True"/>
     </record>
-    <record id="product_template_73" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_73" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="is_published" eval="True"/>
     </record>
-    <record id="website_sale_slides.default_product_course_product_template" model="product.template" context="{'create_product_product': False}" forcecreate="1">
+    <record id="website_sale_slides.default_product_course_product_template" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}" forcecreate="1">
         <field name="is_published" eval="True"/>
     </record>
 </odoo>

--- a/eyewear_shop/data/product_template.xml
+++ b/eyewear_shop/data/product_template.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-  <record id="product_template_108" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_108" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="name">Anti-Fog Lens Wipes</field>
     <field name="image_1920" type="base64" file="eyewear_shop/static/src/binary/product_template/108-image_1920"/>
     <field name="description"><![CDATA[<p>Individually wrapped anti-fog lens wipes for clear vision in any condition.</p>]]></field>
@@ -17,7 +17,7 @@
     <field name="website_sequence">10025</field>
     <field name="public_categ_ids" eval="[(6, 0, [ref('product_public_category_7')])]"/>
   </record>
-  <record id="product_template_24" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_24" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="name">Microfiber Cleaning Cloth</field>
     <field name="image_1920" type="base64" file="eyewear_shop/static/src/binary/product_template/24-image_1920"/>
     <field name="description"><![CDATA[<p>Soft microfiber cleaning cloth that safely cleans lenses without scratching. Reusable and washable.</p>]]></field>
@@ -34,7 +34,7 @@
     <field name="website_sequence">10020</field>
     <field name="public_categ_ids" eval="[(6, 0, [ref('product_public_category_7')])]"/>
   </record>
-  <record id="product_template_130" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_130" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="name">Alfred</field>
     <field name="image_1920" type="base64" file="eyewear_shop/static/src/binary/product_template/130-image_1920"/>
     <field name="description"><![CDATA[<p>Stylish and durable prescription glasses model 'Alfred' designed for everyday use.</p>]]></field>
@@ -53,7 +53,7 @@
     <field name="website_sequence">10025</field>
     <field name="public_categ_ids" eval="[(6, 0, [ref('product_public_category_6')])]"/>
   </record>
-  <record id="product_template_125" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_125" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="name">Anti-Fatigue Glasses</field>
     <field name="image_1920" type="base64" file="eyewear_shop/static/src/binary/product_template/125-image_1920"/>
     <field name="description"><![CDATA[<p>Specialized lenses to reduce eye strain from extended screen use and reading.</p>]]></field>
@@ -72,7 +72,7 @@
     <field name="website_sequence">10025</field>
     <field name="public_categ_ids" eval="[(6, 0, [ref('product_public_category_6')])]"/>
   </record>
-  <record id="product_template_145" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_145" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="name">Astra</field>
     <field name="image_1920" type="base64" file="eyewear_shop/static/src/binary/product_template/145-image_1920"/>
     <field name="description"><![CDATA[<p>High-performance prescription sunglasses model 'Astra' with UV protection and anti-glare coating.</p>]]></field>
@@ -91,7 +91,7 @@
     <field name="website_sequence">10025</field>
     <field name="public_categ_ids" eval="[(6, 0, [ref('product_public_category_6')])]"/>
   </record>
-  <record id="product_template_121" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_121" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="name">Bifocal Glasses</field>
     <field name="image_1920" type="base64" file="eyewear_shop/static/src/binary/product_template/121-image_1920"/>
     <field name="description"><![CDATA[<p>Bifocal glasses designed for both near and far vision, perfect for multitasking.</p>]]></field>
@@ -110,7 +110,7 @@
     <field name="website_sequence">10025</field>
     <field name="public_categ_ids" eval="[(6, 0, [ref('product_public_category_6')])]"/>
   </record>
-  <record id="product_template_150" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_150" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="name">Blaze</field>
     <field name="image_1920" type="base64" file="eyewear_shop/static/src/binary/product_template/148-image_1920"/>
     <field name="description"><![CDATA[<p>High-performance prescription sunglasses model 'Blaze' with UV protection and anti-glare coating.</p>]]></field>
@@ -128,7 +128,7 @@
     <field name="website_sequence">10025</field>
     <field name="public_categ_ids" eval="[(6, 0, [ref('product_public_category_6')])]"/>
   </record>
-  <record id="product_template_21" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_21" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="name">Blue Light Glasses</field>
     <field name="image_1920" type="base64" file="eyewear_shop/static/src/binary/product_template/21-image_1920"/>
     <field name="description"><![CDATA[<p>Modern glasses designed to reduce blue light exposure from screens. Offers anti-glare benefits.</p>]]></field>
@@ -147,7 +147,7 @@
     <field name="website_sequence">10020</field>
     <field name="public_categ_ids" eval="[(6, 0, [ref('product_public_category_6')])]"/>
   </record>
-  <record id="product_template_23" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_23" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="name">Lens Cleaner Spray</field>
     <field name="image_1920" type="base64" file="eyewear_shop/static/src/binary/product_template/23-image_1920"/>
     <field name="description"><![CDATA[<p>Effective lens cleaner spray for removing smudges and dirt. Easy to use and eco-friendly.</p>]]></field>
@@ -164,7 +164,7 @@
     <field name="website_sequence">10020</field>
     <field name="public_categ_ids" eval="[(6, 0, [ref('product_public_category_7')])]"/>
   </record>
-  <record id="product_template_22" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_22" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="name">Daily Contact Lenses</field>
     <field name="image_1920" type="base64" file="eyewear_shop/static/src/binary/product_template/22-image_1920"/>
     <field name="description"><![CDATA[<p>Comfortable daily contact lenses with excellent moisture retention. Ideal for long hours.</p>]]></field>
@@ -182,7 +182,7 @@
     <field name="website_sequence">10020</field>
     <field name="public_categ_ids" eval="[(6, 0, [ref('product_public_category_8')])]"/>
   </record>
-  <record id="product_template_132" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_132" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="name">Eclipse</field>
     <field name="image_1920" type="base64" file="eyewear_shop/static/src/binary/product_template/132-image_1920"/>
     <field name="description"><![CDATA[<p>Stylish and durable prescription glasses model 'Eclipse' designed for everyday use.</p>]]></field>
@@ -201,7 +201,7 @@
     <field name="website_sequence">10025</field>
     <field name="public_categ_ids" eval="[(6, 0, [ref('product_public_category_6')])]"/>
   </record>
-  <record id="product_template_143" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_143" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="name">Eden</field>
     <field name="image_1920" type="base64" file="eyewear_shop/static/src/binary/product_template/143-image_1920"/>
     <field name="description"><![CDATA[<p>High-performance prescription sunglasses model 'Eden' with UV protection and anti-glare coating.</p>]]></field>
@@ -220,7 +220,7 @@
     <field name="website_sequence">10025</field>
     <field name="public_categ_ids" eval="[(6, 0, [ref('product_public_category_6')])]"/>
   </record>
-  <record id="product_template_133" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_133" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="name">Horizon</field>
     <field name="image_1920" type="base64" file="eyewear_shop/static/src/binary/product_template/133-image_1920"/>
     <field name="description"><![CDATA[<p>Stylish and durable prescription glasses model 'Horizon' designed for everyday use.</p>]]></field>
@@ -239,7 +239,7 @@
     <field name="website_sequence">10025</field>
     <field name="public_categ_ids" eval="[(6, 0, [ref('product_public_category_6')])]"/>
   </record>
-  <record id="product_template_116" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_116" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="name">Hydrating Eye Drops</field>
     <field name="image_1920" type="base64" file="eyewear_shop/static/src/binary/product_template/116-image_1920"/>
     <field name="description"><![CDATA[<p>Moisturizing eye drops to soothe dry eyes and provide long-lasting comfort.</p>]]></field>
@@ -257,7 +257,7 @@
     <field name="website_sequence">10025</field>
     <field name="public_categ_ids" eval="[(6, 0, [ref('product_public_category_5')])]"/>
   </record>
-  <record id="product_template_117" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_117" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="name">Luxury Gold-Rim Glasses</field>
     <field name="image_1920" type="base64" file="eyewear_shop/static/src/binary/product_template/117-image_1920"/>
     <field name="description"><![CDATA[<p>Premium gold-rimmed glasses with a sleek and sophisticated design.</p>]]></field>
@@ -275,7 +275,7 @@
     <field name="website_sequence">10025</field>
     <field name="public_categ_ids" eval="[(6, 0, [ref('product_public_category_6')])]"/>
   </record>
-  <record id="product_template_135" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_135" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="name">Lyra</field>
     <field name="image_1920" type="base64" file="eyewear_shop/static/src/binary/product_template/135-image_1920"/>
     <field name="description"><![CDATA[<p>Stylish and durable prescription glasses model 'Lyra' designed for everyday use.</p>]]></field>
@@ -293,7 +293,7 @@
     <field name="website_sequence">10025</field>
     <field name="public_categ_ids" eval="[(6, 0, [ref('product_public_category_6')])]"/>
   </record>
-  <record id="product_template_144" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_144" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="name">Nimbus</field>
     <field name="image_1920" type="base64" file="eyewear_shop/static/src/binary/product_template/144-image_1920"/>
     <field name="description"><![CDATA[<p>High-performance prescription sunglasses model 'Nimbus' with UV protection and anti-glare coating.</p>]]></field>
@@ -311,7 +311,7 @@
     <field name="website_sequence">10025</field>
     <field name="public_categ_ids" eval="[(6, 0, [ref('product_public_category_6')])]"/>
   </record>
-  <record id="product_template_131" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_131" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="name">Nova</field>
     <field name="image_1920" type="base64" file="eyewear_shop/static/src/binary/product_template/131-image_1920"/>
     <field name="description"><![CDATA[<p>Stylish and durable prescription glasses model 'Nova' designed for everyday use.</p>]]></field>
@@ -329,7 +329,7 @@
     <field name="website_sequence">10025</field>
     <field name="public_categ_ids" eval="[(6, 0, [ref('product_public_category_6')])]"/>
   </record>
-  <record id="product_template_147" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_147" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="name">Onyx</field>
     <field name="image_1920" type="base64" file="eyewear_shop/static/src/binary/product_template/147-image_1920"/>
     <field name="description"><![CDATA[<p>High-performance prescription sunglasses model 'Onyx' with UV protection and anti-glare coating.</p>]]></field>
@@ -347,7 +347,7 @@
     <field name="website_sequence">10025</field>
     <field name="public_categ_ids" eval="[(6, 0, [ref('product_public_category_6')])]"/>
   </record>
-  <record id="product_template_136" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_136" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="name">Orion</field>
     <field name="image_1920" type="base64" file="eyewear_shop/static/src/binary/product_template/136-image_1920"/>
     <field name="description"><![CDATA[<p>Stylish and durable prescription glasses model 'Orion' designed for everyday use.</p>]]></field>
@@ -365,7 +365,7 @@
     <field name="website_sequence">10025</field>
     <field name="public_categ_ids" eval="[(6, 0, [ref('product_public_category_6')])]"/>
   </record>
-  <record id="product_template_25" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_25" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="name">Protective Eyeglass Case</field>
     <field name="image_1920" type="base64" file="eyewear_shop/static/src/binary/product_template/25-image_1920"/>
     <field name="description"><![CDATA[<p>Durable eyeglass case with protective padding. Stylish design to keep your glasses secure.</p>]]></field>
@@ -382,7 +382,7 @@
     <field name="website_sequence">10020</field>
     <field name="public_categ_ids" eval="[(6, 0, [ref('product_public_category_5')])]"/>
   </record>
-  <record id="product_template_123" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_123" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="name">Reading Glasses</field>
     <field name="image_1920" type="base64" file="eyewear_shop/static/src/binary/product_template/123-image_1920"/>
     <field name="description"><![CDATA[<p>Lightweight reading glasses with magnification options for clear close-up vision.</p>]]></field>
@@ -400,7 +400,7 @@
     <field name="website_sequence">10025</field>
     <field name="public_categ_ids" eval="[(6, 0, [ref('product_public_category_6')])]"/>
   </record>
-  <record id="product_template_146" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_146" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="name">Shadow</field>
     <field name="image_1920" type="base64" file="eyewear_shop/static/src/binary/product_template/146-image_1920"/>
     <field name="description"><![CDATA[<p>High-performance prescription sunglasses model 'Shadow' with UV protection and anti-glare coating.</p>]]></field>
@@ -418,7 +418,7 @@
     <field name="website_sequence">10025</field>
     <field name="public_categ_ids" eval="[(6, 0, [ref('product_public_category_6')])]"/>
   </record>
-  <record id="product_template_139" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_139" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="name">Solaris</field>
     <field name="image_1920" type="base64" file="eyewear_shop/static/src/binary/product_template/139-image_1920"/>
     <field name="description"><![CDATA[<p>High-performance prescription sunglasses model 'Solaris' with UV protection and anti-glare coating.</p>]]></field>
@@ -436,7 +436,7 @@
     <field name="website_sequence">10025</field>
     <field name="public_categ_ids" eval="[(6, 0, [ref('product_public_category_6')])]"/>
   </record>
-  <record id="product_template_138" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_138" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="name">Stratos</field>
     <field name="image_1920" type="base64" file="eyewear_shop/static/src/binary/product_template/138-image_1920"/>
     <field name="description"><![CDATA[<p>Stylish and durable prescription glasses model 'Stratos' designed for everyday use.</p>]]></field>
@@ -454,7 +454,7 @@
     <field name="website_sequence">10025</field>
     <field name="public_categ_ids" eval="[(6, 0, [ref('product_public_category_6')])]"/>
   </record>
-  <record id="product_template_20" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_20" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="name">Stylish Sunglasses</field>
     <field name="image_1920" type="base64" file="eyewear_shop/static/src/binary/product_template/20-image_1920"/>
     <field name="description"><![CDATA[<p>Trendy sunglasses with UV protection and polarized lenses. Perfect for sunny days.</p>]]></field>
@@ -472,7 +472,7 @@
     <field name="website_sequence">10020</field>
     <field name="public_categ_ids" eval="[(6, 0, [ref('product_public_category_6')])]"/>
   </record>
-  <record id="product_template_141" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_141" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="name">Titan</field>
     <field name="image_1920" type="base64" file="eyewear_shop/static/src/binary/product_template/141-image_1920"/>
     <field name="description"><![CDATA[<p>High-performance prescription sunglasses model 'Titan' with UV protection and anti-glare coating.</p>]]></field>
@@ -490,7 +490,7 @@
     <field name="website_sequence">10025</field>
     <field name="public_categ_ids" eval="[(6, 0, [ref('product_public_category_6')])]"/>
   </record>
-  <record id="product_template_137" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_137" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="name">Zenith</field>
     <field name="image_1920" type="base64" file="eyewear_shop/static/src/binary/product_template/137-image_1920"/>
     <field name="description"><![CDATA[<p>Stylish and durable prescription glasses model 'Zenith' designed for everyday use.</p>]]></field>

--- a/eyewear_shop/data/product_template_attribute_line.xml
+++ b/eyewear_shop/data/product_template_attribute_line.xml
@@ -1,224 +1,224 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1" auto_sequence="1">
-  <record id="product_template_attribute_line_11" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_11" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_130"/>
     <field name="attribute_id" ref="website_sale.product_attribute_brand"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_6')])]"/>
   </record>
-  <record id="product_template_attribute_line_19" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_19" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_145"/>
     <field name="attribute_id" ref="website_sale.product_attribute_brand"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_9')])]"/>
   </record>
-  <record id="product_template_attribute_line_27" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_27" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_144"/>
     <field name="attribute_id" ref="website_sale.product_attribute_brand"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_10')])]"/>
   </record>
-  <record id="product_template_attribute_line_35" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_35" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_25"/>
     <field name="attribute_id" ref="website_sale.product_attribute_brand"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_10')])]"/>
   </record>
-  <record id="product_template_attribute_line_42" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_42" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_150"/>
     <field name="attribute_id" ref="website_sale.product_attribute_brand"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_12')])]"/>
   </record>
-  <record id="product_template_attribute_line_12" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_12" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_130"/>
     <field name="attribute_id" ref="product_barcodelookup.product_attribute_lookup_8"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_1')])]"/>
   </record>
-  <record id="product_template_attribute_line_20" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_20" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_145"/>
     <field name="attribute_id" ref="product_barcodelookup.product_attribute_lookup_8"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_1')])]"/>
   </record>
-  <record id="product_template_attribute_line_28" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_28" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_144"/>
     <field name="attribute_id" ref="product_barcodelookup.product_attribute_lookup_8"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_2')])]"/>
   </record>
-  <record id="product_template_attribute_line_36" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_36" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_25"/>
     <field name="attribute_id" ref="product_barcodelookup.product_attribute_lookup_8"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_1')])]"/>
   </record>
-  <record id="product_template_attribute_line_43" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_43" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_150"/>
     <field name="attribute_id" ref="product_barcodelookup.product_attribute_lookup_8"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_2')])]"/>
   </record>
-  <record id="product_template_attribute_line_13" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_13" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_130"/>
     <field name="sequence">12</field>
     <field name="attribute_id" ref="product_barcodelookup.product_attribute_lookup_2"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_5')])]"/>
   </record>
-  <record id="product_template_attribute_line_21" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_21" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_145"/>
     <field name="sequence">12</field>
     <field name="attribute_id" ref="product_barcodelookup.product_attribute_lookup_2"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_4')])]"/>
   </record>
-  <record id="product_template_attribute_line_29" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_29" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_144"/>
     <field name="sequence">12</field>
     <field name="attribute_id" ref="product_barcodelookup.product_attribute_lookup_2"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_4')])]"/>
   </record>
-  <record id="product_template_attribute_line_37" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_37" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_25"/>
     <field name="sequence">12</field>
     <field name="attribute_id" ref="product_barcodelookup.product_attribute_lookup_2"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_5')])]"/>
   </record>
-  <record id="product_template_attribute_line_44" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_44" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_150"/>
     <field name="sequence">12</field>
     <field name="attribute_id" ref="product_barcodelookup.product_attribute_lookup_2"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_3')])]"/>
   </record>
-  <record id="product_template_attribute_line_22" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_22" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_145"/>
     <field name="sequence">13</field>
     <field name="attribute_id" ref="product_attribute_10"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_15')])]"/>
   </record>
-  <record id="product_template_attribute_line_30" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_30" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_144"/>
     <field name="sequence">13</field>
     <field name="attribute_id" ref="product_attribute_10"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_13')])]"/>
   </record>
-  <record id="product_template_attribute_line_38" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_38" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_25"/>
     <field name="sequence">13</field>
     <field name="attribute_id" ref="product_attribute_10"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_16')])]"/>
   </record>
-  <record id="product_template_attribute_line_45" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_45" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_150"/>
     <field name="sequence">13</field>
     <field name="attribute_id" ref="product_attribute_10"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_14')])]"/>
   </record>
-  <record id="product_template_attribute_line_23" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_23" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_145"/>
     <field name="sequence">14</field>
     <field name="attribute_id" ref="product_attribute_11"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_19')])]"/>
   </record>
-  <record id="product_template_attribute_line_31" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_31" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_144"/>
     <field name="sequence">14</field>
     <field name="attribute_id" ref="product_attribute_11"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_20')])]"/>
   </record>
-  <record id="product_template_attribute_line_46" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_46" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_150"/>
     <field name="sequence">14</field>
     <field name="attribute_id" ref="product_attribute_11"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_17'), ref('product_attribute_value_18'), ref('product_attribute_value_19')])]"/>
   </record>
-  <record id="product_template_attribute_line_39" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_39" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_25"/>
     <field name="sequence">14</field>
     <field name="attribute_id" ref="product_attribute_12"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_21')])]"/>
   </record>
-  <record id="product_template_attribute_line_14" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_14" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_130"/>
     <field name="sequence">15</field>
     <field name="attribute_id" ref="product_attribute_10"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_14')])]"/>
   </record>
-  <record id="product_template_attribute_line_24" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_24" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_145"/>
     <field name="sequence">15</field>
     <field name="attribute_id" ref="product_attribute_12"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_21')])]"/>
   </record>
-  <record id="product_template_attribute_line_32" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_32" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_144"/>
     <field name="sequence">15</field>
     <field name="attribute_id" ref="product_attribute_12"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_22')])]"/>
   </record>
-  <record id="product_template_attribute_line_47" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_47" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_150"/>
     <field name="sequence">15</field>
     <field name="attribute_id" ref="product_attribute_12"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_21')])]"/>
   </record>
-  <record id="product_template_attribute_line_40" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_40" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_25"/>
     <field name="sequence">15</field>
     <field name="attribute_id" ref="product_attribute_13"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_23')])]"/>
   </record>
-  <record id="product_template_attribute_line_15" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_15" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_130"/>
     <field name="sequence">16</field>
     <field name="attribute_id" ref="product_attribute_11"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_18')])]"/>
   </record>
-  <record id="product_template_attribute_line_25" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_25" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_145"/>
     <field name="sequence">16</field>
     <field name="attribute_id" ref="product_attribute_13"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_28')])]"/>
   </record>
-  <record id="product_template_attribute_line_33" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_33" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_144"/>
     <field name="sequence">16</field>
     <field name="attribute_id" ref="product_attribute_13"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_25')])]"/>
   </record>
-  <record id="product_template_attribute_line_48" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_48" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_150"/>
     <field name="sequence">16</field>
     <field name="attribute_id" ref="product_attribute_13"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_24'), ref('product_attribute_value_26'), ref('product_attribute_value_27'), ref('product_attribute_value_28'), ref('product_attribute_value_29')])]"/>
   </record>
-  <record id="product_template_attribute_line_41" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_41" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_25"/>
     <field name="sequence">16</field>
     <field name="attribute_id" ref="product_attribute_14"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_32')])]"/>
   </record>
-  <record id="product_template_attribute_line_16" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_16" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_130"/>
     <field name="sequence">17</field>
     <field name="attribute_id" ref="product_attribute_12"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_21')])]"/>
   </record>
-  <record id="product_template_attribute_line_26" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_26" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_145"/>
     <field name="sequence">17</field>
     <field name="attribute_id" ref="product_attribute_14"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_32')])]"/>
   </record>
-  <record id="product_template_attribute_line_34" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_34" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_144"/>
     <field name="sequence">17</field>
     <field name="attribute_id" ref="product_attribute_14"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_31')])]"/>
   </record>
-  <record id="product_template_attribute_line_49" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_49" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_150"/>
     <field name="sequence">17</field>
     <field name="attribute_id" ref="product_attribute_14"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_31')])]"/>
   </record>
-  <record id="product_template_attribute_line_17" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_17" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_130"/>
     <field name="sequence">18</field>
     <field name="attribute_id" ref="product_attribute_13"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_25')])]"/>
   </record>
-  <record id="product_template_attribute_line_18" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_18" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_130"/>
     <field name="sequence">19</field>
     <field name="attribute_id" ref="product_attribute_14"/>

--- a/florist/data/product_template.xml
+++ b/florist/data/product_template.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-    <record id="product_template_19" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_19" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Delivery &amp; Setup</field>
         <field name="image_1920" type="base64" file="florist/static/src/binary/product_template/19-image_1920"/>
         <field name="list_price">80.0</field>
@@ -9,7 +9,7 @@
         <field name="service_type">manual</field>
         <field name="invoice_policy">order</field>
     </record>
-    <record id="product_template_16" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_16" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Dry Flowers Bouquet</field>
         <field name="image_1920" type="base64" file="florist/static/src/binary/product_template/16-image_1920"/>
         <field name="categ_id" ref="product_category_6"/>
@@ -19,7 +19,7 @@
         <field name="service_type">manual</field>
       <field name="invoice_policy">order</field>
     </record>
-    <record id="product_template_15" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_15" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Gift Card</field>
         <field name="image_1920" type="base64" file="florist/static/src/binary/product_template/15-image_1920"/>
         <field name="list_price">50.0</field>
@@ -31,7 +31,7 @@
         <field name="service_type">manual</field>
         <field name="invoice_policy">order</field>
     </record>
-    <record id="product_template_10" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_10" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Iris</field>
         <field name="image_1920" type="base64" file="florist/static/src/binary/product_template/10-image_1920"/>
         <field name="list_price">4.0</field>
@@ -41,7 +41,7 @@
         <field name="service_type">manual</field>
         <field name="invoice_policy">order</field>
     </record>
-    <record id="product_template_6" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_6" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Peonies</field>
         <field name="image_1920" type="base64" file="florist/static/src/binary/product_template/6-image_1920"/>
         <field name="list_price">7.0</field>
@@ -51,7 +51,7 @@
         <field name="service_type">manual</field>
         <field name="invoice_policy">order</field>
     </record>
-    <record id="product_template_11" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_11" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Seasonal Bouquet (Mixed Flowers)</field>
         <field name="image_1920" type="base64" file="florist/static/src/binary/product_template/11-image_1920"/>
         <field name="categ_id" ref="product_category_6"/>
@@ -63,7 +63,7 @@
         <field name="service_type">manual</field>
         <field name="invoice_policy">order</field>
     </record>
-    <record id="product_template_9" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_9" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Sunflower</field>
         <field name="image_1920" type="base64" file="florist/static/src/binary/product_template/9-image_1920"/>
         <field name="list_price">3.5</field>
@@ -73,7 +73,7 @@
         <field name="service_type">manual</field>
         <field name="invoice_policy">order</field>
     </record>
-    <record id="product_template_17" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_17" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Table Centerpieces</field>
         <field name="image_1920" type="base64" file="florist/static/src/binary/product_template/17-image_1920"/>
         <field name="list_price">25.0</field>
@@ -84,7 +84,7 @@
         <field name="service_type">manual</field>
         <field name="invoice_policy">order</field>
     </record>
-    <record id="product_template_7" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_7" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Tulips</field>
         <field name="image_1920" type="base64" file="florist/static/src/binary/product_template/7-image_1920"/>
         <field name="categ_id" ref="product_category_5"/>
@@ -99,7 +99,7 @@
         <field name="service_type">manual</field>
         <field name="invoice_policy">order</field>
     </record>
-    <record id="product_template_18" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_18" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Venue Floral Design</field>
         <field name="image_1920" type="base64" file="florist/static/src/binary/product_template/18-image_1920"/>
         <field name="list_price">300.0</field>
@@ -110,7 +110,7 @@
         <field name="service_type">manual</field>
         <field name="invoice_policy">order</field>
     </record>
-    <record id="product_template_12" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_12" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Wedding Bouquet</field>
         <field name="image_1920" type="base64" file="florist/static/src/binary/product_template/12-image_1920"/>
         <field name="categ_id" ref="product_category_6"/>
@@ -121,22 +121,22 @@
         <field name="service_type">manual</field>
         <field name="invoice_policy">order</field>
     </record>
-    <record id="pos_settle_due.product_product_deposit_product_template" model="product.template" context="{'create_product_product': False}" forcecreate="0">
+    <record id="pos_settle_due.product_product_deposit_product_template" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}" forcecreate="0">
         <field name="active" eval="False"/>
     </record>
-    <record id="pos_sale.default_downpayment_product_product_template" model="product.template" context="{'create_product_product': False}" forcecreate="0">
+    <record id="pos_sale.default_downpayment_product_product_template" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}" forcecreate="0">
         <field name="active" eval="False"/>
     </record>
-    <record id="loyalty.gift_card_product_50_product_template" model="product.template" context="{'create_product_product': False}" forcecreate="0">
+    <record id="loyalty.gift_card_product_50_product_template" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}" forcecreate="0">
         <field name="active" eval="False"/>
     </record>
-    <record id="pos_settle_due.product_product_settle_product_template" model="product.template" context="{'create_product_product': False}" forcecreate="0">
+    <record id="pos_settle_due.product_product_settle_product_template" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}" forcecreate="0">
         <field name="active" eval="False"/>
     </record>
-    <record id="point_of_sale.product_product_tip_product_template" model="product.template" context="{'create_product_product': False}" forcecreate="0">
+    <record id="point_of_sale.product_product_tip_product_template" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}" forcecreate="0">
         <field name="active" eval="False"/>
     </record>
-    <record id="loyalty.ewallet_product_50_product_template" model="product.template" context="{'create_product_product': False}" forcecreate="0">
+    <record id="loyalty.ewallet_product_50_product_template" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}" forcecreate="0">
         <field name="active" eval="False"/>
     </record>
 </odoo>

--- a/florist/data/product_template_attribute_line.xml
+++ b/florist/data/product_template_attribute_line.xml
@@ -1,21 +1,21 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-    <record id="product_template_attribute_line_1" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_1" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_7"/>
         <field name="attribute_id" ref="product_barcodelookup.product_attribute_lookup_1"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_1'), ref('product_attribute_value_2'), ref('product_attribute_value_3')])]"/>
     </record>
-    <record id="product_template_attribute_line_2" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_2" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_11"/>
         <field name="attribute_id" ref="product_barcodelookup.product_attribute_lookup_7"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_4'), ref('product_attribute_value_5'), ref('product_attribute_value_6')])]"/>
     </record>
-    <record id="product_template_attribute_line_3" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_3" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_12"/>
         <field name="attribute_id" ref="product_barcodelookup.product_attribute_lookup_7"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_4'), ref('product_attribute_value_5'), ref('product_attribute_value_6')])]"/>
     </record>
-    <record id="product_template_attribute_line_4" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_4" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_16"/>
         <field name="attribute_id" ref="product_barcodelookup.product_attribute_lookup_7"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_4'), ref('product_attribute_value_5'), ref('product_attribute_value_6')])]"/>

--- a/fmcg_store/data/product_template.xml
+++ b/fmcg_store/data/product_template.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-    <record id="product_template_11" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_11" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Coca Cola</field>
         <field name="image_1920" type="base64" file="fmcg_store/static/src/binary/product_template/11-image_1920.png"/>
         <field name="available_in_pos" eval="True"/>
@@ -15,7 +15,7 @@
         <field name="removal_time">2</field>
         <field name="pos_categ_ids" eval="[(6, 0, [ref('pos_category_2')])]"/>
     </record>
-    <record id="product_template_23" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_23" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Orea Biscuit</field>
         <field name="description_sale">Vanilla Flavour Cream sandwich</field>
         <field name="product_tag_ids" eval="[(6, 0, [ref('product_tag_1')])]"/>
@@ -31,7 +31,7 @@
         <field name="removal_time">10</field>
         <field name="pos_categ_ids" eval="[(6, 0, [ref('pos_category_7')])]"/>
     </record>
-    <record id="product_template_31" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_31" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Maggie Mega pack</field>
         <field name="image_1920" type="base64" file="fmcg_store/static/src/binary/product_template/31-image_1920"/>
         <field name="available_in_pos" eval="True"/>

--- a/fmcg_store/data/product_template_attribute_line.xml
+++ b/fmcg_store/data/product_template_attribute_line.xml
@@ -1,16 +1,16 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-    <record id="product_template_attribute_line_1" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_1" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_11"/>
         <field name="attribute_id" ref="product_attribute_1"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_39'), ref('product_attribute_value_40')])]"/>
     </record>
-    <record id="product_template_attribute_line_4" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_4" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_23"/>
         <field name="attribute_id" ref="product_attribute_1"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_10'), ref('product_attribute_value_11'), ref('product_attribute_value_12'), ref('product_attribute_value_13')])]"/>
     </record>
-    <record id="product_template_attribute_line_9" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_9" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_31"/>
         <field name="attribute_id" ref="product_attribute_1"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_21'), ref('product_attribute_value_22'), ref('product_attribute_value_23')])]"/>

--- a/food_distribution/data/product_template.xml
+++ b/food_distribution/data/product_template.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-  <record id="product_template_9" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_9" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="image_1920" type="base64" file="food_distribution/static/src/binary/product_template/9-image_1920"/>
     <field name="name">Bucket 5L</field>
     <field name="categ_id" ref="product_category_6"/>
@@ -9,7 +9,7 @@
     <field name="service_type">manual</field>
     <field name="invoice_policy">order</field>
   </record>
-  <record id="product_template_10" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_10" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="image_1920" type="base64" file="food_distribution/static/src/binary/product_template/10-image_1920"/>
     <field name="name">Dispenser 2.6L</field>
     <field name="categ_id" ref="product_category_6"/>
@@ -18,7 +18,7 @@
     <field name="service_type">manual</field>
     <field name="invoice_policy">order</field>
   </record>
-  <record id="product_template_3" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_3" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="name">Mayonnaise</field>
     <field name="categ_id" ref="product_category_5"/>
     <field name="purchase_ok" eval="False"/>
@@ -31,7 +31,7 @@
     <field name="invoice_policy">order</field>
     <field name="serial_prefix_format">%(y)s%(month)s%(day)s-</field>
   </record>
-  <record id="product_template_5" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_5" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="name">Mustard</field>
     <field name="categ_id" ref="product_category_4"/>
     <field name="is_storable" eval="True"/>
@@ -40,7 +40,7 @@
     <field name="service_type">manual</field>
     <field name="invoice_policy">order</field>
   </record>
-  <record id="product_template_8" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_8" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="name">Pasteurised Liquid Egg</field>
     <field name="categ_id" ref="product_category_4"/>
     <field name="is_storable" eval="True"/>
@@ -50,7 +50,7 @@
     <field name="invoice_policy">order</field>
     <field name="x_is_allergen" eval="True"/>
   </record>
-  <record id="product_template_6" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_6" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="name">Salt</field>
     <field name="categ_id" ref="product_category_4"/>
     <field name="is_storable" eval="True"/>
@@ -59,7 +59,7 @@
     <field name="service_type">manual</field>
     <field name="invoice_policy">order</field>
   </record>
-  <record id="product_template_7" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_7" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="name">Sugar</field>
     <field name="categ_id" ref="product_category_4"/>
     <field name="is_storable" eval="True"/>
@@ -68,7 +68,7 @@
     <field name="service_type">manual</field>
     <field name="invoice_policy">order</field>
   </record>
-  <record id="product_template_2" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_2" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="name">Sunflower Oil</field>
     <field name="categ_id" ref="product_category_4"/>
     <field name="is_storable" eval="True"/>
@@ -77,7 +77,7 @@
     <field name="service_type">manual</field>
     <field name="invoice_policy">order</field>
   </record>
-  <record id="product_template_4" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_4" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="name">Vinegar</field>
     <field name="categ_id" ref="product_category_4"/>
     <field name="is_storable" eval="True"/>
@@ -86,7 +86,7 @@
     <field name="service_type">manual</field>
     <field name="invoice_policy">order</field>
   </record>
-  <record id="product_template_12" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_12" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="image_1920" type="base64" file="food_distribution/static/src/binary/product_template/12-image_1920"/>
     <field name="name">Mayonnaise Bucket 5L</field>
     <field name="categ_id" ref="product_category_7"/>
@@ -126,7 +126,7 @@ REFRIGERATE AFTER OPENING. DO NOT FREEZE.]]></field>
         (0, 0, {'x_nutritional_fact_id': ref('x_nutritional_facts_10'), 'x_per_100g': 1.5}),
     ]"/>
   </record>
-  <record id="product_template_13" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_13" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="image_1920" type="base64" file="food_distribution/static/src/binary/product_template/13-image_1920"/>
     <field name="name">Mayonnaise Dispenser 2.6L</field>
     <field name="categ_id" ref="product_category_7"/>

--- a/furniture_store/data/product_template.xml
+++ b/furniture_store/data/product_template.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-    <record id="product_template_9" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_9" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="image_1920" type="base64" file="furniture_store/static/src/binary/product_template/9-image_1920" />
         <field name="name">Bar Stool Design</field>
         <field name="list_price">175.0</field>
@@ -14,7 +14,7 @@
         <field name="website_sequence">10040</field>
         <field name="public_categ_ids" eval="[(6, 0, [ref('product_public_category_9')])]" />
     </record>
-    <record id="product_template_8" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_8" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="image_1920" type="base64" file="furniture_store/static/src/binary/product_template/8-image_1920" />
         <field name="name">Boko Chair</field>
         <field name="list_price">85.0</field>
@@ -29,7 +29,7 @@
         <field name="website_sequence">10035</field>
         <field name="public_categ_ids" eval="[(6, 0, [ref('product_public_category_13')])]" />
     </record>
-    <record id="product_template_15" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_15" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="image_1920" type="base64" file="furniture_store/static/src/binary/product_template/15-image_1920" />
         <field name="name">Ceiling light Zen</field>
         <field name="list_price">140.0</field>
@@ -43,7 +43,7 @@
         <field name="website_sequence">10070</field>
         <field name="public_categ_ids" eval="[(6, 0, [ref('product_public_category_6')])]" />
     </record>
-    <record id="product_template_23" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_23" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="image_1920" type="base64" file="furniture_store/static/src/binary/product_template/23-image_1920" />
         <field name="name">Corner Wardrobe</field>
         <field name="list_price">2140.0</field>
@@ -57,7 +57,7 @@
         <field name="website_sequence">10110</field>
         <field name="public_categ_ids" eval="[(6, 0, [ref('product_public_category_19')])]" />
     </record>
-    <record id="product_template_10" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_10" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="image_1920" type="base64" file="furniture_store/static/src/binary/product_template/10-image_1920" />
         <field name="name">Cosy Bar Stool</field>
         <field name="list_price">210.0</field>
@@ -71,7 +71,7 @@
         <field name="website_sequence">10045</field>
         <field name="public_categ_ids" eval="[(6, 0, [ref('product_public_category_9')])]" />
     </record>
-    <record id="product_template_29" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_29" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="image_1920" type="base64" file="furniture_store/static/src/binary/product_template/29-image_1920" />
         <field name="name">Dark Black</field>
         <field name="list_price">2999.0</field>
@@ -85,7 +85,7 @@
         <field name="website_sequence">10140</field>
         <field name="public_categ_ids" eval="[(6, 0, [ref('product_public_category_11')])]" />
     </record>
-    <record id="product_template_16" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_16" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="image_1920" type="base64" file="furniture_store/static/src/binary/product_template/16-image_1920" />
         <field name="name">Designer Led Ceiling</field>
         <field name="list_price">125.0</field>
@@ -99,7 +99,7 @@
         <field name="website_sequence">10075</field>
         <field name="public_categ_ids" eval="[(6, 0, [ref('product_public_category_6')])]" />
     </record>
-    <record id="product_template_25" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_25" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="image_1920" type="base64" file="furniture_store/static/src/binary/product_template/25-image_1920" />
         <field name="name">Elegant Table</field>
         <field name="list_price">2150.0</field>
@@ -113,7 +113,7 @@
         <field name="website_sequence">10120</field>
         <field name="public_categ_ids" eval="[(6, 0, [ref('product_public_category_11')])]" />
     </record>
-    <record id="product_template_22" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_22" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="image_1920" type="base64" file="furniture_store/static/src/binary/product_template/22-image_1920" />
         <field name="name">Elegant plate</field>
         <field name="list_price">12.0</field>
@@ -127,7 +127,7 @@
         <field name="website_sequence">10105</field>
         <field name="public_categ_ids" eval="[(6, 0, [ref('product_public_category_12')])]" />
     </record>
-    <record id="product_template_13" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_13" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="image_1920" type="base64" file="furniture_store/static/src/binary/product_template/13-image_1920" />
         <field name="name">Luxury Velvet Sofa</field>
         <field name="list_price">680.0</field>
@@ -141,7 +141,7 @@
         <field name="website_sequence">10060</field>
         <field name="public_categ_ids" eval="[(6, 0, [ref('product_public_category_16')])]" />
     </record>
-    <record id="product_template_24" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_24" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="image_1920" type="base64" file="furniture_store/static/src/binary/product_template/24-image_1920" />
         <field name="name">Mars Dining Table</field>
         <field name="list_price">2150.0</field>
@@ -155,7 +155,7 @@
         <field name="website_sequence">10115</field>
         <field name="public_categ_ids" eval="[(6, 0, [ref('product_public_category_11')])]" />
     </record>
-    <record id="product_template_21" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_21" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="image_1920" type="base64" file="furniture_store/static/src/binary/product_template/21-image_1920" />
         <field name="name">Multiple Rounds Ceiling</field>
         <field name="list_price">199.0</field>
@@ -169,7 +169,7 @@
         <field name="website_sequence">10100</field>
         <field name="public_categ_ids" eval="[(6, 0, [ref('product_public_category_6')])]" />
     </record>
-    <record id="product_template_11" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_11" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="image_1920" type="base64" file="furniture_store/static/src/binary/product_template/11-image_1920" />
         <field name="name">Oak Bar Stool</field>
         <field name="list_price">150.0</field>
@@ -183,7 +183,7 @@
         <field name="website_sequence">10050</field>
         <field name="public_categ_ids" eval="[(6, 0, [ref('product_public_category_9')])]" />
     </record>
-    <record id="product_template_27" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_27" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="image_1920" type="base64" file="furniture_store/static/src/binary/product_template/27-image_1920" />
         <field name="name">Oak Bench</field>
         <field name="list_price">249.0</field>
@@ -197,7 +197,7 @@
         <field name="website_sequence">10130</field>
         <field name="public_categ_ids" eval="[(6, 0, [ref('product_public_category_14')])]" />
     </record>
-    <record id="product_template_12" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_12" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="image_1920" type="base64" file="furniture_store/static/src/binary/product_template/12-image_1920" />
         <field name="name">Oak Dining Table</field>
         <field name="list_price">2150.0</field>
@@ -212,7 +212,7 @@
         <field name="website_sequence">10055</field>
         <field name="public_categ_ids" eval="[(6, 0, [ref('product_public_category_11')])]" />
     </record>
-    <record id="product_template_18" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_18" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="image_1920" type="base64" file="furniture_store/static/src/binary/product_template/18-image_1920" />
         <field name="name">Round Gold Design Led Ceiling</field>
         <field name="list_price">99.0</field>
@@ -226,7 +226,7 @@
         <field name="website_sequence">10085</field>
         <field name="public_categ_ids" eval="[(6, 0, [ref('product_public_category_6')])]" />
     </record>
-    <record id="product_template_28" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_28" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="image_1920" type="base64" file="furniture_store/static/src/binary/product_template/28-image_1920" />
         <field name="name">Round table</field>
         <field name="list_price">2150.0</field>
@@ -240,7 +240,7 @@
         <field name="website_sequence">10135</field>
         <field name="public_categ_ids" eval="[(6, 0, [ref('product_public_category_11')])]" />
     </record>
-    <record id="product_template_17" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_17" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="image_1920" type="base64" file="furniture_store/static/src/binary/product_template/17-image_1920" />
         <field name="name">Simple round Led Ceiling </field>
         <field name="list_price">205.0</field>
@@ -254,7 +254,7 @@
         <field name="website_sequence">10080</field>
         <field name="public_categ_ids" eval="[(6, 0, [ref('product_public_category_6')])]" />
     </record>
-    <record id="product_template_19" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_19" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="image_1920" type="base64" file="furniture_store/static/src/binary/product_template/19-image_1920" />
         <field name="name">Style Led Ceiling </field>
         <field name="list_price">155.0</field>
@@ -268,7 +268,7 @@
         <field name="website_sequence">10090</field>
         <field name="public_categ_ids" eval="[(6, 0, [ref('product_public_category_6')])]" />
     </record>
-    <record id="product_template_26" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_26" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="image_1920" type="base64" file="furniture_store/static/src/binary/product_template/26-image_1920" />
         <field name="name">Vintage Table</field>
         <field name="list_price">2150.0</field>
@@ -282,7 +282,7 @@
         <field name="website_sequence">10125</field>
         <field name="public_categ_ids" eval="[(6, 0, [ref('product_public_category_11')])]" />
     </record>
-    <record id="product_template_20" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_20" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="image_1920" type="base64" file="furniture_store/static/src/binary/product_template/20-image_1920" />
         <field name="name">Wood effect</field>
         <field name="list_price">115.0</field>

--- a/furniture_store/data/product_template_attribute_line.xml
+++ b/furniture_store/data/product_template_attribute_line.xml
@@ -1,41 +1,41 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-  <record id="product_template_attribute_line_1" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_1" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_8"/>
     <field name="attribute_id" ref="product_barcodelookup.product_attribute_lookup_1"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_1'), ref('product_attribute_value_2')])]"/>
   </record>
-  <record id="product_template_attribute_line_8" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_8" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_28"/>
     <field name="attribute_id" ref="product_barcodelookup.product_attribute_lookup_1"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_1'), ref('product_attribute_value_2')])]"/>
   </record>
-  <record id="product_template_attribute_line_2" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_2" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_12"/>
     <field name="attribute_id" ref="product_barcodelookup.product_attribute_lookup_7"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_3'), ref('product_attribute_value_4'), ref('product_attribute_value_5')])]"/>
   </record>
-  <record id="product_template_attribute_line_3" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_3" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_24"/>
     <field name="attribute_id" ref="product_barcodelookup.product_attribute_lookup_7"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_3'), ref('product_attribute_value_4'), ref('product_attribute_value_5')])]"/>
   </record>
-  <record id="product_template_attribute_line_4" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_4" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_25"/>
     <field name="attribute_id" ref="product_barcodelookup.product_attribute_lookup_7"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_3'), ref('product_attribute_value_4'), ref('product_attribute_value_5')])]"/>
   </record>
-  <record id="product_template_attribute_line_5" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_5" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_26"/>
     <field name="attribute_id" ref="product_barcodelookup.product_attribute_lookup_7"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_3'), ref('product_attribute_value_4'), ref('product_attribute_value_5')])]"/>
   </record>
-  <record id="product_template_attribute_line_6" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_6" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_27"/>
     <field name="attribute_id" ref="product_barcodelookup.product_attribute_lookup_7"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_3'), ref('product_attribute_value_4'), ref('product_attribute_value_5')])]"/>
   </record>
-  <record id="product_template_attribute_line_10" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_10" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_11"/>
     <field name="attribute_id" ref="product_barcodelookup.product_attribute_lookup_7"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_6'), ref('product_attribute_value_7')])]"/>

--- a/gallery/data/product_template.xml
+++ b/gallery/data/product_template.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-  <record id="product_template_15" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_15" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="image_1920" type="base64" file="gallery/static/src/binary/product_template/15-image_1920"/>
     <field name="name">Calm River</field>
     <field name="description_sale"><![CDATA[Claude Money]]></field>
@@ -17,7 +17,7 @@
     <field name="website_sequence">10070</field>
     <field name="public_categ_ids" eval="[(6, 0, [ref('product_public_category_1')])]"/>
   </record>
-  <record id="product_template_20" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_20" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="image_1920" type="base64" file="gallery/static/src/binary/product_template/20-image_1920"/>
     <field name="name">Chair</field>
     <field name="description_sale"><![CDATA[Thomas Chippendeal]]></field>
@@ -34,7 +34,7 @@
     <field name="website_sequence">10095</field>
     <field name="public_categ_ids" eval="[(6, 0, [ref('product_public_category_4')])]"/>
   </record>
-  <record id="product_template_26" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_26" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="name">Commissioned Artwork</field>
     <field name="type">service</field>
     <field name="sale_ok" eval="False"/>
@@ -45,7 +45,7 @@
     <field name="invoice_policy">order</field>
     <field name="website_sequence">10120</field>
   </record>
-  <record id="product_template_19" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_19" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="image_1920" type="base64" file="gallery/static/src/binary/product_template/19-image_1920"/>
     <field name="name">Country Roads</field>
     <field name="description_sale"><![CDATA[Ainsel Adooms]]></field>
@@ -62,7 +62,7 @@
     <field name="website_sequence">10090</field>
     <field name="public_categ_ids" eval="[(6, 0, [ref('product_public_category_3')])]"/>
   </record>
-  <record id="product_template_9" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_9" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="image_1920" type="base64" file="gallery/static/src/binary/product_template/9-image_1920"/>
     <field name="name">Dreams of Flying</field>
     <field name="description"><![CDATA[<div data-oe-version="1.1"><br></div>]]></field>
@@ -80,7 +80,7 @@
     <field name="website_sequence">10040</field>
     <field name="public_categ_ids" eval="[(6, 0, [ref('product_public_category_1')])]"/>
   </record>
-  <record id="product_template_11" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_11" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="image_1920" type="base64" file="gallery/static/src/binary/product_template/22-image_1920"/>
     <field name="name">Once Upon a Time Before POS</field>
     <field name="description_sale"><![CDATA[ Peter Paul Odoobens]]></field>
@@ -94,7 +94,7 @@
     <field name="description_ecommerce"><![CDATA[<div data-oe-version=\"1.1\">The <strong>grand visions of Peter Paul Odoobens</strong> bring drama and movement to life with masterful strokes. His Baroque compositions, filled with rich contrasts and dynamic figures, capture the essence of power, emotion, and storytelling. In every scene, light and shadow dance together, transforming myth and history into timeless spectacle.</div>]]></field>
     <field name="website_sequence">10050</field>
   </record>
-  <record id="product_template_21" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_21" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="image_1920" type="base64" file="gallery/static/src/binary/product_template/21-image_1920"/>
     <field name="name">Dresser</field>
     <field name="description_sale"><![CDATA[Thomas Chippendeal]]></field>
@@ -111,7 +111,7 @@
     <field name="website_sequence">10100</field>
     <field name="public_categ_ids" eval="[(6, 0, [ref('product_public_category_4')])]"/>
   </record>
-  <record id="product_template_29" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_29" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="name">Artist's Resale Right</field>
     <field name="categ_id" ref="product_category_9"/>
     <field name="responsible_id" ref="base.user_admin"/>
@@ -121,7 +121,7 @@
     <field name="website_sequence">10140</field>
     <field name="base_unit_count">1.0</field>
   </record>
-  <record id="product_template_14" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_14" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="image_1920" type="base64" file="gallery/static/src/binary/product_template/14-image_1920"/>
     <field name="name">Mountain View</field>
     <field name="description_sale"><![CDATA[Claude Money]]></field>
@@ -138,7 +138,7 @@
     <field name="website_sequence">10060</field>
     <field name="public_categ_ids" eval="[(6, 0, [ref('product_public_category_1')])]"/>
   </record>
-  <record id="product_template_8" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_8" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="image_1920" type="base64" file="gallery/static/src/binary/product_template/8-image_1920"/>
     <field name="name">Rain on the Horizon</field>
     <field name="description_sale"><![CDATA[Salvador Dall-E]]></field>
@@ -155,7 +155,7 @@
     <field name="website_sequence">10065</field>
     <field name="public_categ_ids" eval="[(6, 0, [ref('product_public_category_1')])]"/>
   </record>
-  <record id="product_template_10" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_10" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="image_1920" type="base64" file="gallery/static/src/binary/product_template/10-image_1920"/>
     <field name="name">Salvation</field>
     <field name="description_sale"><![CDATA[Peter Paul Rewbens]]></field>
@@ -172,7 +172,7 @@
     <field name="website_sequence">10035</field>
     <field name="allow_out_of_stock_order" eval="True"/>
   </record>
-  <record id="product_template_17" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_17" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="image_1920" type="base64" file="gallery/static/src/binary/product_template/17-image_1920"/>
     <field name="name">Saturday Night</field>
     <field name="description_sale"><![CDATA[Auguste Crodin]]></field>
@@ -189,7 +189,7 @@
     <field name="website_sequence">10080</field>
     <field name="public_categ_ids" eval="[(6, 0, [ref('product_public_category_2')])]"/>
   </record>
-  <record id="product_template_16" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_16" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="image_1920" type="base64" file="gallery/static/src/binary/product_template/16-image_1920"/>
     <field name="name">Stroll in the Park</field>
     <field name="description_sale"><![CDATA[Auguste Crodin]]></field>
@@ -206,7 +206,7 @@
     <field name="website_sequence">10075</field>
     <field name="public_categ_ids" eval="[(6, 0, [ref('product_public_category_2')])]"/>
   </record>
-  <record id="product_template_24" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_24" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="image_1920" type="base64" file="gallery/static/src/binary/product_template/24-image_1920"/>
     <field name="name">The Great Wave of Ramillies</field>
     <field name="description_sale"><![CDATA[Katsushike Hodusai]]></field>
@@ -224,7 +224,7 @@
     <field name="public_categ_ids" eval="[(6, 0, [ref('product_public_category_5')])]"/>
     <field name="show_availability" eval="True"/>
   </record>
-  <record id="product_template_22" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_22" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="image_1920" type="base64" file="gallery/static/src/binary/product_template/22-image_1920"/>
     <field name="name">The Market of Genoa</field>
     <field name="description_sale"><![CDATA[Peter Paul Rewbens]]></field>
@@ -241,7 +241,7 @@
     <field name="website_sequence">10105</field>
     <field name="allow_out_of_stock_order" eval="True"/>
   </record>
-  <record id="product_template_23" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_23" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="image_1920" type="base64" file="gallery/static/src/binary/product_template/23-image_1920"/>
     <field name="name">The Odoovian Man</field>
     <field name="description_sale"><![CDATA[Leonodoo da Vinci]]></field>
@@ -258,7 +258,7 @@
     <field name="website_sequence">10110</field>
     <field name="public_categ_ids" eval="[(6, 0, [ref('product_public_category_1')])]"/>
   </record>
-  <record id="product_template_13" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_13" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="image_1920" type="base64" file="gallery/static/src/binary/product_template/13-image_1920"/>
     <field name="name">The Reader</field>
     <field name="description_sale"><![CDATA[Bablo Fincasso]]></field>
@@ -276,7 +276,7 @@
     <field name="public_categ_ids" eval="[(6, 0, [ref('product_public_category_1')])]"/>
     <field name="allow_out_of_stock_order" eval="True"/>
   </record>
-  <record id="product_template_18" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_18" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="image_1920" type="base64" file="gallery/static/src/binary/product_template/18-image_1920"/>
     <field name="name">The Trail of Tears</field>
     <field name="description_sale"><![CDATA[Ainsel Adooms]]></field>
@@ -293,7 +293,7 @@
     <field name="website_sequence">10085</field>
     <field name="public_categ_ids" eval="[(6, 0, [ref('product_public_category_3')])]"/>
   </record>
-  <record id="product_template_12" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_12" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="image_1920" type="base64" file="gallery/static/src/binary/product_template/12-image_1920"/>
     <field name="name">Visions from Distance</field>
     <field name="description_sale"><![CDATA[Bablo Ficasso]]></field>

--- a/gallery/data/product_template_attribute_line.xml
+++ b/gallery/data/product_template_attribute_line.xml
@@ -1,176 +1,176 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1" auto_sequence="1">
-  <record id="product_template_attribute_line_2" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_2" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="attribute_id" ref="product_attribute_11"/>
     <field name="product_tmpl_id" ref="product_template_23"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_5')])]"/>
   </record>
-  <record id="product_template_attribute_line_5" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_5" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_8"/>
     <field name="attribute_id" ref="product_attribute_11"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_8')])]"/>
   </record>
-  <record id="product_template_attribute_line_8" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_8" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_9"/>
     <field name="attribute_id" ref="product_attribute_11"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_8')])]"/>
   </record>
-  <record id="product_template_attribute_line_11" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_11" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_10"/>
     <field name="attribute_id" ref="product_attribute_11"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_14')])]"/>
   </record>
-  <record id="product_template_attribute_line_14" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_14" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="attribute_id" ref="product_attribute_11"/>
     <field name="product_tmpl_id" ref="product_template_11"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_14')])]"/>
   </record>
-  <record id="product_template_attribute_line_17" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_17" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_12"/>
     <field name="attribute_id" ref="product_attribute_11"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_7')])]"/>
   </record>
-  <record id="product_template_attribute_line_20" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_20" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_13"/>
     <field name="attribute_id" ref="product_attribute_11"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_7')])]"/>
   </record>
-  <record id="product_template_attribute_line_23" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_23" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_14"/>
     <field name="attribute_id" ref="product_attribute_11"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_6')])]"/>
   </record>
-  <record id="product_template_attribute_line_26" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_26" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_15"/>
     <field name="attribute_id" ref="product_attribute_11"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_6')])]"/>
   </record>
-  <record id="product_template_attribute_line_30" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_30" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_16"/>
     <field name="attribute_id" ref="product_attribute_11"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_16')])]"/>
   </record>
-  <record id="product_template_attribute_line_33" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_33" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_17"/>
     <field name="attribute_id" ref="product_attribute_11"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_16')])]"/>
   </record>
-  <record id="product_template_attribute_line_36" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_36" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_18"/>
     <field name="attribute_id" ref="product_attribute_11"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_16')])]"/>
   </record>
-  <record id="product_template_attribute_line_39" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_39" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_19"/>
     <field name="attribute_id" ref="product_attribute_11"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_16')])]"/>
   </record>
-  <record id="product_template_attribute_line_41" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_41" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_20"/>
     <field name="attribute_id" ref="product_attribute_11"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_19')])]"/>
   </record>
-  <record id="product_template_attribute_line_44" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_44" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_21"/>
     <field name="attribute_id" ref="product_attribute_11"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_19')])]"/>
   </record>
-  <record id="product_template_attribute_line_47" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_47" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_22"/>
     <field name="attribute_id" ref="product_attribute_11"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_14')])]"/>
   </record>
-  <record id="product_template_attribute_line_50" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_50" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_23"/>
     <field name="attribute_id" ref="product_attribute_11"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_5')])]"/>
   </record>
-  <record id="product_template_attribute_line_53" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_53" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_24"/>
     <field name="attribute_id" ref="product_attribute_12"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_9')])]"/>
   </record>
-  <record id="product_template_attribute_line_3" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_3" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="attribute_id" ref="product_attribute_12"/>
     <field name="product_tmpl_id" ref="product_template_23"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_9')])]"/>
   </record>
-  <record id="product_template_attribute_line_6" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_6" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_8"/>
     <field name="attribute_id" ref="product_attribute_12"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_9')])]"/>
   </record>
-  <record id="product_template_attribute_line_9" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_9" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_9"/>
     <field name="attribute_id" ref="product_attribute_12"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_9')])]"/>
   </record>
-  <record id="product_template_attribute_line_12" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_12" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_10"/>
     <field name="attribute_id" ref="product_attribute_12"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_9')])]"/>
   </record>
-  <record id="product_template_attribute_line_15" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_15" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="attribute_id" ref="product_attribute_12"/>
     <field name="product_tmpl_id" ref="product_template_11"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_9')])]"/>
   </record>
-  <record id="product_template_attribute_line_18" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_18" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_12"/>
     <field name="attribute_id" ref="product_attribute_12"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_11')])]"/>
   </record>
-  <record id="product_template_attribute_line_21" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_21" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_13"/>
     <field name="attribute_id" ref="product_attribute_12"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_11')])]"/>
   </record>
-  <record id="product_template_attribute_line_24" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_24" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_14"/>
     <field name="attribute_id" ref="product_attribute_12"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_9')])]"/>
   </record>
-  <record id="product_template_attribute_line_27" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_27" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_15"/>
     <field name="attribute_id" ref="product_attribute_12"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_9')])]"/>
   </record>
-  <record id="product_template_attribute_line_29" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_29" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_16"/>
     <field name="attribute_id" ref="product_attribute_12"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_10')])]"/>
   </record>
-  <record id="product_template_attribute_line_32" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_32" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_17"/>
     <field name="attribute_id" ref="product_attribute_12"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_10')])]"/>
   </record>
-  <record id="product_template_attribute_line_35" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_35" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_18"/>
     <field name="attribute_id" ref="product_attribute_12"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_10')])]"/>
   </record>
-  <record id="product_template_attribute_line_38" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_38" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_19"/>
     <field name="attribute_id" ref="product_attribute_12"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_10')])]"/>
   </record>
-  <record id="product_template_attribute_line_42" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_42" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_20"/>
     <field name="attribute_id" ref="product_attribute_12"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_9')])]"/>
   </record>
-  <record id="product_template_attribute_line_45" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_45" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_21"/>
     <field name="attribute_id" ref="product_attribute_12"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_9')])]"/>
   </record>
-  <record id="product_template_attribute_line_48" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_48" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_22"/>
     <field name="attribute_id" ref="product_attribute_12"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_9')])]"/>
   </record>
-  <record id="product_template_attribute_line_51" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_51" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_23"/>
     <field name="attribute_id" ref="product_attribute_12"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_9')])]"/>

--- a/gardening/data/product_template.xml
+++ b/gardening/data/product_template.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-    <record id="product_template_4" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_4" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Compost (50KG)</field>
         <field name="list_price">20.0</field>
         <field name="is_storable" eval="True"/>
@@ -9,7 +9,7 @@
         <field name="invoice_policy">delivery</field>
         <field name="image_1920" type="base64" file="gardening/static/src/binary/product/Compost.jpg"/>
     </record>
-    <record id="product_template_5" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_5" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Fertilizers (5L)</field>
         <field name="list_price">10.0</field>
         <field name="is_storable" eval="True"/>
@@ -18,7 +18,7 @@
         <field name="invoice_policy">delivery</field>
         <field name="image_1920" type="base64" file="gardening/static/src/binary/product/Fertilizers.jpg"/>
     </record>
-    <record id="product_template_6" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_6" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Soil (50KG)</field>
         <field name="list_price">15.0</field>
         <field name="is_storable" eval="True"/>

--- a/gardening/data/product_template_attribute_line.xml
+++ b/gardening/data/product_template_attribute_line.xml
@@ -1,11 +1,11 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-    <record id="product_template_attribute_line_1" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_1" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_4"/>
         <field name="attribute_id" ref="product_attribute_9"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_1'), ref('product_attribute_value_2')])]"/>
     </record>
-    <record id="product_template_attribute_line_2" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_2" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_6"/>
         <field name="attribute_id" ref="product_attribute_9"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_3'), ref('product_attribute_value_4'), ref('product_attribute_value_5')])]"/>

--- a/guest_house/data/product_template.xml
+++ b/guest_house/data/product_template.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-  <record id="product_template_11" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_11" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="image_1920" type="base64" file="guest_house/static/src/binary/product_template/9-image_1920"/>
     <field name="name">Free Cancellation</field>
     <field name="type">service</field>
@@ -13,7 +13,7 @@
     <field name="website_sequence">10050</field>
     <field name="base_unit_count">1.0</field>
   </record>
-  <record id="product_template_12" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_12" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="name">Breakfast (1 guest)</field>
     <field name="image_1920" type="base64" file="guest_house/static/src/binary/product_template/11-image_1920"/>
     <field name="type">service</field>
@@ -24,7 +24,7 @@
     <field name="service_type">manual</field>
     <field name="invoice_policy">order</field>
   </record>
-  <record id="product_template_17" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_17" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="image_1920" type="base64" file="guest_house/static/src/binary/product_template/17-image_1920"/>
     <field name="name">Comfy Room (2 guests)</field>
     <field name="type">service</field>
@@ -42,7 +42,7 @@
     <field name="x_has_city_tax" eval="True"/> 
     <field name="x_offer_type">STD</field>
   </record>
-  <record id="product_template_20" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_20" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="image_1920" type="base64" file="guest_house/static/src/binary/product_template/20-image_1920"/>
     <field name="name">Dinner Plate (1 guest)</field>
     <field name="type">service</field>
@@ -54,7 +54,7 @@
     <field name="description_ecommerce"><![CDATA[<div data-oe-version="2.0">Enjoy a beautifully arranged board featuring a curated selection of local cheeses, premium cured meats, fresh bread, and seasonal accompaniments.</div><div>Perfect for a relaxed evening at the property.</div>]]></field>
     <field name="website_sequence">10095</field>
   </record>
-  <record id="product_template_14" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_14" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="image_1920" type="base64" file="guest_house/static/src/binary/product_template/14-image_1920"/>
     <field name="name">Fireplace Room (2 guests)</field>
     <field name="type">service</field>
@@ -72,7 +72,7 @@
     <field name="x_has_city_tax" eval="True"/> 
     <field name="x_offer_type">SUP</field>
   </record>
-  <record id="product_template_19" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_19" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="image_1920" type="base64" file="guest_house/static/src/binary/product_template/19-image_1920"/>
     <field name="name">Garden Room (2 guests)</field>
     <field name="type">service</field>
@@ -90,7 +90,7 @@
     <field name="x_has_city_tax" eval="True"/> 
     <field name="x_offer_type">SUP</field>
   </record>
-  <record id="product_template_16" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_16" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="image_1920" type="base64" file="guest_house/static/src/binary/product_template/16-image_1920"/>
     <field name="name">Renaissance Room (2 guests)</field>
     <field name="type">service</field>
@@ -108,7 +108,7 @@
     <field name="x_has_city_tax" eval="True"/> 
     <field name="x_offer_type">SUP</field>
   </record>
-  <record id="product_template_18" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_18" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="image_1920" type="base64" file="guest_house/static/src/binary/product_template/18-image_1920"/>
     <field name="name">Roof Room (2 guests)</field>
     <field name="type">service</field>
@@ -126,7 +126,7 @@
     <field name="x_has_city_tax" eval="True"/> 
     <field name="x_offer_type">STD</field>
   </record>
-  <record id="product_template_15" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_15" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="image_1920" type="base64" file="guest_house/static/src/binary/product_template/15-image_1920"/>
     <field name="name">Studious Room (2 guests)</field>
     <field name="type">service</field>

--- a/guest_house/data/product_template_attribute_line.xml
+++ b/guest_house/data/product_template_attribute_line.xml
@@ -1,294 +1,294 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-  <record id="product_template_attribute_line_31" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_31" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_14"/>
     <field name="attribute_id" ref="booking_engine.product_attribute_10"/>
     <field name="value_ids" eval="[(6, 0, [ref('booking_engine.product_attribute_value_2')])]"/>
   </record>
-  <record id="product_template_attribute_line_43" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_43" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_15"/>
     <field name="attribute_id" ref="booking_engine.product_attribute_10"/>
     <field name="value_ids" eval="[(6, 0, [ref('booking_engine.product_attribute_value_2')])]"/>
   </record>
-  <record id="product_template_attribute_line_52" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_52" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_16"/>
     <field name="attribute_id" ref="booking_engine.product_attribute_10"/>
     <field name="value_ids" eval="[(6, 0, [ref('booking_engine.product_attribute_value_2')])]"/>
   </record>
-  <record id="product_template_attribute_line_61" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_61" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_17"/>
     <field name="attribute_id" ref="booking_engine.product_attribute_10"/>
     <field name="value_ids" eval="[(6, 0, [ref('booking_engine.product_attribute_value_2')])]"/>
   </record>
-  <record id="product_template_attribute_line_70" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_70" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_18"/>
     <field name="attribute_id" ref="booking_engine.product_attribute_10"/>
     <field name="value_ids" eval="[(6, 0, [ref('booking_engine.product_attribute_value_2')])]"/>
   </record>
-  <record id="product_template_attribute_line_79" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_79" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_19"/>
     <field name="attribute_id" ref="booking_engine.product_attribute_10"/>
     <field name="value_ids" eval="[(6, 0, [ref('booking_engine.product_attribute_value_2')])]"/>
   </record>
-  <record id="product_template_attribute_line_42" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_42" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_14"/>
     <field name="sequence">11</field>
     <field name="attribute_id" ref="booking_engine.product_attribute_20"/>
     <field name="value_ids" eval="[(6, 0, [ref('booking_engine.product_attribute_value_13')])]"/>
   </record>
-  <record id="product_template_attribute_line_51" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_51" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_15"/>
     <field name="sequence">11</field>
     <field name="attribute_id" ref="booking_engine.product_attribute_20"/>
     <field name="value_ids" eval="[(6, 0, [ref('booking_engine.product_attribute_value_13')])]"/>
   </record>
-  <record id="product_template_attribute_line_60" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_60" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_16"/>
     <field name="sequence">11</field>
     <field name="attribute_id" ref="booking_engine.product_attribute_20"/>
     <field name="value_ids" eval="[(6, 0, [ref('booking_engine.product_attribute_value_13')])]"/>
   </record>
-  <record id="product_template_attribute_line_87" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_87" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_19"/>
     <field name="sequence">11</field>
     <field name="attribute_id" ref="booking_engine.product_attribute_20"/>
     <field name="value_ids" eval="[(6, 0, [ref('booking_engine.product_attribute_value_13')])]"/>
   </record>
-  <record id="product_template_attribute_line_35" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_35" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_14"/>
     <field name="sequence">12</field>
     <field name="attribute_id" ref="booking_engine.product_attribute_11"/>
     <field name="value_ids" eval="[(6, 0, [ref('booking_engine.product_attribute_value_3')])]"/>
   </record>
-  <record id="product_template_attribute_line_47" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_47" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_15"/>
     <field name="sequence">12</field>
     <field name="attribute_id" ref="booking_engine.product_attribute_11"/>
     <field name="value_ids" eval="[(6, 0, [ref('booking_engine.product_attribute_value_3')])]"/>
   </record>
-  <record id="product_template_attribute_line_56" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_56" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_16"/>
     <field name="sequence">12</field>
     <field name="attribute_id" ref="booking_engine.product_attribute_11"/>
     <field name="value_ids" eval="[(6, 0, [ref('booking_engine.product_attribute_value_3')])]"/>
   </record>
-  <record id="product_template_attribute_line_65" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_65" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_17"/>
     <field name="sequence">12</field>
     <field name="attribute_id" ref="booking_engine.product_attribute_11"/>
     <field name="value_ids" eval="[(6, 0, [ref('booking_engine.product_attribute_value_3')])]"/>
   </record>
-  <record id="product_template_attribute_line_74" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_74" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_18"/>
     <field name="sequence">12</field>
     <field name="attribute_id" ref="booking_engine.product_attribute_11"/>
     <field name="value_ids" eval="[(6, 0, [ref('booking_engine.product_attribute_value_3')])]"/>
   </record>
-  <record id="product_template_attribute_line_83" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_83" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_19"/>
     <field name="sequence">12</field>
     <field name="attribute_id" ref="booking_engine.product_attribute_11"/>
     <field name="value_ids" eval="[(6, 0, [ref('booking_engine.product_attribute_value_3')])]"/>
   </record>
-  <record id="product_template_attribute_line_39" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_39" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_14"/>
     <field name="sequence">13</field>
     <field name="attribute_id" ref="booking_engine.product_attribute_16"/>
     <field name="value_ids" eval="[(6, 0, [ref('booking_engine.product_attribute_value_8')])]"/>
   </record>
-  <record id="product_template_attribute_line_48" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_48" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_15"/>
     <field name="sequence">13</field>
     <field name="attribute_id" ref="booking_engine.product_attribute_16"/>
     <field name="value_ids" eval="[(6, 0, [ref('booking_engine.product_attribute_value_8')])]"/>
   </record>
-  <record id="product_template_attribute_line_57" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_57" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_16"/>
     <field name="sequence">13</field>
     <field name="attribute_id" ref="booking_engine.product_attribute_16"/>
     <field name="value_ids" eval="[(6, 0, [ref('booking_engine.product_attribute_value_8')])]"/>
   </record>
-  <record id="product_template_attribute_line_66" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_66" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_17"/>
     <field name="sequence">13</field>
     <field name="attribute_id" ref="booking_engine.product_attribute_16"/>
     <field name="value_ids" eval="[(6, 0, [ref('booking_engine.product_attribute_value_8')])]"/>
   </record>
-  <record id="product_template_attribute_line_75" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_75" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_18"/>
     <field name="sequence">13</field>
     <field name="attribute_id" ref="booking_engine.product_attribute_16"/>
     <field name="value_ids" eval="[(6, 0, [ref('booking_engine.product_attribute_value_8')])]"/>
   </record>
-  <record id="product_template_attribute_line_84" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_84" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_19"/>
     <field name="sequence">13</field>
     <field name="attribute_id" ref="booking_engine.product_attribute_16"/>
     <field name="value_ids" eval="[(6, 0, [ref('booking_engine.product_attribute_value_8')])]"/>
   </record>
-  <record id="product_template_attribute_line_41" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_41" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_14"/>
     <field name="sequence">14</field>
     <field name="attribute_id" ref="booking_engine.product_attribute_13"/>
     <field name="value_ids" eval="[(6, 0, [ref('booking_engine.product_attribute_value_5')])]"/>
   </record>
-  <record id="product_template_attribute_line_50" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_50" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_15"/>
     <field name="sequence">14</field>
     <field name="attribute_id" ref="booking_engine.product_attribute_13"/>
     <field name="value_ids" eval="[(6, 0, [ref('booking_engine.product_attribute_value_5')])]"/>
   </record>
-  <record id="product_template_attribute_line_59" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_59" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_16"/>
     <field name="sequence">14</field>
     <field name="attribute_id" ref="booking_engine.product_attribute_13"/>
     <field name="value_ids" eval="[(6, 0, [ref('booking_engine.product_attribute_value_5')])]"/>
   </record>
-  <record id="product_template_attribute_line_68" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_68" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_17"/>
     <field name="sequence">14</field>
     <field name="attribute_id" ref="booking_engine.product_attribute_13"/>
     <field name="value_ids" eval="[(6, 0, [ref('booking_engine.product_attribute_value_5')])]"/>
   </record>
-  <record id="product_template_attribute_line_86" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_86" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_19"/>
     <field name="sequence">14</field>
     <field name="attribute_id" ref="booking_engine.product_attribute_13"/>
     <field name="value_ids" eval="[(6, 0, [ref('booking_engine.product_attribute_value_5')])]"/>
   </record>
-  <record id="product_template_attribute_line_32" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_32" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_14"/>
     <field name="sequence">15</field>
     <field name="attribute_id" ref="booking_engine.product_attribute_18"/>
     <field name="value_ids" eval="[(6, 0, [ref('booking_engine.product_attribute_value_10')])]"/>
   </record>
-  <record id="product_template_attribute_line_44" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_44" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_15"/>
     <field name="sequence">15</field>
     <field name="attribute_id" ref="booking_engine.product_attribute_18"/>
     <field name="value_ids" eval="[(6, 0, [ref('booking_engine.product_attribute_value_10')])]"/>
   </record>
-  <record id="product_template_attribute_line_53" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_53" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_16"/>
     <field name="sequence">15</field>
     <field name="attribute_id" ref="booking_engine.product_attribute_18"/>
     <field name="value_ids" eval="[(6, 0, [ref('booking_engine.product_attribute_value_10')])]"/>
   </record>
-  <record id="product_template_attribute_line_62" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_62" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_17"/>
     <field name="sequence">15</field>
     <field name="attribute_id" ref="booking_engine.product_attribute_18"/>
     <field name="value_ids" eval="[(6, 0, [ref('booking_engine.product_attribute_value_10')])]"/>
   </record>
-  <record id="product_template_attribute_line_71" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_71" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_18"/>
     <field name="sequence">15</field>
     <field name="attribute_id" ref="booking_engine.product_attribute_18"/>
     <field name="value_ids" eval="[(6, 0, [ref('booking_engine.product_attribute_value_10')])]"/>
   </record>
-  <record id="product_template_attribute_line_80" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_80" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_19"/>
     <field name="sequence">15</field>
     <field name="attribute_id" ref="booking_engine.product_attribute_18"/>
     <field name="value_ids" eval="[(6, 0, [ref('booking_engine.product_attribute_value_10')])]"/>
   </record>
-  <record id="product_template_attribute_line_33" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_33" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_14"/>
     <field name="sequence">16</field>
     <field name="attribute_id" ref="booking_engine.product_attribute_17"/>
     <field name="value_ids" eval="[(6, 0, [ref('booking_engine.product_attribute_value_9')])]"/>
   </record>
-  <record id="product_template_attribute_line_45" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_45" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_15"/>
     <field name="sequence">16</field>
     <field name="attribute_id" ref="booking_engine.product_attribute_17"/>
     <field name="value_ids" eval="[(6, 0, [ref('booking_engine.product_attribute_value_9')])]"/>
   </record>
-  <record id="product_template_attribute_line_54" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_54" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_16"/>
     <field name="sequence">16</field>
     <field name="attribute_id" ref="booking_engine.product_attribute_17"/>
     <field name="value_ids" eval="[(6, 0, [ref('booking_engine.product_attribute_value_9')])]"/>
   </record>
-  <record id="product_template_attribute_line_63" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_63" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_17"/>
     <field name="sequence">16</field>
     <field name="attribute_id" ref="booking_engine.product_attribute_17"/>
     <field name="value_ids" eval="[(6, 0, [ref('booking_engine.product_attribute_value_9')])]"/>
   </record>
-  <record id="product_template_attribute_line_72" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_72" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_18"/>
     <field name="sequence">16</field>
     <field name="attribute_id" ref="booking_engine.product_attribute_17"/>
     <field name="value_ids" eval="[(6, 0, [ref('booking_engine.product_attribute_value_9')])]"/>
   </record>
-  <record id="product_template_attribute_line_81" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_81" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_19"/>
     <field name="sequence">16</field>
     <field name="attribute_id" ref="booking_engine.product_attribute_17"/>
     <field name="value_ids" eval="[(6, 0, [ref('booking_engine.product_attribute_value_9')])]"/>
   </record>
-  <record id="product_template_attribute_line_34" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_34" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_14"/>
     <field name="sequence">17</field>
     <field name="attribute_id" ref="booking_engine.product_attribute_12"/>
     <field name="value_ids" eval="[(6, 0, [ref('booking_engine.product_attribute_value_4')])]"/>
   </record>
-  <record id="product_template_attribute_line_46" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_46" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_15"/>
     <field name="sequence">17</field>
     <field name="attribute_id" ref="booking_engine.product_attribute_12"/>
     <field name="value_ids" eval="[(6, 0, [ref('booking_engine.product_attribute_value_4')])]"/>
   </record>
-  <record id="product_template_attribute_line_55" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_55" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_16"/>
     <field name="sequence">17</field>
     <field name="attribute_id" ref="booking_engine.product_attribute_12"/>
     <field name="value_ids" eval="[(6, 0, [ref('booking_engine.product_attribute_value_4')])]"/>
   </record>
-  <record id="product_template_attribute_line_64" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_64" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_17"/>
     <field name="sequence">17</field>
     <field name="attribute_id" ref="booking_engine.product_attribute_12"/>
     <field name="value_ids" eval="[(6, 0, [ref('booking_engine.product_attribute_value_12')])]"/>
   </record>
-  <record id="product_template_attribute_line_73" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_73" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_18"/>
     <field name="sequence">17</field>
     <field name="attribute_id" ref="booking_engine.product_attribute_12"/>
     <field name="value_ids" eval="[(6, 0, [ref('booking_engine.product_attribute_value_12')])]"/>
   </record>
-  <record id="product_template_attribute_line_82" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_82" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_19"/>
     <field name="sequence">17</field>
     <field name="attribute_id" ref="booking_engine.product_attribute_12"/>
     <field name="value_ids" eval="[(6, 0, [ref('booking_engine.product_attribute_value_4')])]"/>
   </record>
-  <record id="product_template_attribute_line_40" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_40" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_14"/>
     <field name="sequence">18</field>
     <field name="attribute_id" ref="booking_engine.product_attribute_19"/>
     <field name="value_ids" eval="[(6, 0, [ref('booking_engine.product_attribute_value_11')])]"/>
   </record>
-  <record id="product_template_attribute_line_49" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_49" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_15"/>
     <field name="sequence">18</field>
     <field name="attribute_id" ref="booking_engine.product_attribute_19"/>
     <field name="value_ids" eval="[(6, 0, [ref('booking_engine.product_attribute_value_11')])]"/>
   </record>
-  <record id="product_template_attribute_line_58" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_58" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_16"/>
     <field name="sequence">18</field>
     <field name="attribute_id" ref="booking_engine.product_attribute_19"/>
     <field name="value_ids" eval="[(6, 0, [ref('booking_engine.product_attribute_value_11')])]"/>
   </record>
-  <record id="product_template_attribute_line_67" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_67" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_17"/>
     <field name="sequence">18</field>
     <field name="attribute_id" ref="booking_engine.product_attribute_19"/>
     <field name="value_ids" eval="[(6, 0, [ref('booking_engine.product_attribute_value_11')])]"/>
   </record>
-  <record id="product_template_attribute_line_85" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_85" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_19"/>
     <field name="sequence">18</field>
     <field name="attribute_id" ref="booking_engine.product_attribute_19"/>

--- a/hair_salon/data/product_product.xml
+++ b/hair_salon/data/product_product.xml
@@ -55,7 +55,7 @@
     <record id="product_product_6" model="product.product">
         <field name="product_tmpl_id" ref="product_template_6"/>
     </record>
-    <record id="product_product_26" model="product.product" context="{'create_product_product': False}">
+    <record id="product_product_26" model="product.product" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="purchase_ok" eval="False"/>
         <field name="sale_ok" eval="False"/>
         <field name="purchase_method">purchase</field>

--- a/hair_salon/data/product_template.xml
+++ b/hair_salon/data/product_template.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-    <record id="product_template_20" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_20" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="is_storable" eval="True"/>
         <field name="purchase_method">receive</field>
         <field name="available_in_pos" eval="True"/>
@@ -9,7 +9,7 @@
         <field name="pos_categ_ids" eval="[(6, 0, [ref('pos_category_3')])]"/>
         <field name="image_1920" type="base64" file="hair_salon/static/src/binary/product_template/Conditioner - 500ml.webp"/>
     </record>
-    <record id="product_template_21" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_21" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="is_storable" eval="True"/>
         <field name="purchase_method">receive</field>
         <field name="available_in_pos" eval="True"/>
@@ -18,7 +18,7 @@
         <field name="pos_categ_ids" eval="[(6, 0, [ref('pos_category_3')])]"/>
         <field name="image_1920" type="base64" file="hair_salon/static/src/binary/product_template/Hair Styling Gel - 250ml.jpg"/>
     </record>
-    <record id="product_template_22" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_22" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="is_storable" eval="True"/>
         <field name="purchase_method">receive</field>
         <field name="available_in_pos" eval="True"/>
@@ -27,7 +27,7 @@
         <field name="pos_categ_ids" eval="[(6, 0, [ref('pos_category_3')])]"/>
         <field name="image_1920" type="base64" file="hair_salon/static/src/binary/product_template/Hair Spray - 250ml.jpg"/>
     </record>
-    <record id="product_template_23" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_23" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="is_storable" eval="True"/>
         <field name="purchase_method">receive</field>
         <field name="available_in_pos" eval="True"/>
@@ -37,7 +37,7 @@
         <field name="pos_categ_ids" eval="[(6, 0, [ref('pos_category_3')])]"/>
         <field name="image_1920" type="base64" file="hair_salon/static/src/binary/product_template/Hair Dye Kit.webp"/>
     </record>
-    <record id="product_template_24" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_24" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="purchase_method">receive</field>
         <field name="name">Professional Shampoo 2L</field>
         <field name="sale_ok" eval="False"/>
@@ -46,7 +46,7 @@
         <field name="pos_categ_ids" eval="[(6, 0, [ref('pos_category_3')])]"/>
         <field name="image_1920" type="base64" file="hair_salon/static/src/binary/product_template/Shampoo - 500ml.webp"/>
     </record>
-    <record id="product_template_25" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_25" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="purchase_method">receive</field>
         <field name="name">Professional Conditionner 2L</field>
         <field name="sale_ok" eval="False"/>
@@ -66,7 +66,7 @@
         <field name="image_1920" type="base64" file="hair_salon/static/src/binary/product_template/Women's Haircut.png"/>
         <field name="type">service</field>
     </record>
-    <record id="product_template_5" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_5" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="purchase_method">purchase</field>
         <field name="available_in_pos" eval="True"/>
         <field name="name">Hair Coloring</field>
@@ -76,7 +76,7 @@
         <field name="pos_categ_ids" eval="[(6, 0, [ref('pos_category_4')])]"/>
         <field name="image_1920" type="base64" file="hair_salon/static/src/binary/product_template/Hair Coloring.png"/>
     </record>
-    <record id="product_template_6" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_6" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="is_storable" eval="True"/>
         <field name="purchase_method">receive</field>
         <field name="available_in_pos" eval="True"/>

--- a/hair_salon/data/product_template_attribute_line.xml
+++ b/hair_salon/data/product_template_attribute_line.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-    <record id="product_template_attribute_line_4" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_4" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_5"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_2'), ref('product_attribute_value_1')])]"/>
         <field name="attribute_id" ref="product_attribute_1"/>

--- a/hardware_shop/data/product_template.xml
+++ b/hardware_shop/data/product_template.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-    <record id="product_template_100" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_100" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Asian. Water Proofing Hydroloc</field>
         <field name="is_storable">True</field>
         <field name="is_favorite" eval="True"/>
@@ -10,7 +10,7 @@
         <field name="list_price">579.0</field>
         <field name="pos_categ_ids" eval="[ref('pos_category_4')]"/>
     </record>
-    <record id="product_template_102" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_102" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">BIRLA (arc) WALL PUTTY RAFF (MF) 40 kg</field>
         <field name="is_storable">True</field>
         <field name="available_in_pos" eval="True" />
@@ -19,7 +19,7 @@
         <field name="list_price">695.0</field>
         <field name="pos_categ_ids" eval="[ref('pos_category_4')]"/>
     </record>
-    <record id="product_template_104" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_104" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">JK Wall Putty Fine</field>
         <field name="is_storable">True</field>
         <field name="available_in_pos" eval="True" />
@@ -28,7 +28,7 @@
         <field name="list_price">44.5</field>
         <field name="pos_categ_ids" eval="[ref('pos_category_4')]"/>
     </record>
-    <record id="product_template_118" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_118" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Ring Lock [Tala]</field>
         <field name="is_storable">True</field>
         <field name="is_favorite" eval="True"/>
@@ -38,7 +38,7 @@
         <field name="list_price">116.0</field>
         <field name="pos_categ_ids" eval="[ref('pos_category_8')]"/>
     </record>
-    <record id="product_template_119" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_119" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Shutter Lock Side Ultra 3 Stroke</field>
         <field name="is_storable">True</field>
         <field name="available_in_pos" eval="True" />
@@ -47,7 +47,7 @@
         <field name="list_price">447.0</field>
         <field name="pos_categ_ids" eval="[ref('pos_category_8')]"/>
     </record>
-    <record id="product_template_120" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_120" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Sliding Lock Center</field>
         <field name="is_storable">True</field>
         <field name="available_in_pos" eval="True" />
@@ -56,7 +56,7 @@
         <field name="list_price">200.0</field>
         <field name="pos_categ_ids" eval="[ref('pos_category_8')]"/>
     </record>
-    <record id="product_template_121" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_121" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Socar Gas Pump 9" SGS 001-05 kg</field>
         <field name="is_storable">True</field>
         <field name="available_in_pos" eval="True" />
@@ -65,7 +65,7 @@
         <field name="list_price">410.0</field>
         <field name="pos_categ_ids" eval="[ref('pos_category_8')]"/>
     </record>
-    <record id="product_template_123" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_123" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">TAB Cabinet Handle (ZC)</field>
         <field name="is_storable">True</field>
         <field name="is_favorite" eval="True"/>
@@ -75,7 +75,7 @@
         <field name="list_price">565.0</field>
         <field name="pos_categ_ids" eval="[ref('pos_category_8')]"/>
     </record>
-    <record id="product_template_14" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_14" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Aqua Double Soap Dish</field>
         <field name="is_storable">True</field>
         <field name="is_favorite" eval="True"/>
@@ -85,7 +85,7 @@
         <field name="list_price">300.0</field>
         <field name="pos_categ_ids" eval="[ref('pos_category_2')]"/>
     </record>
-    <record id="product_template_53" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_53" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Aqua Towel Rack</field>
         <field name="is_storable">True</field>
         <field name="available_in_pos" eval="True" />
@@ -94,7 +94,7 @@
         <field name="list_price">2773.0</field>
         <field name="pos_categ_ids" eval="[ref('pos_category_2')]"/>
     </record>
-    <record id="product_template_56" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_56" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Bathroom Set [Com.]</field>
         <field name="is_storable">True</field>
         <field name="available_in_pos" eval="True" />
@@ -112,7 +112,7 @@
         <field name="pos_categ_ids" eval="[ref('pos_category_delivery')]"/>
     </record>
     
-    <record id="product_template_58" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_58" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">City Set Top Box Stand Brawon</field>
         <field name="is_storable">True</field>
         <field name="available_in_pos" eval="True" />
@@ -121,7 +121,7 @@
         <field name="list_price">311.0</field>
         <field name="pos_categ_ids" eval="[ref('pos_category_8')]"/>
     </record>
-    <record id="product_template_67" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_67" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Pioneer PVC Adhesive</field>
         <field name="is_storable">True</field>
         <field name="available_in_pos" eval="True" />
@@ -130,7 +130,7 @@
         <field name="list_price">337.0</field>
         <field name="pos_categ_ids" eval="[ref('pos_category_4')]"/>
     </record>
-    <record id="product_template_69" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_69" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Roff Epoxy [Tiles]</field>
         <field name="is_storable">True</field>
         <field name="available_in_pos" eval="True" />
@@ -139,7 +139,7 @@
         <field name="list_price">652.67</field>
         <field name="pos_categ_ids" eval="[ref('pos_category_4')]"/>
     </record>
-    <record id="product_template_7" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_7" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Gift Card</field>
         <field name="type">service</field>
         <field name="purchase_method">purchase</field>
@@ -147,7 +147,7 @@
         <field name="purchase_ok" eval="False" />
         <field name="sale_ok" eval="False" />
     </record>
-    <record id="product_template_70" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_70" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Mario Super Water Tank</field>
         <field name="is_storable">True</field>
         <field name="available_in_pos" eval="True" />

--- a/hardware_shop/data/product_template_attribute_line.xml
+++ b/hardware_shop/data/product_template_attribute_line.xml
@@ -1,26 +1,26 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-    <record id="product_template_attribute_line_11" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_11" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="attribute_id" ref="product_attribute_6"/>
         <field name="product_tmpl_id" ref="product_template_118"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_11'), ref('product_attribute_value_12')])]"/>
     </record>
-    <record id="product_template_attribute_line_3" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_3" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="attribute_id" ref="product_attribute_4"/>
         <field name="product_tmpl_id" ref="product_template_70"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_3'), ref('product_attribute_value_4')])]"/>
     </record>
-    <record id="product_template_attribute_line_6" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_6" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="attribute_id" ref="product_attribute_brand"/>
         <field name="product_tmpl_id" ref="product_template_120"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_6'), ref('product_attribute_value_7')])]"/>
     </record>
-    <record id="product_template_attribute_line_7" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_7" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="attribute_id" ref="product_attribute_brand"/>
         <field name="product_tmpl_id" ref="product_template_14"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_6'), ref('product_attribute_value_7')])]"/>
     </record>
-    <record id="product_template_attribute_line_9" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_9" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="attribute_id" ref="product_attribute_brand"/>
         <field name="product_tmpl_id" ref="product_template_123"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_6'), ref('product_attribute_value_10')])]"/>

--- a/holiday_house/data/product_template.xml
+++ b/holiday_house/data/product_template.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-  <record id="product_template_11" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_11" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="image_1920" type="base64" file="holiday_house/static/src/binary/product_template/11-image_1920"/>
     <field name="name">Free Cancellation</field>
     <field name="type">service</field>
@@ -12,7 +12,7 @@
     <field name="description_ecommerce"><![CDATA[<div data-oe-version="2.0">Free cancellation up to 48h prior your stay.<br>50% refund within the 48h.</div><div>No refund on no-show.</div>]]></field>
     <field name="base_unit_count">1.0</field>
   </record>
-  <record id="product_template_14" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_14" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="image_1920" type="base64" file="holiday_house/static/src/binary/product_template/14-image_1920"/>
     <field name="name">Beach House</field>
     <field name="type">service</field>
@@ -40,7 +40,7 @@
     <field name="x_has_city_tax" eval="True"/> 
     <field name="x_offer_type">DLX</field>
   </record>
-  <record id="product_template_12" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_12" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="image_1920" type="base64" file="holiday_house/static/src/binary/product_template/12-image_1920"/>
     <field name="name">Hobbit House</field>
     <field name="type">service</field>
@@ -68,7 +68,7 @@
     <field name="x_has_city_tax" eval="True"/> 
     <field name="x_offer_type">STD</field>
   </record>
-  <record id="product_template_13" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_13" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="image_1920" type="base64" file="holiday_house/static/src/binary/product_template/13-image_1920"/>
     <field name="name">A-frame Cabin</field>
     <field name="type">service</field>

--- a/holiday_house/data/product_template_attribute_line.xml
+++ b/holiday_house/data/product_template_attribute_line.xml
@@ -1,71 +1,71 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-  <record id="product_template_attribute_line_60" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_60" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_13"/>
     <field name="attribute_id" ref="booking_engine.product_attribute_11"/>
     <field name="value_ids" eval="[(6, 0, [ref('booking_engine.product_attribute_value_3')])]"/>
   </record>
-  <record id="product_template_attribute_line_53" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_53" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_12"/>
     <field name="attribute_id" ref="booking_engine.product_attribute_16"/>
     <field name="value_ids" eval="[(6, 0, [ref('booking_engine.product_attribute_value_8')])]"/>
   </record>
-  <record id="product_template_attribute_line_61" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_61" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_13"/>
     <field name="attribute_id" ref="booking_engine.product_attribute_16"/>
     <field name="value_ids" eval="[(6, 0, [ref('booking_engine.product_attribute_value_8')])]"/>
   </record>
-  <record id="product_template_attribute_line_54" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_54" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_12"/>
     <field name="attribute_id" ref="booking_engine.product_attribute_13"/>
     <field name="value_ids" eval="[(6, 0, [ref('booking_engine.product_attribute_value_5')])]"/>
   </record>
-  <record id="product_template_attribute_line_62" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_62" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_13"/>
     <field name="attribute_id" ref="booking_engine.product_attribute_13"/>
     <field name="value_ids" eval="[(6, 0, [ref('booking_engine.product_attribute_value_5')])]"/>
   </record>
-  <record id="product_template_attribute_line_55" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_55" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_12"/>
     <field name="attribute_id" ref="booking_engine.product_attribute_18"/>
     <field name="value_ids" eval="[(6, 0, [ref('booking_engine.product_attribute_value_10')])]"/>
   </record>
-  <record id="product_template_attribute_line_63" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_63" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_13"/>
     <field name="attribute_id" ref="booking_engine.product_attribute_18"/>
     <field name="value_ids" eval="[(6, 0, [ref('booking_engine.product_attribute_value_10')])]"/>
   </record>
-  <record id="product_template_attribute_line_56" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_56" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_12"/>
     <field name="attribute_id" ref="booking_engine.product_attribute_17"/>
     <field name="value_ids" eval="[(6, 0, [ref('booking_engine.product_attribute_value_9')])]"/>
   </record>
-  <record id="product_template_attribute_line_64" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_64" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_13"/>
     <field name="attribute_id" ref="booking_engine.product_attribute_17"/>
     <field name="value_ids" eval="[(6, 0, [ref('booking_engine.product_attribute_value_9')])]"/>
   </record>
-  <record id="product_template_attribute_line_68" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_68" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_14"/>
     <field name="attribute_id" ref="booking_engine.product_attribute_11"/>
     <field name="value_ids" eval="[(6, 0, [ref('booking_engine.product_attribute_value_3')])]"/>
   </record>
-  <record id="product_template_attribute_line_69" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_69" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_14"/>
     <field name="attribute_id" ref="booking_engine.product_attribute_16"/>
     <field name="value_ids" eval="[(6, 0, [ref('booking_engine.product_attribute_value_8')])]"/>
   </record>
-  <record id="product_template_attribute_line_70" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_70" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_14"/>
     <field name="attribute_id" ref="booking_engine.product_attribute_13"/>
     <field name="value_ids" eval="[(6, 0, [ref('booking_engine.product_attribute_value_5')])]"/>
   </record>
-  <record id="product_template_attribute_line_71" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_71" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_14"/>
     <field name="attribute_id" ref="booking_engine.product_attribute_18"/>
     <field name="value_ids" eval="[(6, 0, [ref('booking_engine.product_attribute_value_10')])]"/>
   </record>
-  <record id="product_template_attribute_line_72" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_72" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_14"/>
     <field name="attribute_id" ref="booking_engine.product_attribute_17"/>
     <field name="value_ids" eval="[(6, 0, [ref('booking_engine.product_attribute_value_9')])]"/>

--- a/hotel/data/product_template.xml
+++ b/hotel/data/product_template.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-  <record id="product_template_11" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_11" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="image_1920" type="base64" file="hotel/static/src/binary/product_template/11-image_1920"/>
     <field name="name">Free Cancellation</field>
     <field name="type">service</field>
@@ -10,7 +10,7 @@
     <field name="service_type">manual</field>
     <field name="invoice_policy">order</field>
   </record>
-  <record id="product_template_12" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_12" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="image_1920" type="base64" file="hotel/static/src/binary/product_template/12-image_1920"/>
     <field name="name">Breakfast</field>
     <field name="type">service</field>
@@ -23,7 +23,7 @@
     <field name="available_in_pos" eval="True"/>
     <field name="pos_categ_ids" eval="[(6, 0, [ref('pos_category_1')])]"/>
   </record>
-  <record id="product_template_14" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_14" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="image_1920" type="base64" file="hotel/static/src/binary/product_template/breakfast-tray"/>
     <field name="name">Breakfast Tray</field>
     <field name="type">service</field>
@@ -35,7 +35,7 @@
     <field name="available_in_pos" eval="True"/>
     <field name="pos_categ_ids" eval="[(6, 0, [ref('pos_category_1')])]"/>
   </record>
-  <record id="product_template_15" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_15" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="image_1920" type="base64" file="hotel/static/src/binary/product_template/dinner-tray"/>
     <field name="name">Dinner Tray</field>
     <field name="type">service</field>
@@ -47,7 +47,7 @@
     <field name="available_in_pos" eval="True"/>
     <field name="pos_categ_ids" eval="[(6, 0, [ref('pos_category_1')])]"/>
   </record>
-  <record id="product_template_16" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_16" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="image_1920" type="base64" file="hotel/static/src/binary/product_template/champagne"/>
     <field name="name">Champagne Bottle</field>
     <field name="type">service</field>
@@ -59,7 +59,7 @@
     <field name="available_in_pos" eval="True"/>
     <field name="pos_categ_ids" eval="[(6, 0, [ref('pos_category_1')])]"/>
   </record>
-  <record id="product_template_17" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_17" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="image_1920" type="base64" file="hotel/static/src/binary/product_template/shuttle"/>
     <field name="name">Airport Shuttle</field>
     <field name="type">service</field>
@@ -71,7 +71,7 @@
     <field name="available_in_pos" eval="True"/>
     <field name="pos_categ_ids" eval="[(6, 0, [ref('pos_category_1')])]"/>
   </record>
-  <record id="product_template_10" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_10" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="image_1920" type="base64" file="hotel/static/src/binary/product_template/10-image_1920"/>
     <field name="name">Deluxe Suite</field>
     <field name="type">service</field>
@@ -87,7 +87,7 @@
     <field name="x_has_city_tax" eval="True"/> 
     <field name="x_offer_type">SUI</field>
   </record>
-  <record id="product_template_9" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_9" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="image_1920" type="base64" file="hotel/static/src/binary/product_template/9-image_1920"/>
     <field name="name">Deluxe Room</field>
     <field name="type">service</field>
@@ -104,7 +104,7 @@
     <field name="x_has_city_tax" eval="True"/>
     <field name="x_offer_type">DLX</field>
   </record>
-  <record id="product_template_8" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_8" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="image_1920" type="base64" file="hotel/static/src/binary/product_template/8-image_1920"/>
     <field name="name">Standard Room</field>
     <field name="type">service</field>

--- a/hotel/data/product_template_attribute_line.xml
+++ b/hotel/data/product_template_attribute_line.xml
@@ -1,181 +1,181 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo auto_sequence="1" noupdate="1">
-  <record id="product_template_attribute_line_1" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_1" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_9"/>
     <field name="attribute_id" ref="booking_engine.product_attribute_10"/>
     <field name="value_ids" eval="[(6, 0, [ref('booking_engine.product_attribute_value_1'), ref('booking_engine.product_attribute_value_2')])]"/>
   </record>
-  <record id="product_template_attribute_line_2" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_2" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_10"/>
     <field name="attribute_id" ref="booking_engine.product_attribute_10"/>
     <field name="value_ids" eval="[(6, 0, [ref('booking_engine.product_attribute_value_1'), ref('booking_engine.product_attribute_value_2')])]"/>
   </record>
-  <record id="product_template_attribute_line_3" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_3" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_8"/>
     <field name="attribute_id" ref="booking_engine.product_attribute_10"/>
     <field name="value_ids" eval="[(6, 0, [ref('booking_engine.product_attribute_value_1'), ref('booking_engine.product_attribute_value_2')])]"/>
   </record>
-  <record id="product_template_attribute_line_11" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_11" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_9"/>
     <field name="attribute_id" ref="booking_engine.product_attribute_18"/>
     <field name="value_ids" eval="[(6, 0, [ref('booking_engine.product_attribute_value_10')])]"/>
   </record>
-  <record id="product_template_attribute_line_20" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_20" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_10"/>
     <field name="attribute_id" ref="booking_engine.product_attribute_18"/>
     <field name="value_ids" eval="[(6, 0, [ref('booking_engine.product_attribute_value_10')])]"/>
   </record>
-  <record id="product_template_attribute_line_29" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_29" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_8"/>
     <field name="attribute_id" ref="booking_engine.product_attribute_18"/>
     <field name="value_ids" eval="[(6, 0, [ref('booking_engine.product_attribute_value_10')])]"/>
   </record>
-  <record id="product_template_attribute_line_10" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_10" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_9"/>
     <field name="attribute_id" ref="booking_engine.product_attribute_17"/>
     <field name="value_ids" eval="[(6, 0, [ref('booking_engine.product_attribute_value_9')])]"/>
   </record>
-  <record id="product_template_attribute_line_19" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_19" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_10"/>
     <field name="attribute_id" ref="booking_engine.product_attribute_17"/>
     <field name="value_ids" eval="[(6, 0, [ref('booking_engine.product_attribute_value_9')])]"/>
   </record>
-  <record id="product_template_attribute_line_28" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_28" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_8"/>
     <field name="attribute_id" ref="booking_engine.product_attribute_17"/>
     <field name="value_ids" eval="[(6, 0, [ref('booking_engine.product_attribute_value_9')])]"/>
   </record>
-  <record id="product_template_attribute_line_5" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_5" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_9"/>
     <field name="attribute_id" ref="booking_engine.product_attribute_12"/>
     <field name="value_ids" eval="[(6, 0, [ref('booking_engine.product_attribute_value_4')])]"/>
   </record>
-  <record id="product_template_attribute_line_14" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_14" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_10"/>
     <field name="attribute_id" ref="booking_engine.product_attribute_12"/>
     <field name="value_ids" eval="[(6, 0, [ref('booking_engine.product_attribute_value_4')])]"/>
   </record>
-  <record id="product_template_attribute_line_23" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_23" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_8"/>
     <field name="attribute_id" ref="booking_engine.product_attribute_12"/>
     <field name="value_ids" eval="[(6, 0, [ref('booking_engine.product_attribute_value_4')])]"/>
   </record>
-  <record id="product_template_attribute_line_4" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_4" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_9"/>
     <field name="attribute_id" ref="booking_engine.product_attribute_11"/>
     <field name="value_ids" eval="[(6, 0, [ref('booking_engine.product_attribute_value_3')])]"/>
   </record>
-  <record id="product_template_attribute_line_13" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_13" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_10"/>
     <field name="attribute_id" ref="booking_engine.product_attribute_11"/>
     <field name="value_ids" eval="[(6, 0, [ref('booking_engine.product_attribute_value_3')])]"/>
   </record>
-  <record id="product_template_attribute_line_22" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_22" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_8"/>
     <field name="attribute_id" ref="booking_engine.product_attribute_11"/>
     <field name="value_ids" eval="[(6, 0, [ref('booking_engine.product_attribute_value_3')])]"/>
   </record>
-  <record id="product_template_attribute_line_6" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_6" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_9"/>
     <field name="attribute_id" ref="booking_engine.product_attribute_13"/>
     <field name="value_ids" eval="[(6, 0, [ref('booking_engine.product_attribute_value_5')])]"/>
   </record>
-  <record id="product_template_attribute_line_15" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_15" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_10"/>
     <field name="attribute_id" ref="booking_engine.product_attribute_13"/>
     <field name="value_ids" eval="[(6, 0, [ref('booking_engine.product_attribute_value_5')])]"/>
   </record>
-  <record id="product_template_attribute_line_24" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_24" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_8"/>
     <field name="attribute_id" ref="booking_engine.product_attribute_13"/>
     <field name="value_ids" eval="[(6, 0, [ref('booking_engine.product_attribute_value_5')])]"/>
   </record>
-  <record id="product_template_attribute_line_7" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_7" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_9"/>
     <field name="attribute_id" ref="booking_engine.product_attribute_14"/>
     <field name="value_ids" eval="[(6, 0, [ref('booking_engine.product_attribute_value_6')])]"/>
   </record>
-  <record id="product_template_attribute_line_16" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_16" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_10"/>
     <field name="attribute_id" ref="booking_engine.product_attribute_14"/>
     <field name="value_ids" eval="[(6, 0, [ref('booking_engine.product_attribute_value_6')])]"/>
   </record>
-  <record id="product_template_attribute_line_25" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_25" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_8"/>
     <field name="attribute_id" ref="booking_engine.product_attribute_14"/>
     <field name="value_ids" eval="[(6, 0, [ref('booking_engine.product_attribute_value_6')])]"/>
   </record>
-  <record id="product_template_attribute_line_8" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_8" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_9"/>
     <field name="attribute_id" ref="booking_engine.product_attribute_15"/>
     <field name="value_ids" eval="[(6, 0, [ref('booking_engine.product_attribute_value_7')])]"/>
   </record>
-  <record id="product_template_attribute_line_17" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_17" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_10"/>
     <field name="attribute_id" ref="booking_engine.product_attribute_15"/>
     <field name="value_ids" eval="[(6, 0, [ref('booking_engine.product_attribute_value_7')])]"/>
   </record>
-  <record id="product_template_attribute_line_26" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_26" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_8"/>
     <field name="attribute_id" ref="booking_engine.product_attribute_15"/>
     <field name="value_ids" eval="[(6, 0, [ref('booking_engine.product_attribute_value_7')])]"/>
   </record>
-  <record id="product_template_attribute_line_9" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_9" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_9"/>
     <field name="attribute_id" ref="booking_engine.product_attribute_16"/>
     <field name="value_ids" eval="[(6, 0, [ref('booking_engine.product_attribute_value_8')])]"/>
   </record>
-  <record id="product_template_attribute_line_18" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_18" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_10"/>
     <field name="attribute_id" ref="booking_engine.product_attribute_16"/>
     <field name="value_ids" eval="[(6, 0, [ref('booking_engine.product_attribute_value_8')])]"/>
   </record>
-  <record id="product_template_attribute_line_27" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_27" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_8"/>
     <field name="attribute_id" ref="booking_engine.product_attribute_16"/>
     <field name="value_ids" eval="[(6, 0, [ref('booking_engine.product_attribute_value_8')])]"/>
   </record>
-  <record id="product_template_attribute_line_12" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_12" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_9"/>
     <field name="attribute_id" ref="booking_engine.product_attribute_19"/>
     <field name="value_ids" eval="[(6, 0, [ref('booking_engine.product_attribute_value_11')])]"/>
   </record>
-  <record id="product_template_attribute_line_21" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_21" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_10"/>
     <field name="attribute_id" ref="booking_engine.product_attribute_19"/>
     <field name="value_ids" eval="[(6, 0, [ref('booking_engine.product_attribute_value_11')])]"/>
   </record>
-  <record id="product_template_attribute_line_30" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_30" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_8"/>
     <field name="attribute_id" ref="booking_engine.product_attribute_19"/>
     <field name="value_ids" eval="[(6, 0, [ref('booking_engine.product_attribute_value_11')])]"/>
   </record>
-  <record id="product_template_attribute_line_33" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_33" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_10"/>
     <field name="attribute_id" ref="booking_engine.product_attribute_21"/>
     <field name="value_ids" eval="[(6, 0, [ref('booking_engine.product_attribute_value_14'), ref('booking_engine.product_attribute_value_15')])]"/>
   </record>
-  <record id="product_template_attribute_line_37" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_37" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_8"/>
     <field name="attribute_id" ref="booking_engine.product_attribute_21"/>
     <field name="value_ids" eval="[(6, 0, [ref('booking_engine.product_attribute_value_14'), ref('booking_engine.product_attribute_value_15')])]"/>
   </record>
-  <record id="product_template_attribute_line_38" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_38" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_8"/>
     <field name="attribute_id" ref="booking_engine.product_attribute_22"/>
     <field name="value_ids" eval="[(6, 0, [ref('booking_engine.product_attribute_guest1'), ref('booking_engine.product_attribute_guest2'), ref('booking_engine.product_attribute_guest2_1')])]"/>
   </record>
-  <record id="product_template_attribute_line_39" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_39" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_9"/>
     <field name="attribute_id" ref="booking_engine.product_attribute_22"/>
     <field name="value_ids" eval="[(6, 0, [ref('booking_engine.product_attribute_guest1'), ref('booking_engine.product_attribute_guest2'), ref('booking_engine.product_attribute_guest2_1')])]"/>
   </record>
-  <record id="product_template_attribute_line_40" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_40" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_9"/>
     <field name="attribute_id" ref="booking_engine.product_attribute_21"/>
     <field name="value_ids" eval="[(6, 0, [ref('booking_engine.product_attribute_value_14'), ref('booking_engine.product_attribute_value_15')])]"/>
   </record>
-  <record id="product_template_attribute_line_41" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_41" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_10"/>
     <field name="attribute_id" ref="booking_engine.product_attribute_22"/>
     <field name="value_ids" eval="[(6, 0, [ref('booking_engine.product_attribute_guest1'), ref('booking_engine.product_attribute_guest2'), ref('booking_engine.product_attribute_guest3'), ref('booking_engine.product_attribute_guest4'), ref('booking_engine.product_attribute_guest2_1'), ref('booking_engine.product_attribute_guest2_2')])]"/>

--- a/hvac_services/data/product_template.xml
+++ b/hvac_services/data/product_template.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <odoo noupdate="1">
-    <record id="product_template_installation" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_installation" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Installation</field>
         <field name="image_1920" type="base64" file="hvac_services/static/src/binary/product_template/5-image_1920"/>
         <field name="type">service</field>
@@ -15,7 +15,7 @@
         <field name="project_id" ref="industry_fsm.fsm_project"/>
         <field name="worksheet_template_id" ref="worksheet_template"/>
     </record>
-    <record id="product_template_repair" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_repair" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Repair</field>
         <field name="image_1920" type="base64" file="hvac_services/static/src/binary/product_template/10-image_1920"/>
         <field name="type">service</field>
@@ -32,7 +32,7 @@
         <field name="worksheet_template_id" ref="worksheet_template"/>
         <field name="x_is_maintenance" eval="True"/>
     </record>
-    <record id="product_template_maintenance" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_maintenance" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Maintenance</field>
         <field name="image_1920" type="base64" file="hvac_services/static/src/binary/product_template/7-image_1920"/>
         <field name="type">service</field>
@@ -49,7 +49,7 @@
         <field name="worksheet_template_id" ref="worksheet_template"/>
         <field name="x_is_maintenance" eval="True"/>
     </record>
-    <record id="product_template_4" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_4" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Com Koil Cleaner</field>
         <field name="image_1920" type="base64" file="hvac_services/static/src/binary/product_template/4-image_1920"/>
         <field name="categ_id" ref="product_category_maintenance"/>
@@ -58,7 +58,7 @@
         <field name="service_type">manual</field>
         <field name="invoice_policy">order</field>
     </record>
-    <record id="product_template_6" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_6" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">LG S12ET Split Airco 3.5kW</field>
         <field name="image_1920" type="base64" file="hvac_services/static/src/binary/product_template/6-image_1920"/>
         <field name="categ_id" ref="product_category_devices"/>
@@ -72,7 +72,7 @@
         <field name="invoice_policy">order</field>
         <field name="serial_prefix_format">S12ET-</field>
     </record>
-    <record id="product_template_8" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_8" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Maintenance Kit</field>
         <field name="image_1920" type="base64" file="hvac_services/static/src/binary/product_template/8-image_1920"/>
         <field name="categ_id" ref="product_category_maintenance"/>
@@ -81,7 +81,7 @@
         <field name="service_type">manual</field>
         <field name="invoice_policy">order</field>
     </record>
-    <record id="product_template_9" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_9" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Refrigerant 134a</field>
         <field name="image_1920" type="base64" file="hvac_services/static/src/binary/product_template/9-image_1920"/>
         <field name="categ_id" ref="product_category_maintenance"/>
@@ -91,7 +91,7 @@
         <field name="invoice_policy">order</field>
         <field name="x_is_refrigerant" eval="True"/>
     </record>
-    <record id="product_template_11" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_11" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Samsung AR35 Airco 3.5kW</field>
         <field name="image_1920" type="base64" file="hvac_services/static/src/binary/product_template/11-image_1920"/>
         <field name="categ_id" ref="product_category_devices"/>
@@ -105,7 +105,7 @@
         <field name="invoice_policy">order</field>
         <field name="serial_prefix_format">AR35-</field>
     </record>
-    <record id="product_template_12" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_12" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Sicaf R452A Split system HMM200</field>
         <field name="image_1920" type="base64" file="hvac_services/static/src/binary/product_template/12-image_1920"/>
         <field name="categ_id" ref="product_category_devices"/>

--- a/it_hardware/data/product_product.xml
+++ b/it_hardware/data/product_product.xml
@@ -174,17 +174,17 @@
         <field name="default_code">21CDS0LN00</field>
         <field name="purchase_method">purchase</field>
     </record>
-    <record id="product_template_7" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_7" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="alternative_product_ids" eval="[(6, 0, [ref('product_template_5'), ref('product_template_4')])]"/>
         <field name="accessory_product_ids" eval="[(6, 0, [ref('product_product_12'), ref('product_product_11'), ref('product_product_10')])]"/>
         <field name="purchase_method">purchase</field>
     </record>
-    <record id="product_template_5" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_5" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="alternative_product_ids" eval="[(6, 0, [ref('product_template_4'), ref('product_template_7')])]"/>
         <field name="accessory_product_ids" eval="[(6, 0, [ref('product_product_12'), ref('product_product_11'), ref('product_product_10')])]"/>
         <field name="purchase_method">purchase</field>
     </record>
-    <record id="product_template_4" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_4" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="alternative_product_ids" eval="[(6, 0, [ref('product_template_5'), ref('product_template_7')])]"/>
         <field name="accessory_product_ids" eval="[(6, 0, [ref('product_product_12'), ref('product_product_11'), ref('product_product_10')])]"/>
         <field name="purchase_method">purchase</field>

--- a/it_hardware/data/product_template.xml
+++ b/it_hardware/data/product_template.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-    <record id="product_template_10" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_10" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Installation Service</field>
         <field name="type">service</field>
         <field name="project_id" ref="project_project_3"/>
@@ -8,21 +8,21 @@
         <field name="list_price">100.0</field>        
         <field name="image_1920" type="base64" file="it_hardware/static/src/binary/product_template/10-image_1920"/>
     </record>
-    <record id="product_template_11" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_11" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">CCTV Camera</field>
         <field name="is_storable">True</field>
         <field name="list_price">52.01</field>
         <field name="tracking">serial</field>
         <field name="image_1920" type="base64" file="it_hardware/static/src/binary/product_template/11-image_1920"/>
     </record>
-    <record id="product_template_6" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_6" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Warranty Service</field>
         <field name="type">service</field>
         <field name="project_id" ref="industry_fsm.fsm_project"/>
         <field name="service_tracking">task_global_project</field>
         <field name="image_1920" type="base64" file="it_hardware/static/src/binary/product_template/6-image_1920"/>
     </record>
-    <record id="product_template_7" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_7" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">ThinkPad X1 Yoga 35.56cms - 12th Gen Intel i7</field>
         <field name="is_storable">True</field>
         <field name="list_price">2813.29</field>
@@ -34,7 +34,7 @@
         Plus, high-performance 12th Gen Intel&#174; Core&#8482; vPro processing, on the Intel&#174; Evo&#8482; platform provides super-responsive, on-the-go power.</field>
         <field name="image_1920" type="base64" file="it_hardware/static/src/binary/product_template/7-image_1920"/>
     </record>
-    <record id="product_template_5" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_5" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">ThinkPad X1 Carbon 35.56cms - 12th Gen Intel i7</field>
         <field name="is_storable">True</field>
         <field name="list_price">3780.49</field>
@@ -45,7 +45,7 @@
         We&#8217;ve also transformed the camera into a Communications Bar to improve video conferencing.</field>
         <field name="image_1920" type="base64" file="it_hardware/static/src/binary/product_template/5-image_1920"/>
     </record>
-    <record id="product_template_4" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_4" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">ThinkPad X1 Nano 33.02cms - 12th Gen Intel i7</field>
         <field name="is_storable">True</field>
         <field name="categ_id" ref="product_category_5"/>
@@ -57,7 +57,7 @@
         Just as impressive is the truly stunning viewing and immersive audio experience it gives you.</field>
         <field name="image_1920" type="base64" file="it_hardware/static/src/binary/product_template/4-image_1920"/>
     </record>
-    <record id="product_template_8" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_8" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Mouse</field>
         <field name="is_storable">True</field>
         <field name="categ_id" ref="product_category_6"/>
@@ -65,7 +65,7 @@
         <field name="tracking">serial</field>
         <field name="image_1920" type="base64" file="it_hardware/static/src/binary/product_template/8-image_1920"/>
     </record>
-    <record id="product_template_9" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_9" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name"> Wireless Keyboard</field>
         <field name="is_storable">True</field>
         <field name="list_price">14.63</field>

--- a/it_hardware/data/product_template_attribute_line.xml
+++ b/it_hardware/data/product_template_attribute_line.xml
@@ -1,161 +1,161 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-    <record id="product_template_attribute_line_1" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_1" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_4"/>
         <field name="attribute_id" ref="product_attribute_2"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_1')])]"/>
     </record>
-    <record id="product_template_attribute_line_10" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_10" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_4"/>
         <field name="attribute_id" ref="product_attribute_11"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_11')])]"/>
     </record>
-    <record id="product_template_attribute_line_11" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_11" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_5"/>
         <field name="attribute_id" ref="product_attribute_2"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_1')])]"/>
     </record>
-    <record id="product_template_attribute_line_12" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_12" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_5"/>
         <field name="attribute_id" ref="product_attribute_3"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_12')])]"/>
     </record>
-    <record id="product_template_attribute_line_13" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_13" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_5"/>
         <field name="attribute_id" ref="product_attribute_4"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_18')])]"/>
     </record>
-    <record id="product_template_attribute_line_14" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_14" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_5"/>
         <field name="attribute_id" ref="product_attribute_5"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_4'), ref('product_attribute_value_14')])]"/>
     </record>
-    <record id="product_template_attribute_line_15" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_15" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_5"/>
         <field name="attribute_id" ref="product_attribute_6"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_5'), ref('product_attribute_value_15')])]"/>
     </record>
-    <record id="product_template_attribute_line_16" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_16" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_5"/>
         <field name="attribute_id" ref="product_attribute_7"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_16')])]"/>
     </record>
-    <record id="product_template_attribute_line_17" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_17" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_5"/>
         <field name="attribute_id" ref="product_attribute_8"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_7')])]"/>
     </record>
-    <record id="product_template_attribute_line_18" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_18" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_5"/>
         <field name="attribute_id" ref="product_attribute_9"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_8')])]"/>
     </record>
-    <record id="product_template_attribute_line_19" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_19" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_5"/>
         <field name="attribute_id" ref="product_attribute_10"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_10')])]"/>
     </record>
-    <record id="product_template_attribute_line_2" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_2" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_4"/>
         <field name="attribute_id" ref="product_attribute_3"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_2')])]"/>
     </record>
-    <record id="product_template_attribute_line_20" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_20" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_5"/>
         <field name="attribute_id" ref="product_attribute_11"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_11')])]"/>
     </record>
-    <record id="product_template_attribute_line_21" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_21" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_6"/>
         <field name="attribute_id" ref="product_attribute_7"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_6'), ref('product_attribute_value_17'), ref('product_attribute_value_16')])]"/>
     </record>
-    <record id="product_template_attribute_line_22" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_22" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_7"/>
         <field name="attribute_id" ref="product_attribute_2"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_1')])]"/>
     </record>
-    <record id="product_template_attribute_line_23" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_23" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_7"/>
         <field name="attribute_id" ref="product_attribute_3"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_12')])]"/>
     </record>
-    <record id="product_template_attribute_line_24" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_24" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_7"/>
         <field name="attribute_id" ref="product_attribute_4"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_18')])]"/>
     </record>
-    <record id="product_template_attribute_line_25" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_25" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_7"/>
         <field name="attribute_id" ref="product_attribute_5"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_4'), ref('product_attribute_value_14')])]"/>
     </record>
-    <record id="product_template_attribute_line_26" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_26" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_7"/>
         <field name="attribute_id" ref="product_attribute_6"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_5'), ref('product_attribute_value_15')])]"/>
     </record>
-    <record id="product_template_attribute_line_27" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_27" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_7"/>
         <field name="attribute_id" ref="product_attribute_7"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_16')])]"/>
     </record>
-    <record id="product_template_attribute_line_28" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_28" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_7"/>
         <field name="attribute_id" ref="product_attribute_8"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_7'), ref('product_attribute_value_19')])]"/>
     </record>
-    <record id="product_template_attribute_line_29" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_29" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_7"/>
         <field name="attribute_id" ref="product_attribute_9"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_8')])]"/>
     </record>
-    <record id="product_template_attribute_line_3" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_3" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_4"/>
         <field name="attribute_id" ref="product_attribute_4"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_3')])]"/>
     </record>
-    <record id="product_template_attribute_line_30" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_30" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_7"/>
         <field name="attribute_id" ref="product_attribute_10"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_10')])]"/>
     </record>
-    <record id="product_template_attribute_line_31" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_31" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_7"/>
         <field name="attribute_id" ref="product_attribute_11"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_11')])]"/>
     </record>
-    <record id="product_template_attribute_line_32" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_32" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_9"/>
         <field name="attribute_id" ref="website_sale.product_attribute_brand"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_20'), ref('product_attribute_value_21')])]"/>
     </record>
-    <record id="product_template_attribute_line_4" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_4" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_4"/>
         <field name="attribute_id" ref="product_attribute_5"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_4'), ref('product_attribute_value_14')])]"/>
     </record>
-    <record id="product_template_attribute_line_5" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_5" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_4"/>
         <field name="attribute_id" ref="product_attribute_6"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_5'), ref('product_attribute_value_15')])]"/>
     </record>
-    <record id="product_template_attribute_line_6" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_6" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_4"/>
         <field name="attribute_id" ref="product_attribute_7"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_6')])]"/>
     </record>
-    <record id="product_template_attribute_line_7" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_7" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_4"/>
         <field name="attribute_id" ref="product_attribute_8"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_7'), ref('product_attribute_value_19')])]"/>
     </record>
-    <record id="product_template_attribute_line_8" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_8" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_4"/>
         <field name="attribute_id" ref="product_attribute_9"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_8')])]"/>
     </record>
-    <record id="product_template_attribute_line_9" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_9" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_4"/>
         <field name="attribute_id" ref="product_attribute_10"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_10')])]"/>

--- a/it_hardware/demo/product_template.xml
+++ b/it_hardware/demo/product_template.xml
@@ -1,18 +1,18 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-    <record id="product_template_4" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_4" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="is_published" eval="True"/>
     </record>
-    <record id="product_template_5" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_5" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="is_published" eval="True"/>
     </record>
-    <record id="product_template_7" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_7" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="is_published" eval="True"/>
     </record>
-    <record id="product_template_8" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_8" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="is_published" eval="True"/>
     </record>
-    <record id="product_template_9" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_9" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="is_published" eval="True"/>
     </record>
 </odoo>

--- a/members_club/data/product_template.xml
+++ b/members_club/data/product_template.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <odoo noupdate="1">
-  <record id="product_template_4" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_4" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="image_1920" type="base64" file="members_club/static/src/binary/product_template/4-image_1920"/>
     <field name="name">Members - 2026</field>
     <field name="type">service</field>
@@ -12,7 +12,7 @@
     <field name="is_published">True</field>
     <field name="public_categ_ids" eval="[(6, 0, [ref('product_public_category_9')])]"/>
   </record>
-  <record id="product_template_5" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_5" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="image_1920" type="base64" file="members_club/static/src/binary/product_template/5-image_1920"/>
     <field name="name">Recurring Members</field>
     <field name="type">service</field>
@@ -26,7 +26,7 @@
     <field name="public_categ_ids" eval="[(6, 0, [ref('product_public_category_9')])]"/>
     <field name="subscription_rule_ids" eval="[(6,0,[ref('sale_subscription_pricing_1'), ref('sale_subscription_pricing_2')])]"/>
   </record>
-  <record id="product_template_6" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_6" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="image_1920" type="base64" file="members_club/static/src/binary/product_template/6-image_1920"/>
     <field name="name">Gold Members - 2026</field>
     <field name="type">service</field>
@@ -38,7 +38,7 @@
     <field name="is_published">True</field>
     <field name="public_categ_ids" eval="[(6, 0, [ref('product_public_category_9')])]"/>
   </record>
-  <record id="product_template_7" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_7" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="name">Guests</field>
     <field name="type">service</field>
     <field name="service_tracking">event</field>

--- a/micro_brewery/data/product_template.xml
+++ b/micro_brewery/data/product_template.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-    <record id="product_template_20" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_20" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Blond Beer</field>
         <field name="is_storable">True</field>
         <field name="uom_id" ref="excise_management.uom_hl"/>
@@ -8,7 +8,7 @@
         <field name="sale_ok" eval="False"/>
         <field name="purchase_ok" eval="False"/>
     </record>
-    <record id="product_template_3" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_3" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Blond Beer - Box</field>
         <field name="is_storable">True</field>
         <field name="list_price">33.0</field>
@@ -21,7 +21,7 @@
         <field name="pos_categ_ids" eval="[(6, 0, [ref('pos_category_4')])]"/>
         <field name="image_1920" type="base64" file="micro_brewery/static/src/binary/product_template/3-image_1920"/>
     </record>
-    <record id="product_template_2" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_2" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Blond Beer - Bottle</field>
         <field name="is_storable">True</field>
         <field name="list_price">1.5</field>
@@ -36,7 +36,7 @@
         <field name="image_1920" type="base64" file="micro_brewery/static/src/binary/product_template/2-image_1920"/>
         <field name="purchase_ok" eval="False"/>
     </record>
-    <record id="product_template_21" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_21" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Brown Beer</field>
         <field name="is_storable">True</field>
         <field name="uom_id" ref="excise_management.uom_hl"/>
@@ -44,7 +44,7 @@
         <field name="sale_ok" eval="False"/>
         <field name="purchase_ok" eval="False"/>
     </record>
-    <record id="product_template_14" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_14" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Brown Beer - Bottle</field>
         <field name="is_storable">True</field>
         <field name="list_price">1.75</field>
@@ -59,7 +59,7 @@
         <field name="image_1920" type="base64" file="micro_brewery/static/src/binary/product_template/14-image_1920"/>
         <field name="purchase_ok" eval="False"/>
     </record>
-    <record id="product_template_92" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_92" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Brown Beer - Bottle unit</field>
         <field name="is_storable">True</field>
         <field name="categ_id" ref="product_category_102"/>
@@ -67,7 +67,7 @@
         <field name="base_unit_count">0.33</field>
         <field name="image_1920" type="base64" file="micro_brewery/static/src/binary/product_template/14-image_1920"/>
     </record>
-    <record id="product_template_22" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_22" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Lager Beer</field>
         <field name="is_storable">True</field>
         <field name="uom_id" ref="excise_management.uom_hl"/>
@@ -75,7 +75,7 @@
         <field name="sale_ok" eval="False"/>
         <field name="purchase_ok" eval="False"/>
     </record>
-    <record id="product_template_15" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_15" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Lager Beer - Box</field>
         <field name="is_storable">True</field>
         <field name="list_price">23.0</field>
@@ -90,7 +90,7 @@
         <field name="website_size_x">2</field>
         <field name="image_1920" type="base64" file="micro_brewery/static/src/binary/product_template/15-image_1920"/>
     </record>
-    <record id="product_template_19" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_19" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Lager Beer - Keg 20L</field>
         <field name="is_storable">True</field>
         <field name="list_price">56.0</field>
@@ -101,7 +101,7 @@
         <field name="image_1920" type="base64" file="micro_brewery/static/src/binary/product_template/19-image_1920"/>
         <field name="purchase_ok" eval="True"/>
     </record>
-    <record id="product_template_13" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_13" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Lager Beer - Bottle</field>
         <field name="is_storable">True</field>
         <field name="categ_id" ref="product_category_104"/>
@@ -117,7 +117,7 @@
         <field name="image_1920" type="base64" file="micro_brewery/static/src/binary/product_template/13-image_1920"/>
         <field name="purchase_ok" eval="False"/>
     </record>
-    <record id="product_template_93" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_93" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Lager Beer - Bottle unit</field>
         <field name="is_storable">True</field>
         <field name="categ_id" ref="product_category_102"/>
@@ -125,7 +125,7 @@
         <field name="base_unit_count">0.33</field>
         <field name="image_1920" type="base64" file="micro_brewery/static/src/binary/product_template/13-image_1920"/>
     </record>
-    <record id="product_template_16" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_16" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Brown Beer - Box</field>
         <field name="is_storable">True</field>
         <field name="list_price">40.0</field>
@@ -137,7 +137,7 @@
         <field name="pos_categ_ids" eval="[(6, 0, [ref('pos_category_4')])]"/>
         <field name="image_1920" type="base64" file="micro_brewery/static/src/binary/product_template/16-image_1920"/>
     </record>
-    <record id="product_template_17" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_17" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Blond Beer - Keg 20L</field>
         <field name="is_storable">True</field>
         <field name="list_price">80.0</field>
@@ -148,7 +148,7 @@
         <field name="image_1920" type="base64" file="micro_brewery/static/src/binary/product_template/17-image_1920"/>
         <field name="purchase_ok" eval="True"/>
     </record>
-    <record id="product_template_18" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_18" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Brown Beer - Keg 20L</field>
         <field name="is_storable">True</field>
         <field name="list_price">100.0</field>
@@ -159,7 +159,7 @@
         <field name="image_1920" type="base64" file="micro_brewery/static/src/binary/product_template/18-image_1920"/>
         <field name="purchase_ok" eval="True"/>
     </record>
-    <record id="product_template_23" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_23" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">T-Shirt</field>
         <field name="is_storable">True</field>
         <field name="list_price">15.0</field>
@@ -169,7 +169,7 @@
         <field name="pos_categ_ids" eval="[(6, 0, [ref('pos_category_3')])]"/>
         <field name="image_1920" type="base64" file="micro_brewery/static/src/binary/product_template/23-image_1920"/>
     </record>
-    <record id="product_template_24" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_24" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Sweat Shirt</field>
         <field name="is_storable">True</field>
         <field name="list_price">35.0</field>
@@ -179,7 +179,7 @@
         <field name="pos_categ_ids" eval="[(6, 0, [ref('pos_category_3')])]"/>
         <field name="image_1920" type="base64" file="micro_brewery/static/src/binary/product_template/24-image_1920"/>
     </record>
-    <record id="product_template_29" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_29" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Blond Beer (50cl)</field>
         <field name="list_price">4.5</field>
         <field name="categ_id" ref="product_category_102"/>
@@ -223,7 +223,7 @@
         <field name="pos_categ_ids" eval="[(6, 0, [ref('pos_category_5')])]"/>
         <field name="purchase_ok" eval="False"/>
     </record>
-    <record id="product_template_56" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_56" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Crate 24x33cl</field>
         <field name="categ_id" ref="deposit_management.product_category_deposit"/>
         <field name="list_price" eval="False"/>

--- a/micro_brewery/data/product_template_attribute_line.xml
+++ b/micro_brewery/data/product_template_attribute_line.xml
@@ -1,21 +1,21 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-    <record id="product_template_attribute_line_2" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_2" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_23"/>
         <field name="attribute_id" ref="product_attribute_3"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_4'), ref('product_attribute_value_5'), ref('product_attribute_value_6'), ref('product_attribute_value_7'), ref('product_attribute_value_8')])]"/>
     </record>
-    <record id="product_template_attribute_line_3" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_3" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_23"/>
         <field name="attribute_id" ref="product_attribute_4"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_9'), ref('product_attribute_value_10'), ref('product_attribute_value_11'), ref('product_attribute_value_12'), ref('product_attribute_value_13')])]"/>
     </record>
-    <record id="product_template_attribute_line_4" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_4" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_24"/>
         <field name="attribute_id" ref="product_attribute_3"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_4'), ref('product_attribute_value_5'), ref('product_attribute_value_6'), ref('product_attribute_value_7'), ref('product_attribute_value_8')])]"/>
     </record>
-    <record id="product_template_attribute_line_5" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_5" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_24"/>
         <field name="attribute_id" ref="product_attribute_4"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_9'), ref('product_attribute_value_10'), ref('product_attribute_value_11'), ref('product_attribute_value_12'), ref('product_attribute_value_13')])]"/>

--- a/non_profit_organization/data/product_template.xml
+++ b/non_profit_organization/data/product_template.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
     <record id="product_template_8" model="product.template"
-        context="{'create_product_product': False}">
+        context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="image_1920" type="base64"
             file="non_profit_organization/static/src/binary/product_template/8-image_1920"/>
         <field name="name">Children’s Book – “All Equal”</field>
@@ -13,7 +13,7 @@
         <field name="website_sequence">10035</field>
     </record>
     <record id="product_template_7" model="product.template"
-        context="{'create_product_product': False}">
+        context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="image_1920" type="base64"
             file="non_profit_organization/static/src/binary/product_template/7-image_1920"/>
         <field name="name">Human Rights Notebook</field>
@@ -25,7 +25,7 @@
         <field name="website_sequence">10030</field>
     </record>
     <record id="product_template_4" model="product.template"
-        context="{'create_product_product': False}">
+        context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Membership</field>
         <field name="image_1920" type="base64"
             file="non_profit_organization/static/src/binary/product_template/4-image_1920.webp"/>
@@ -44,7 +44,7 @@
         <field name="public_categ_ids" eval="[(6, 0, [ref('product_public_category_9')])]"/>
     </record>
     <record id="product_template_5" model="product.template"
-        context="{'create_product_product': False}">
+        context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="image_1920" type="base64"
             file="non_profit_organization/static/src/binary/product_template/5-image_1920"/>
         <field name="name">Solidarity Candle (Set of 3) </field>
@@ -56,7 +56,7 @@
         <field name="website_sequence">10020</field>
     </record>
     <record id="product_template_6" model="product.template"
-        context="{'create_product_product': False}">
+        context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="image_1920" type="base64"
             file="non_profit_organization/static/src/binary/product_template/6-image_1920"/>
         <field name="name">Tote Bag – “Justice Is for Everyone”</field>
@@ -67,7 +67,7 @@
         <field name="description_ecommerce"><![CDATA[<div data-oe-version="2.0">Carry your values with you. This 100% organic cotton tote bag is both practical and powerful. Screen-printed with our slogan: <em>Justice Is for Everyone.</em></div>]]></field>
         <field name="website_sequence">10025</field>
     </record>
-    <record id="event_product.product_product_event_product_template" model="product.template" context="{'create_product_product': False}" forcecreate="1">
+    <record id="event_product.product_product_event_product_template" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}" forcecreate="1">
         <field name="name">Event Registration</field>
         <field name="image_1920" type="base64"
             file="non_profit_organization/static/src/binary/product_template/3-image_1920.png"/>
@@ -79,7 +79,7 @@
         <field name="invoice_policy">order</field>
     </record>
     <record id="product_template_donation" model="product.template"
-        context="{'create_product_product': False}">
+        context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="image_1920" type="base64"
             file="non_profit_organization/static/src/binary/product_template/15-image_1920"/>
         <field name="name">Donation</field>

--- a/pharmacy_retail/data/product_template.xml
+++ b/pharmacy_retail/data/product_template.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-    <record id="product_template_13" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_13" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Acetratine 10 mg</field>
         <field name="categ_id" ref="product_category_1"/>
         <field name="is_storable">True</field>
@@ -17,7 +17,7 @@
         <field name="product_tag_ids" eval="[(6, 0, [ref('product_tag_12'), ref('product_tag_13'), ref('product_tag_14'), ref('product_tag_15')])]"/>
         <field name="pos_categ_ids" eval="[(6, 0, [ref('pos_category_1')])]"/>
     </record>
-    <record id="product_template_14" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_14" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Crocin 650</field>
         <field name="categ_id" ref="product_category_3"/>
         <field name="is_storable">True</field>
@@ -34,7 +34,7 @@
         <field name="product_tag_ids" eval="[(6, 0, [ref('product_tag_10'), ref('product_tag_11')])]"/>
         <field name="pos_categ_ids" eval="[(6, 0, [ref('pos_category_3')])]"/>
     </record>
-    <record id="product_template_15" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_15" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Paracetamol</field>
         <field name="categ_id" ref="product_category_3"/>
         <field name="is_storable">True</field>
@@ -51,7 +51,7 @@
         <field name="product_tag_ids" eval="[(6, 0, [ref('product_tag_16'), ref('product_tag_17')])]"/>
         <field name="pos_categ_ids" eval="[(6, 0, [ref('pos_category_3')])]"/>
     </record>
-    <record id="product_template_16" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_16" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">TELVAS AM TAB</field>
         <field name="categ_id" ref="product_category_4"/>
         <field name="is_storable">True</field>
@@ -67,7 +67,7 @@
         <field name="image_1920" type="base64" file="pharmacy_retail/static/src/binary/product_template/16-image_1920"/>
         <field name="pos_categ_ids" eval="[(6, 0, [ref('pos_category_4')])]"/>
     </record>
-    <record id="product_template_17" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_17" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">ENAPRIL 10MG TAB</field>
         <field name="categ_id" ref="product_category_4"/>
         <field name="is_storable">True</field>
@@ -83,7 +83,7 @@
         <field name="image_1920" type="base64" file="pharmacy_retail/static/src/binary/product_template/17-image_1920"/>
         <field name="pos_categ_ids" eval="[(6, 0, [ref('pos_category_4')])]"/>
     </record>
-    <record id="product_template_18" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_18" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">CEFTAS 400 5 TAB</field>
         <field name="categ_id" ref="product_category_2"/>
         <field name="is_storable">True</field>

--- a/pharmacy_retail/data/product_template_attribute_line.xml
+++ b/pharmacy_retail/data/product_template_attribute_line.xml
@@ -1,61 +1,61 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-    <record id="product_template_attribute_line_10" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_10" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_17"/>
         <field name="attribute_id" ref="product_attribute_2"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_5')])]"/>
     </record>
-    <record id="product_template_attribute_line_11" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_11" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_17"/>
         <field name="attribute_id" ref="product_attribute_3"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_6')])]"/>
     </record>
-    <record id="product_template_attribute_line_12" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_12" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_15"/>
         <field name="attribute_id" ref="product_attribute_2"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_8')])]"/>
     </record>
-    <record id="product_template_attribute_line_13" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_13" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_15"/>
         <field name="attribute_id" ref="product_attribute_3"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_6')])]"/>
     </record>
-    <record id="product_template_attribute_line_14" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_14" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_16"/>
         <field name="attribute_id" ref="product_attribute_2"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_5')])]"/>
     </record>
-    <record id="product_template_attribute_line_15" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_15" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_16"/>
         <field name="attribute_id" ref="product_attribute_3"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_6')])]"/>
     </record>
-    <record id="product_template_attribute_line_2" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_2" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_13"/>
         <field name="attribute_id" ref="product_attribute_2"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_5')])]"/>
     </record>
-    <record id="product_template_attribute_line_3" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_3" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_13"/>
         <field name="attribute_id" ref="product_attribute_3"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_6')])]"/>
     </record>
-    <record id="product_template_attribute_line_4" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_4" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_18"/>
         <field name="attribute_id" ref="product_attribute_2"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_5')])]"/>
     </record>
-    <record id="product_template_attribute_line_5" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_5" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_18"/>
         <field name="attribute_id" ref="product_attribute_3"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_6')])]"/>
     </record>
-    <record id="product_template_attribute_line_8" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_8" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_14"/>
         <field name="attribute_id" ref="product_attribute_2"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_5')])]"/>
     </record>
-    <record id="product_template_attribute_line_9" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_9" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_14"/>
         <field name="attribute_id" ref="product_attribute_3"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_7')])]"/>

--- a/real_estate/demo/product_template.xml
+++ b/real_estate/demo/product_template.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-    <record id="product_template_3" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_3" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="image_1920" type="base64" file="real_estate/static/src/binary/product_template/3-image_1920"/>
         <field name="name">Amazing 5 bedrooms manor</field>
         <field name="list_price">480000.0</field>
@@ -27,7 +27,7 @@
         <field name="x_notary_id" ref="base_industry_data.res_partner_26"/>
         <field name="x_developer_id" ref="base_industry_data.res_partner_34"/>
     </record>
-    <record id="product_template_30" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_30" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="image_1920" type="base64" file="real_estate/static/src/binary/product_template/30-image_1920"/>
         <field name="name">Ardennes Manor</field>
         <field name="list_price">1200000.0</field>
@@ -41,7 +41,7 @@
         <field name="is_published" eval="True"/>
         <field name="x_technical_partner_id" ref="res_partner_77"/>
     </record>
-    <record id="product_template_29" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_29" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="image_1920" type="base64" file="real_estate/static/src/binary/product_template/29-image_1920"/>
         <field name="name">Art Deco Apartment</field>
         <field name="list_price">850.0</field>
@@ -56,7 +56,7 @@
         <field name="is_published" eval="True"/>
         <field name="x_technical_partner_id" ref="res_partner_76"/>
     </record>
-    <record id="product_template_15" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_15" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="image_1920" type="base64" file="real_estate/static/src/binary/product_template/15-image_1920"/>
         <field name="name">Beautiful Renovated Farm in Liege</field>
         <field name="list_price">270000.0</field>
@@ -76,7 +76,7 @@
         <field name="x_technical_partner_id" ref="res_partner_72"/>
         <field name="x_owner_id" ref="res_partner_29"/>
     </record>
-    <record id="product_template_31" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_31" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="image_1920" type="base64" file="real_estate/static/src/binary/product_template/31-image_1920"/>
         <field name="name">Botanique Studio</field>
         <field name="list_price">650.0</field>
@@ -91,7 +91,7 @@
         <field name="is_published" eval="True"/>
         <field name="x_technical_partner_id" ref="res_partner_78"/>
     </record>
-    <record id="product_template_28" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_28" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="image_1920" type="base64" file="real_estate/static/src/binary/product_template/28-image_1920"/>
         <field name="name">Canal House</field>
         <field name="list_price">395000.0</field>
@@ -106,7 +106,7 @@
         <field name="is_published" eval="True"/>
         <field name="x_technical_partner_id" ref="res_partner_75"/>
     </record>
-    <record id="product_template_4" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_4" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="image_1920" type="base64" file="real_estate/static/src/binary/product_template/4-image_1920"/>
         <field name="name">Charming renovated farm in Incourt</field>
         <field name="list_price">460000.0</field>
@@ -125,7 +125,7 @@
         <field name="x_technical_partner_id" ref="res_partner_80"/>
         <field name="x_owner_id" ref="base_industry_data.res_partner_28"/>
     </record>
-    <record id="product_template_27" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_27" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="image_1920" type="base64" file="real_estate/static/src/binary/product_template/27-image_1920"/>
         <field name="name">Louise Loft</field>
         <field name="list_price">2200.0</field>
@@ -139,7 +139,7 @@
         <field name="is_published" eval="True"/>
         <field name="x_technical_partner_id" ref="res_partner_74"/>
     </record>
-    <record id="product_template_32" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_32" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="image_1920" type="base64" file="real_estate/static/src/binary/product_template/32-image_1920"/>
         <field name="name">Namur Family Home</field>
         <field name="list_price">457000.0</field>
@@ -169,7 +169,7 @@
         <field name="x_technical_partner_id" ref="res_partner_71"/>
         <field name="x_owner_id" ref="base_industry_data.res_partner_24"/>
     </record>
-    <record id="product_template_26" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_26" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="image_1920" type="base64" file="real_estate/static/src/binary/product_template/26-image_1920"/>
         <field name="name">Verviers Villa</field>
         <field name="list_price">649000.0</field>
@@ -183,7 +183,7 @@
         <field name="is_published" eval="True"/>
         <field name="x_technical_partner_id" ref="res_partner_73"/>
     </record>
-    <record id="product_template_16" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_16" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="image_1920" type="base64" file="real_estate/static/src/binary/product_template/16-image_1920"/>
         <field name="name">Old farm to renovate</field>
         <field name="list_price">495000.0</field>

--- a/real_estate/demo/product_template_attribute_line.xml
+++ b/real_estate/demo/product_template_attribute_line.xml
@@ -1,346 +1,346 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-    <record id="product_template_attribute_line_1" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_1" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_3"/>
         <field name="attribute_id" ref="product_attribute_10"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_7')])]"/>
     </record>
-    <record id="product_template_attribute_line_8" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_8" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_4"/>
         <field name="attribute_id" ref="product_attribute_10"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_9')])]"/>
     </record>
-    <record id="product_template_attribute_line_43" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_43" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_15"/>
         <field name="attribute_id" ref="product_attribute_10"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_5')])]"/>
     </record>
-    <record id="product_template_attribute_line_72" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_72" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_28"/>
         <field name="attribute_id" ref="product_attribute_10"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_10')])]"/>
     </record>
-    <record id="product_template_attribute_line_80" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_80" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_29"/>
         <field name="attribute_id" ref="product_attribute_10"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_4')])]"/>
     </record>
-    <record id="product_template_attribute_line_90" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_90" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_31"/>
         <field name="attribute_id" ref="product_attribute_10"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_28')])]"/>
     </record>
-    <record id="product_template_attribute_line_95" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_95" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_32"/>
         <field name="attribute_id" ref="product_attribute_10"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_8')])]"/>
     </record>
-    <record id="product_template_attribute_line_66" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_66" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_26"/>
         <field name="attribute_id" ref="product_attribute_11"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_11')])]"/>
     </record>
-    <record id="product_template_attribute_line_70" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_70" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_27"/>
         <field name="attribute_id" ref="product_attribute_11"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_27')])]"/>
     </record>
-    <record id="product_template_attribute_line_85" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_85" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_30"/>
         <field name="attribute_id" ref="product_attribute_12"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_34')])]"/>
     </record>
-    <record id="product_template_attribute_line_81" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_81" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_29"/>
         <field name="sequence">11</field>
         <field name="attribute_id" ref="product_attribute_17"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_30')])]"/>
     </record>
-    <record id="product_template_attribute_line_91" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_91" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_31"/>
         <field name="sequence">11</field>
         <field name="attribute_id" ref="product_attribute_17"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_30')])]"/>
     </record>
-    <record id="product_template_attribute_line_96" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_96" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_32"/>
         <field name="sequence">11</field>
         <field name="attribute_id" ref="product_attribute_17"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_32')])]"/>
     </record>
-    <record id="product_template_attribute_line_2" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_2" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_3"/>
         <field name="sequence">11</field>
         <field name="attribute_id" ref="product_attribute_11"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_18')])]"/>
     </record>
-    <record id="product_template_attribute_line_9" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_9" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_4"/>
         <field name="sequence">11</field>
         <field name="attribute_id" ref="product_attribute_11"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_17')])]"/>
     </record>
-    <record id="product_template_attribute_line_44" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_44" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_15"/>
         <field name="sequence">11</field>
         <field name="attribute_id" ref="product_attribute_11"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_17')])]"/>
     </record>
-    <record id="product_template_attribute_line_73" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_73" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_28"/>
         <field name="sequence">11</field>
         <field name="attribute_id" ref="product_attribute_11"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_17')])]"/>
     </record>
-    <record id="product_template_attribute_line_86" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_86" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_30"/>
         <field name="sequence">11</field>
         <field name="attribute_id" ref="product_attribute_11"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_18')])]"/>
     </record>
-    <record id="product_template_attribute_line_67" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_67" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_26"/>
         <field name="sequence">11</field>
         <field name="attribute_id" ref="product_attribute_16"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_16')])]"/>
     </record>
-    <record id="product_template_attribute_line_71" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_71" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_27"/>
         <field name="sequence">11</field>
         <field name="attribute_id" ref="product_attribute_12"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_31')])]"/>
     </record>
-    <record id="product_template_attribute_line_77" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_77" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_27"/>
         <field name="sequence">12</field>
         <field name="attribute_id" ref="product_attribute_10"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_28')])]"/>
     </record>
-    <record id="product_template_attribute_line_68" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_68" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_26"/>
         <field name="sequence">12</field>
         <field name="attribute_id" ref="product_attribute_17"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_26')])]"/>
     </record>
-    <record id="product_template_attribute_line_87" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_87" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_30"/>
         <field name="sequence">12</field>
         <field name="attribute_id" ref="product_attribute_17"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_35')])]"/>
     </record>
-    <record id="product_template_attribute_line_45" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_45" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_15"/>
         <field name="sequence">12</field>
         <field name="attribute_id" ref="product_attribute_16"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_24')])]"/>
     </record>
-    <record id="product_template_attribute_line_82" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_82" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_29"/>
         <field name="sequence">12</field>
         <field name="attribute_id" ref="product_attribute_16"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_25')])]"/>
     </record>
-    <record id="product_template_attribute_line_92" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_92" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_31"/>
         <field name="sequence">12</field>
         <field name="attribute_id" ref="product_attribute_16"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_37')])]"/>
     </record>
-    <record id="product_template_attribute_line_97" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_97" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_32"/>
         <field name="sequence">12</field>
         <field name="attribute_id" ref="product_attribute_16"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_24')])]"/>
     </record>
-    <record id="product_template_attribute_line_3" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_3" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_3"/>
         <field name="sequence">12</field>
         <field name="attribute_id" ref="product_attribute_12"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_19')])]"/>
     </record>
-    <record id="product_template_attribute_line_10" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_10" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_4"/>
         <field name="sequence">12</field>
         <field name="attribute_id" ref="product_attribute_12"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_12')])]"/>
     </record>
-    <record id="product_template_attribute_line_74" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_74" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_28"/>
         <field name="sequence">12</field>
         <field name="attribute_id" ref="product_attribute_12"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_29')])]"/>
     </record>
-    <record id="product_template_attribute_line_75" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_75" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_28"/>
         <field name="sequence">13</field>
         <field name="attribute_id" ref="product_attribute_17"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_30')])]"/>
     </record>
-    <record id="product_template_attribute_line_83" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_83" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_29"/>
         <field name="sequence">13</field>
         <field name="attribute_id" ref="product_attribute_11"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_33')])]"/>
     </record>
-    <record id="product_template_attribute_line_93" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_93" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_31"/>
         <field name="sequence">13</field>
         <field name="attribute_id" ref="product_attribute_11"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_38')])]"/>
     </record>
-    <record id="product_template_attribute_line_98" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_98" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_32"/>
         <field name="sequence">13</field>
         <field name="attribute_id" ref="product_attribute_11"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_17')])]"/>
     </record>
-    <record id="product_template_attribute_line_78" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_78" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_27"/>
         <field name="sequence">13</field>
         <field name="attribute_id" ref="product_attribute_16"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_25')])]"/>
     </record>
-    <record id="product_template_attribute_line_88" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_88" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_30"/>
         <field name="sequence">13</field>
         <field name="attribute_id" ref="product_attribute_16"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_36')])]"/>
     </record>
-    <record id="product_template_attribute_line_46" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_46" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_15"/>
         <field name="sequence">13</field>
         <field name="attribute_id" ref="product_attribute_12"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_12')])]"/>
     </record>
-    <record id="product_template_attribute_line_69" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_69" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_26"/>
         <field name="sequence">13</field>
         <field name="attribute_id" ref="product_attribute_12"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_12')])]"/>
     </record>
-    <record id="product_template_attribute_line_4" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_4" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_3"/>
         <field name="sequence">13</field>
         <field name="attribute_id" ref="product_attribute_13"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_13')])]"/>
     </record>
-    <record id="product_template_attribute_line_11" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_11" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_4"/>
         <field name="sequence">13</field>
         <field name="attribute_id" ref="product_attribute_13"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_13')])]"/>
     </record>
-    <record id="product_template_attribute_line_89" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_89" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_30"/>
         <field name="sequence">14</field>
         <field name="attribute_id" ref="product_attribute_10"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_7')])]"/>
     </record>
-    <record id="product_template_attribute_line_79" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_79" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_27"/>
         <field name="sequence">14</field>
         <field name="attribute_id" ref="product_attribute_17"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_32')])]"/>
     </record>
-    <record id="product_template_attribute_line_76" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_76" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_28"/>
         <field name="sequence">14</field>
         <field name="attribute_id" ref="product_attribute_16"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_24')])]"/>
     </record>
-    <record id="product_template_attribute_line_84" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_84" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_29"/>
         <field name="sequence">14</field>
         <field name="attribute_id" ref="product_attribute_12"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_12')])]"/>
     </record>
-    <record id="product_template_attribute_line_94" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_94" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_31"/>
         <field name="sequence">14</field>
         <field name="attribute_id" ref="product_attribute_12"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_29')])]"/>
     </record>
-    <record id="product_template_attribute_line_99" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_99" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_32"/>
         <field name="sequence">14</field>
         <field name="attribute_id" ref="product_attribute_12"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_12')])]"/>
     </record>
-    <record id="product_template_attribute_line_47" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_47" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_15"/>
         <field name="sequence">14</field>
         <field name="attribute_id" ref="product_attribute_13"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_13')])]"/>
     </record>
-    <record id="product_template_attribute_line_5" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_5" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_3"/>
         <field name="sequence">14</field>
         <field name="attribute_id" ref="product_attribute_14"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_14')])]"/>
     </record>
-    <record id="product_template_attribute_line_12" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_12" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_4"/>
         <field name="sequence">14</field>
         <field name="attribute_id" ref="product_attribute_14"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_22')])]"/>
     </record>
-    <record id="product_template_attribute_line_48" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_48" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_15"/>
         <field name="sequence">15</field>
         <field name="attribute_id" ref="product_attribute_14"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_14')])]"/>
     </record>
-    <record id="product_template_attribute_line_100" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_100" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_3"/>
         <field name="sequence">15</field>
         <field name="attribute_id" ref="product_attribute_17"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_26')])]"/>
     </record>
-    <record id="product_template_attribute_line_101" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_101" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_4"/>
         <field name="sequence">15</field>
         <field name="attribute_id" ref="product_attribute_17"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_32')])]"/>
     </record>
-    <record id="product_template_attribute_line_7" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_7" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_3"/>
         <field name="sequence">16</field>
         <field name="attribute_id" ref="product_attribute_16"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_16')])]"/>
     </record>
-    <record id="product_template_attribute_line_14" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_14" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_4"/>
         <field name="sequence">16</field>
         <field name="attribute_id" ref="product_attribute_16"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_20')])]"/>
     </record>
-    <record id="product_template_attribute_line_102" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_102" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_15"/>
         <field name="sequence">16</field>
         <field name="attribute_id" ref="product_attribute_17"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_30')])]"/>
     </record>
-    <record id="product_template_attribute_line_56" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_56" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_16"/>
         <field name="attribute_id" ref="product_attribute_10"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_1')])]"/>
     </record>
-    <record id="product_template_attribute_line_57" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_57" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_16"/>
         <field name="attribute_id" ref="product_attribute_12"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_34')])]"/>
     </record>
-    <record id="product_template_attribute_line_58" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_58" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_16"/>
         <field name="attribute_id" ref="product_attribute_16"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_16')])]"/>
     </record>
-    <record id="product_template_attribute_line_59" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_59" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_16"/>
         <field name="attribute_id" ref="product_attribute_14"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_14')])]"/>
     </record>
-    <record id="product_template_attribute_line_60" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_60" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_16"/>
         <field name="attribute_id" ref="product_attribute_11"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_18')])]"/>

--- a/shoe_maker/data/product_template.xml
+++ b/shoe_maker/data/product_template.xml
@@ -8,7 +8,7 @@
         <field name="service_type">manual</field>
         <field name="invoice_policy">order</field>
     </record>
-    <record id="product_template_8" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_8" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Heel skates</field>
         <field name="categ_id" ref="product_category_5"/>
         <field name="list_price" eval="0"/>
@@ -17,7 +17,7 @@
         <field name="service_type">manual</field>
         <field name="invoice_policy">order</field>
     </record>
-    <record id="product_template_7" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_7" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Heels</field>
         <field name="categ_id" ref="product_category_5"/>
         <field name="list_price" eval="0"/>
@@ -26,7 +26,7 @@
         <field name="service_type">manual</field>
         <field name="invoice_policy">order</field>
     </record>
-    <record id="product_template_15" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_15" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="image_1920" type="base64" file="shoe_maker/static/src/binary/product_template/15-image_1920"/>
         <field name="name">Insoles</field>
         <field name="categ_id" ref="product.product_category_goods"/>
@@ -38,7 +38,7 @@
         <field name="service_type">manual</field>
         <field name="invoice_policy">order</field>
     </record>
-    <record id="product_template_13" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_13" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="image_1920" type="base64" file="shoe_maker/static/src/binary/product_template/13-image_1920"/>
         <field name="name">Large laces</field>
         <field name="categ_id" ref="product.product_category_goods"/>
@@ -50,7 +50,7 @@
         <field name="service_type">manual</field>
         <field name="invoice_policy">order</field>
     </record>
-    <record id="product_template_6" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_6" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Outsoles</field>
         <field name="categ_id" ref="product_category_5"/>
         <field name="list_price" eval="0"/>
@@ -67,7 +67,7 @@
         <field name="service_type">manual</field>
         <field name="invoice_policy">order</field>
     </record>
-    <record id="product_template_14" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_14" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="image_1920" type="base64" file="shoe_maker/static/src/binary/product_template/14-image_1920"/>
         <field name="name">Slim laces</field>
         <field name="categ_id" ref="product.product_category_goods"/>

--- a/shoe_maker/data/product_template_attribute_line.xml
+++ b/shoe_maker/data/product_template_attribute_line.xml
@@ -1,48 +1,48 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-    <record id="product_template_attribute_line_7" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_7" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_14"/>
         <field name="attribute_id" ref="product_barcodelookup.product_attribute_lookup_1"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_3'), ref('product_attribute_value_15'), ref('product_attribute_value_16'), ref('product_attribute_value_17'), ref('product_attribute_value_18')])]"/>
     </record>
-    <record id="product_template_attribute_line_9" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_9" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_13"/>
         <field name="attribute_id" ref="product_barcodelookup.product_attribute_lookup_1"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_3'), ref('product_attribute_value_15'), ref('product_attribute_value_17')])]"/>
     </record>
-    <record id="product_template_attribute_line_1" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_1" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_6"/>
         <field name="attribute_id" ref="product_barcodelookup.product_attribute_lookup_2"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_1'), ref('product_attribute_value_2')])]"/>
     </record>
-    <record id="product_template_attribute_line_3" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_3" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_7"/>
         <field name="attribute_id" ref="product_barcodelookup.product_attribute_lookup_2"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_1'), ref('product_attribute_value_2')])]"/>
     </record>
-    <record id="product_template_attribute_line_6" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_6" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_8"/>
         <field name="attribute_id" ref="product_barcodelookup.product_attribute_lookup_7"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_13'), ref('product_attribute_value_14')])]"/>
     </record>
-    <record id="product_template_attribute_line_8" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_8" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_15"/>
         <field name="attribute_id" ref="product_barcodelookup.product_attribute_lookup_7"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_20'), ref('product_attribute_value_21'), ref('product_attribute_value_22'), ref('product_attribute_value_23')])]"/>
     </record>
-    <record id="product_template_attribute_line_2" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_2" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_6"/>
         <field name="sequence">11</field>
         <field name="attribute_id" ref="product_barcodelookup.product_attribute_lookup_1"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_3'), ref('product_attribute_value_4')])]"/>
     </record>
-    <record id="product_template_attribute_line_4" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_4" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_7"/>
         <field name="sequence">11</field>
         <field name="attribute_id" ref="product_attribute_9"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_5'), ref('product_attribute_value_6'), ref('product_attribute_value_7'), ref('product_attribute_value_8')])]"/>
     </record>
-    <record id="product_template_attribute_line_5" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_5" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_7"/>
         <field name="sequence">12</field>
         <field name="attribute_id" ref="product_barcodelookup.product_attribute_lookup_3"/>

--- a/solar_installation/data/product_template.xml
+++ b/solar_installation/data/product_template.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-    <record id="product_template_4" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_4" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="image_1920" type="base64" file="solar_installation/static/src/binary/product_template/4-image_1920"/>
         <field name="name">Client Site Survey (Free)</field>
         <field name="service_type">timesheet</field>

--- a/student_organization/data/product_template.xml
+++ b/student_organization/data/product_template.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-  <record id="product_template_1" model="product.template" context="{'create_product_product': False}" >
+  <record id="product_template_1" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}" >
     <field name="image_1920" type="base64" file="student_organization/static/src/binary/product_template/29-image_1920"/>
     <field name="name" eval="'Annual Membership Card - %s-%s' % (datetime.now().year, datetime.now().year + 1)" />
     <field name="description"><![CDATA[<p>Grants access to student union facilities and discounted events for one year.</p>]]></field>
@@ -19,7 +19,7 @@
     <field name="website_sequence">10040</field>
     <field name="public_categ_ids" eval="[(6, 0, [ref('product_public_category_9')])]"/>
   </record>
-  <record id="product_template_2" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_2" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="image_1920" type="base64" file="student_organization/static/src/binary/product_template/32-image_1920"/>
     <field name="name">Career Workshop Access</field>
     <field name="description"><![CDATA[<p>Participate in a skill-building career workshop led by industry experts.</p>]]></field>
@@ -36,21 +36,21 @@
     <field name="website_sequence">10040</field>
     <field name="public_categ_ids" eval="[(6, 0, [ref('product_public_category_8')])]"/>
   </record>
-  <record id="product_template_45" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_45" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="name">Catering Services</field>
     <field name="pos_sequence">21</field>
     <field name="service_type">manual</field>
     <field name="invoice_policy">order</field>
     <field name="website_sequence">10105</field>
   </record>
-  <record id="product_template_44" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_44" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="name">Gala Venue Rental</field>
     <field name="pos_sequence">20</field>
     <field name="service_type">manual</field>
     <field name="invoice_policy">order</field>
     <field name="website_sequence">10100</field>
   </record>
-  <record id="product_template_3" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_3" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="image_1920" type="base64" file="student_organization/static/src/binary/product_template/28-image_1920"/>
     <field name="name">Guest Lecture Pass</field>
     <field name="description"><![CDATA[<p>Entry to an exclusive guest lecture hosted by the student union.</p>]]></field>
@@ -68,7 +68,7 @@
     <field name="website_sequence">10040</field>
     <field name="public_categ_ids" eval="[(6, 0, [ref('product_public_category_8')])]"/>
   </record>
-  <record id="product_template_4" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_4" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="image_1920" type="base64" file="student_organization/static/src/binary/product_template/31-image_1920"/>
     <field name="name">Networking Night Ticket</field>
     <field name="description"><![CDATA[<p>Admission to a networking evening with alumni and professionals.</p>]]></field>
@@ -86,7 +86,7 @@
     <field name="website_sequence">10040</field>
     <field name="public_categ_ids" eval="[(6, 0, [ref('product_public_category_8')])]"/>
   </record>
-  <record id="product_template_42" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_42" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="name">Pickup</field>
     <field name="type">service</field>
     <field name="sale_ok" eval="False"/>
@@ -96,7 +96,7 @@
     <field name="invoice_policy">order</field>
     <field name="website_sequence">10090</field>
   </record>
-  <record id="product_template_41" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_41" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="image_1920" type="base64" file="student_organization/static/src/binary/product_template/41-image_1920"/>
     <field name="name" eval="'Sponsorship - %s-%s' % (datetime.now().year, datetime.now().year + 1)" />
     <field name="type">service</field>
@@ -124,7 +124,7 @@ Add to cart to become a sponsor today.</p><p><br></p>]]></field>
     <field name="website_sequence">10085</field>
     <field name="public_categ_ids" eval="[(6, 0, [ref('product_public_category_9')])]"/>
   </record>
-  <record id="product_template_33" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_33" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="image_1920" type="base64" file="student_organization/static/src/binary/product_template/33-image_1920"/>
     <field name="name">Student Organization Gala - Entrance</field>
     <field name="description"><![CDATA[<p>Access to the student union welcome party. Includes one drink voucher.</p>]]></field>
@@ -142,7 +142,7 @@ Add to cart to become a sponsor today.</p><p><br></p>]]></field>
     <field name="website_sequence">10045</field>
     <field name="public_categ_ids" eval="[(6, 0, [ref('product_public_category_8')])]"/>
   </record>
-  <record id="product_template_40" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_40" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="image_1920" type="base64" file="student_organization/static/src/binary/product_template/40-image_1920"/>
     <field name="name">Student Organization Gala - VIP</field>
     <field name="type">service</field>
@@ -157,7 +157,7 @@ Add to cart to become a sponsor today.</p><p><br></p>]]></field>
     <field name="website_sequence">10080</field>
     <field name="public_categ_ids" eval="[(6, 0, [ref('product_public_category_8')])]"/>
   </record>
-  <record id="product_template_5" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_5" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="image_1920" type="base64" file="student_organization/static/src/binary/product_template/25-image_1920"/>
     <field name="name">Student Union Hoodie</field>
     <field name="description"><![CDATA[<p>Warm and comfortable hoodie with the student union logo. Available in multiple sizes.</p>]]></field>
@@ -172,7 +172,7 @@ Add to cart to become a sponsor today.</p><p><br></p>]]></field>
     <field name="website_sequence">10040</field>
     <field name="public_categ_ids" eval="[(6, 0, [ref('product_public_category_10')])]"/>
   </record>
-  <record id="product_template_6" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_6" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="image_1920" type="base64" file="student_organization/static/src/binary/product_template/26-image_1920"/>
     <field name="name">Student Union T-Shirt</field>
     <field name="description"><![CDATA[<p>Casual T-shirt featuring the student union design. Great for everyday wear.</p>]]></field>
@@ -187,7 +187,7 @@ Add to cart to become a sponsor today.</p><p><br></p>]]></field>
     <field name="website_sequence">10040</field>
     <field name="public_categ_ids" eval="[(6, 0, [ref('product_public_category_10')])]"/>
   </record>
-  <record id="product_template_7" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_7" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="image_1920" type="base64" file="student_organization/static/src/binary/product_template/27-image_1920"/>
     <field name="name">Welcome Party Ticket</field>
     <field name="description"><![CDATA[<p>Access to the student union welcome party. Includes one drink voucher.</p>]]></field>

--- a/student_organization/data/product_template_attribute_line.xml
+++ b/student_organization/data/product_template_attribute_line.xml
@@ -1,21 +1,21 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-  <record id="product_template_attribute_line_5" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_5" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_6"/>
     <field name="attribute_id" ref="product_barcodelookup.product_attribute_lookup_1"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_11'), ref('product_attribute_value_12'), ref('product_attribute_value_13'), ref('product_attribute_value_14')])]"/>
   </record>
-  <record id="product_template_attribute_line_3" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_3" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_5"/>
     <field name="attribute_id" ref="product_barcodelookup.product_attribute_lookup_7"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_7'), ref('product_attribute_value_8'), ref('product_attribute_value_9'), ref('product_attribute_value_10')])]"/>
   </record>
-  <record id="product_template_attribute_line_2" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_2" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_41"/>
     <field name="attribute_id" ref="product_attribute_10"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_1'), ref('product_attribute_value_2'), ref('product_attribute_value_3'), ref('product_attribute_value_4'), ref('product_attribute_value_5'), ref('product_attribute_value_6')])]"/>
   </record>
-  <record id="product_template_attribute_line_4" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_4" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_5"/>
     <field name="attribute_id" ref="product_barcodelookup.product_attribute_lookup_1"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_11'), ref('product_attribute_value_12'), ref('product_attribute_value_13'), ref('product_attribute_value_14')])]"/>

--- a/summer_camps/data/product_template.xml
+++ b/summer_camps/data/product_template.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-  <record id="product_template_5" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_5" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="name">Art Camp Registration</field>
     <field name="type">service</field>
     <field name="service_tracking">event</field>
@@ -8,7 +8,7 @@
     <field name="invoice_policy">order</field>
     <field name="website_sequence">10020</field>
   </record>
-  <record id="product_template_6" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_6" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="name">IT Camp Registration</field>
     <field name="type">service</field>
     <field name="service_tracking">event</field>
@@ -16,7 +16,7 @@
     <field name="invoice_policy">order</field>
     <field name="website_sequence">10025</field>
   </record>
-  <record id="product_template_4" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_4" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="name">Summer Camp Registration</field>
     <field name="type">service</field>
     <field name="service_tracking">event</field>

--- a/takeaway_restaurant/data/product_template.xml
+++ b/takeaway_restaurant/data/product_template.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-    <record id="product_template_bbq_chicken_pizza" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_bbq_chicken_pizza" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="image_1920" type="base64" file="takeaway_restaurant/static/src/binary/product_template/125-image_1920.jpeg"/>
         <field name="name">BBQ Chicken Pizza</field>
         <field name="description"><![CDATA[<p>Grilled chicken with BBQ sauce and red onions.</p>]]></field>
@@ -13,7 +13,7 @@
         <field name="available_in_pos" eval="True"/>
         <field name="pos_sequence">6</field>
     </record>
-    <record id="product_template_buffalo_mozzarella_pizza" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_buffalo_mozzarella_pizza" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="image_1920" type="base64" file="takeaway_restaurant/static/src/binary/product_template/131-image_1920.jpeg"/>
         <field name="name">Buffalo Mozzarella Pizza</field>
         <field name="description"><![CDATA[<p>Fresh buffalo mozzarella with cherry tomatoes and basil.</p>]]></field>
@@ -26,7 +26,7 @@
         <field name="available_in_pos" eval="True"/>
         <field name="pos_sequence">6</field>
     </record>
-    <record id="product_template_133" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_133" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="image_1920" type="base64" file="takeaway_restaurant/static/src/binary/product_template/133-image_1920.jpeg"/>
         <field name="name">Chicken Wings</field>
         <field name="list_price">5.0</field>
@@ -36,7 +36,7 @@
         <field name="available_in_pos" eval="True"/>
         <field name="pos_sequence">7</field>
     </record>
-    <record id="product_template_chocolate_brownie" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_chocolate_brownie" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="image_1920" type="base64" file="takeaway_restaurant/static/src/binary/product_template/121-image_1920.jpeg"/>
         <field name="name">Chocolate Brownie</field>
         <field name="description"><![CDATA[<p>Rich and fudgy chocolate brownie, freshly baked.</p>]]></field>
@@ -50,7 +50,7 @@
         <field name="available_in_pos" eval="True"/>
         <field name="pos_sequence">6</field>
     </record>
-    <record id="product_template_coca_cola_can" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_coca_cola_can" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="image_1920" type="base64" file="takeaway_restaurant/static/src/binary/product_template/120-image_1920.jpeg"/>
         <field name="name">Coca-Cola Can</field>
         <field name="description"><![CDATA[<p>Chilled can of Coca-Cola, 330ml.</p>]]></field>
@@ -64,7 +64,7 @@
         <field name="available_in_pos" eval="True"/>
         <field name="pos_sequence">6</field>
     </record>
-    <record id="product_template_delivery_service" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_delivery_service" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="image_1920" type="base64" file="takeaway_restaurant/static/src/binary/product_template/122-image_1920.jpeg"/>
         <field name="name">Delivery Service</field>
         <field name="description"><![CDATA[<p>Pizza delivery to your doorstep within 30 minutes.</p>]]></field>
@@ -78,7 +78,7 @@
         <field name="available_in_pos" eval="True"/>
         <field name="pos_sequence">6</field>
     </record>
-    <record id="product_template_134" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_134" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="image_1920" type="base64" file="takeaway_restaurant/static/src/binary/product_template/134-image_1920.jpeg"/>
         <field name="name">Fanta</field>
         <field name="list_price">2.0</field>
@@ -88,7 +88,7 @@
         <field name="available_in_pos" eval="True"/>
         <field name="pos_sequence">8</field>
     </record>
-    <record id="product_template_four_cheese_pizza" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_four_cheese_pizza" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="image_1920" type="base64" file="takeaway_restaurant/static/src/binary/product_template/123-image_1920.jpeg"/>
         <field name="name">Four Cheese Pizza</field>
         <field name="description"><![CDATA[<p>A creamy blend of mozzarella, cheddar, gorgonzola, and parmesan.</p>]]></field>
@@ -101,7 +101,7 @@
         <field name="available_in_pos" eval="True"/>
         <field name="pos_sequence">6</field>
     </record>
-    <record id="product_template_garlic_bread" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_garlic_bread" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="image_1920" type="base64" file="takeaway_restaurant/static/src/binary/product_template/119-image_1920.jpeg"/>
         <field name="name">Garlic Bread</field>
         <field name="description"><![CDATA[<p>Crispy garlic bread perfect as a side dish.</p>]]></field>
@@ -114,7 +114,7 @@
         <field name="available_in_pos" eval="True"/>
         <field name="pos_sequence">6</field>
     </record>
-    <record id="product_template_hawaiian_pizza" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_hawaiian_pizza" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="image_1920" type="base64" file="takeaway_restaurant/static/src/binary/product_template/124-image_1920.jpeg"/>
         <field name="name">Hawaiian Pizza</field>
         <field name="description"><![CDATA[<p>Ham and pineapple on a tomato base with mozzarella.</p>]]></field>
@@ -127,7 +127,7 @@
         <field name="available_in_pos" eval="True"/>
         <field name="pos_sequence">6</field>
     </record>
-    <record id="product_template_margherita_pizza" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_margherita_pizza" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="image_1920" type="base64" file="takeaway_restaurant/static/src/binary/product_template/117-image_1920.jpeg"/>
         <field name="name">Margherita Pizza</field>
         <field name="description"><![CDATA[<p>Classic Margherita pizza with fresh mozzarella and basil.</p>]]></field>
@@ -140,7 +140,7 @@
         <field name="available_in_pos" eval="True"/>
         <field name="pos_sequence">6</field>
     </record>
-    <record id="product_template_meat_feast_pizza" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_meat_feast_pizza" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="image_1920" type="base64" file="takeaway_restaurant/static/src/binary/product_template/130-image_1920.jpeg"/>
         <field name="name">Meat Feast Pizza</field>
         <field name="description"><![CDATA[<p>Loaded with pepperoni, sausage, ham, and beef.</p>]]></field>
@@ -153,7 +153,7 @@
         <field name="available_in_pos" eval="True"/>
         <field name="pos_sequence">6</field>
     </record>
-    <record id="product_template_mushroom_truffle_pizza" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_mushroom_truffle_pizza" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="image_1920" type="base64" file="takeaway_restaurant/static/src/binary/product_template/129-image_1920.jpeg"/>
         <field name="name">Mushroom Truffle Pizza</field>
         <field name="description"><![CDATA[<p>Truffle oil drizzled over roasted mushrooms and cheese.</p>]]></field>
@@ -166,7 +166,7 @@
         <field name="available_in_pos" eval="True"/>
         <field name="pos_sequence">6</field>
     </record>
-    <record id="product_template_pepperoni_pizza" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_pepperoni_pizza" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="image_1920" type="base64" file="takeaway_restaurant/static/src/binary/product_template/118-image_1920.jpeg"/>
         <field name="name">Pepperoni Pizza</field>
         <field name="description"><![CDATA[<p>Spicy pepperoni layered on melted cheese and tomato sauce.</p>]]></field>
@@ -179,7 +179,7 @@
         <field name="available_in_pos" eval="True"/>
         <field name="pos_sequence">6</field>
     </record>
-    <record id="product_template_pesto_chicken_pizza" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_pesto_chicken_pizza" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="image_1920" type="base64" file="takeaway_restaurant/static/src/binary/product_template/132-image_1920.jpeg"/>
         <field name="name">Pesto Chicken Pizza</field>
         <field name="description"><![CDATA[<p>Creamy pesto sauce base with grilled chicken and sun-dried tomatoes.</p>]]></field>
@@ -192,7 +192,7 @@
         <field name="available_in_pos" eval="True"/>
         <field name="pos_sequence">6</field>
     </record>
-    <record id="product_template_138" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_138" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="image_1920" type="base64" file="takeaway_restaurant/static/src/binary/product_template/138-image_1920.jpeg"/>
         <field name="name">Pick up</field>
         <field name="description"><![CDATA[<p>Pizza delivery to your doorstep within 30 minutes.</p>]]></field>
@@ -206,22 +206,22 @@
         <field name="available_in_pos" eval="True"/>
         <field name="pos_sequence">12</field>
     </record>
-    <record id="product_template_143" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_143" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Pizza Dough L</field>
         <field name="purchase_method">receive</field>
         <field name="pos_sequence">17</field>
     </record>
-    <record id="product_template_142" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_142" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Pizza Dough M</field>
         <field name="purchase_method">receive</field>
         <field name="pos_sequence">16</field>
     </record>
-    <record id="product_template_141" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_141" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Pizza Dough S</field>
         <field name="purchase_method">receive</field>
         <field name="pos_sequence">15</field>
     </record>
-    <record id="product_template_137" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_137" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="image_1920" type="base64" file="takeaway_restaurant/static/src/binary/product_template/137-image_1920.jpeg"/>
         <field name="name">Pizza Meal Deal - Large</field>
         <field name="type">combo</field>
@@ -233,7 +233,7 @@
         <field name="available_in_pos" eval="True"/>
         <field name="pos_sequence">11</field>
     </record>
-    <record id="product_template_136" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_136" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="image_1920" type="base64" file="takeaway_restaurant/static/src/binary/product_template/136-image_1920.jpeg"/>
         <field name="name">Pizza Meal Deal - Medium</field>
         <field name="type">combo</field>
@@ -245,7 +245,7 @@
         <field name="available_in_pos" eval="True"/>
         <field name="pos_sequence">10</field>
     </record>
-    <record id="product_template_135" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_135" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="image_1920" type="base64" file="takeaway_restaurant/static/src/binary/product_template/135-image_1920.jpeg"/>
         <field name="name">Pizza Meal Deal - Small</field>
         <field name="type">combo</field>
@@ -257,7 +257,7 @@
         <field name="available_in_pos" eval="True"/>
         <field name="pos_sequence">9</field>
     </record>
-    <record id="product_template_spicy_beef_pizza" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_spicy_beef_pizza" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="image_1920" type="base64" file="takeaway_restaurant/static/src/binary/product_template/127-image_1920.jpeg"/>
         <field name="name">Spicy Beef Pizza</field>
         <field name="description"><![CDATA[<p>Ground beef with jalapeños and chili flakes.</p>]]></field>
@@ -270,17 +270,17 @@
         <field name="available_in_pos" eval="True"/>
         <field name="pos_sequence">6</field>
     </record>
-    <record id="product_template_139" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_139" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Tomato Sauce</field>
         <field name="purchase_method">receive</field>
         <field name="pos_sequence">13</field>
     </record>
-    <record id="product_template_140" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_140" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Tomato Sauce - Spicy</field>
         <field name="purchase_method">receive</field>
         <field name="pos_sequence">14</field>
     </record>
-    <record id="product_template_veggie_supreme_pizza" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_veggie_supreme_pizza" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="image_1920" type="base64" file="takeaway_restaurant/static/src/binary/product_template/126-image_1920.jpeg"/>
         <field name="name">Veggie Supreme Pizza</field>
         <field name="description"><![CDATA[<p>Loaded with bell peppers, mushrooms, olives, and onions.</p>]]></field>

--- a/takeaway_restaurant/data/product_template_attribute_line.xml
+++ b/takeaway_restaurant/data/product_template_attribute_line.xml
@@ -1,166 +1,166 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo auto_sequence="1" noupdate="1">
-    <record id="product_template_attribute_line_1" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_1" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_bbq_chicken_pizza"/>
         <field name="attribute_id" ref="product_attribute_9"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_1'), ref('product_attribute_value_2'), ref('product_attribute_value_3')])]"/>
     </record>
-    <record id="product_template_attribute_line_4" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_4" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_buffalo_mozzarella_pizza"/>
         <field name="attribute_id" ref="product_attribute_9"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_1'), ref('product_attribute_value_2'), ref('product_attribute_value_3')])]"/>
     </record>
-    <record id="product_template_attribute_line_7" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_7" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_four_cheese_pizza"/>
         <field name="attribute_id" ref="product_attribute_9"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_1'), ref('product_attribute_value_2'), ref('product_attribute_value_3')])]"/>
     </record>
-    <record id="product_template_attribute_line_13" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_13" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_hawaiian_pizza"/>
         <field name="attribute_id" ref="product_attribute_9"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_1'), ref('product_attribute_value_2'), ref('product_attribute_value_3')])]"/>
     </record>
-    <record id="product_template_attribute_line_16" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_16" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_margherita_pizza"/>
         <field name="attribute_id" ref="product_attribute_9"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_1'), ref('product_attribute_value_2'), ref('product_attribute_value_3')])]"/>
     </record>
-    <record id="product_template_attribute_line_19" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_19" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_meat_feast_pizza"/>
         <field name="attribute_id" ref="product_attribute_9"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_1'), ref('product_attribute_value_2'), ref('product_attribute_value_3')])]"/>
     </record>
-    <record id="product_template_attribute_line_22" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_22" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_mushroom_truffle_pizza"/>
         <field name="attribute_id" ref="product_attribute_9"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_1'), ref('product_attribute_value_2'), ref('product_attribute_value_3')])]"/>
     </record>
-    <record id="product_template_attribute_line_25" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_25" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_pepperoni_pizza"/>
         <field name="attribute_id" ref="product_attribute_9"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_1'), ref('product_attribute_value_2'), ref('product_attribute_value_3')])]"/>
     </record>
-    <record id="product_template_attribute_line_28" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_28" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_pesto_chicken_pizza"/>
         <field name="attribute_id" ref="product_attribute_9"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_1'), ref('product_attribute_value_2'), ref('product_attribute_value_3')])]"/>
     </record>
-    <record id="product_template_attribute_line_31" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_31" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_spicy_beef_pizza"/>
         <field name="attribute_id" ref="product_attribute_9"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_1'), ref('product_attribute_value_2'), ref('product_attribute_value_3')])]"/>
     </record>
-    <record id="product_template_attribute_line_34" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_34" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_veggie_supreme_pizza"/>
         <field name="attribute_id" ref="product_attribute_9"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_1'), ref('product_attribute_value_2'), ref('product_attribute_value_3')])]"/>
     </record>
-    <record id="product_template_attribute_line_2" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_2" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_bbq_chicken_pizza"/>
         <field name="attribute_id" ref="product_attribute_10"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_4'), ref('product_attribute_value_5'), ref('product_attribute_value_6'), ref('product_attribute_value_7'), ref('product_attribute_value_8'), ref('product_attribute_value_9'), ref('product_attribute_value_10'), ref('product_attribute_value_11'), ref('product_attribute_value_12'), ref('product_attribute_value_13')])]"/>
     </record>
-    <record id="product_template_attribute_line_5" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_5" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_buffalo_mozzarella_pizza"/>
         <field name="attribute_id" ref="product_attribute_10"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_4'), ref('product_attribute_value_5'), ref('product_attribute_value_6'), ref('product_attribute_value_7'), ref('product_attribute_value_8'), ref('product_attribute_value_9'), ref('product_attribute_value_10'), ref('product_attribute_value_11'), ref('product_attribute_value_12'), ref('product_attribute_value_13')])]"/>
     </record>
-    <record id="product_template_attribute_line_8" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_8" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_four_cheese_pizza"/>
         <field name="attribute_id" ref="product_attribute_10"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_4'), ref('product_attribute_value_5'), ref('product_attribute_value_6'), ref('product_attribute_value_7'), ref('product_attribute_value_8'), ref('product_attribute_value_9'), ref('product_attribute_value_10'), ref('product_attribute_value_11'), ref('product_attribute_value_12'), ref('product_attribute_value_13')])]"/>
     </record>
-    <record id="product_template_attribute_line_14" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_14" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_hawaiian_pizza"/>
         <field name="attribute_id" ref="product_attribute_10"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_4'), ref('product_attribute_value_5'), ref('product_attribute_value_6'), ref('product_attribute_value_7'), ref('product_attribute_value_8'), ref('product_attribute_value_9'), ref('product_attribute_value_10'), ref('product_attribute_value_11'), ref('product_attribute_value_12'), ref('product_attribute_value_13')])]"/>
     </record>
-    <record id="product_template_attribute_line_17" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_17" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_margherita_pizza"/>
         <field name="attribute_id" ref="product_attribute_10"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_4'), ref('product_attribute_value_5'), ref('product_attribute_value_6'), ref('product_attribute_value_7'), ref('product_attribute_value_8'), ref('product_attribute_value_9'), ref('product_attribute_value_10'), ref('product_attribute_value_11'), ref('product_attribute_value_12'), ref('product_attribute_value_13')])]"/>
     </record>
-    <record id="product_template_attribute_line_20" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_20" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_meat_feast_pizza"/>
         <field name="attribute_id" ref="product_attribute_10"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_4'), ref('product_attribute_value_5'), ref('product_attribute_value_6'), ref('product_attribute_value_7'), ref('product_attribute_value_8'), ref('product_attribute_value_9'), ref('product_attribute_value_10'), ref('product_attribute_value_11'), ref('product_attribute_value_12'), ref('product_attribute_value_13')])]"/>
     </record>
-    <record id="product_template_attribute_line_23" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_23" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_mushroom_truffle_pizza"/>
         <field name="attribute_id" ref="product_attribute_10"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_4'), ref('product_attribute_value_5'), ref('product_attribute_value_6'), ref('product_attribute_value_7'), ref('product_attribute_value_8'), ref('product_attribute_value_9'), ref('product_attribute_value_10'), ref('product_attribute_value_11'), ref('product_attribute_value_12'), ref('product_attribute_value_13')])]"/>
     </record>
-    <record id="product_template_attribute_line_26" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_26" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_pepperoni_pizza"/>
         <field name="attribute_id" ref="product_attribute_10"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_4'), ref('product_attribute_value_5'), ref('product_attribute_value_6'), ref('product_attribute_value_7'), ref('product_attribute_value_8'), ref('product_attribute_value_9'), ref('product_attribute_value_10'), ref('product_attribute_value_11'), ref('product_attribute_value_12'), ref('product_attribute_value_13')])]"/>
     </record>
-    <record id="product_template_attribute_line_29" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_29" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_pesto_chicken_pizza"/>
         <field name="attribute_id" ref="product_attribute_10"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_4'), ref('product_attribute_value_5'), ref('product_attribute_value_6'), ref('product_attribute_value_7'), ref('product_attribute_value_8'), ref('product_attribute_value_9'), ref('product_attribute_value_10'), ref('product_attribute_value_11'), ref('product_attribute_value_12'), ref('product_attribute_value_13')])]"/>
     </record>
-    <record id="product_template_attribute_line_32" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_32" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_spicy_beef_pizza"/>
         <field name="attribute_id" ref="product_attribute_10"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_4'), ref('product_attribute_value_5'), ref('product_attribute_value_6'), ref('product_attribute_value_7'), ref('product_attribute_value_8'), ref('product_attribute_value_9'), ref('product_attribute_value_10'), ref('product_attribute_value_11'), ref('product_attribute_value_12'), ref('product_attribute_value_13')])]"/>
     </record>
-    <record id="product_template_attribute_line_35" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_35" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_veggie_supreme_pizza"/>
         <field name="attribute_id" ref="product_attribute_10"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_4'), ref('product_attribute_value_5'), ref('product_attribute_value_6'), ref('product_attribute_value_7'), ref('product_attribute_value_8'), ref('product_attribute_value_9'), ref('product_attribute_value_10'), ref('product_attribute_value_11'), ref('product_attribute_value_12'), ref('product_attribute_value_13')])]"/>
     </record>
-    <record id="product_template_attribute_line_3" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_3" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_bbq_chicken_pizza"/>
         <field name="attribute_id" ref="product_attribute_11"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_15'), ref('product_attribute_value_14')])]"/>
     </record>
-    <record id="product_template_attribute_line_6" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_6" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_buffalo_mozzarella_pizza"/>
         <field name="attribute_id" ref="product_attribute_11"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_15'), ref('product_attribute_value_14')])]"/>
     </record>
-    <record id="product_template_attribute_line_9" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_9" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_four_cheese_pizza"/>
         <field name="attribute_id" ref="product_attribute_11"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_15'), ref('product_attribute_value_14')])]"/>
     </record>
-    <record id="product_template_attribute_line_15" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_15" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_hawaiian_pizza"/>
         <field name="attribute_id" ref="product_attribute_11"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_15'), ref('product_attribute_value_14')])]"/>
     </record>
-    <record id="product_template_attribute_line_18" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_18" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_margherita_pizza"/>
         <field name="attribute_id" ref="product_attribute_11"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_15'), ref('product_attribute_value_14')])]"/>
     </record>
-    <record id="product_template_attribute_line_21" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_21" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_meat_feast_pizza"/>
         <field name="attribute_id" ref="product_attribute_11"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_15'), ref('product_attribute_value_14')])]"/>
     </record>
-    <record id="product_template_attribute_line_24" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_24" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_mushroom_truffle_pizza"/>
         <field name="attribute_id" ref="product_attribute_11"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_15'), ref('product_attribute_value_14')])]"/>
     </record>
-    <record id="product_template_attribute_line_27" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_27" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_pepperoni_pizza"/>
         <field name="attribute_id" ref="product_attribute_11"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_15'), ref('product_attribute_value_14')])]"/>
     </record>
-    <record id="product_template_attribute_line_30" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_30" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_pesto_chicken_pizza"/>
         <field name="attribute_id" ref="product_attribute_11"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_15'), ref('product_attribute_value_14')])]"/>
     </record>
-    <record id="product_template_attribute_line_33" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_33" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_spicy_beef_pizza"/>
         <field name="attribute_id" ref="product_attribute_11"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_15'), ref('product_attribute_value_14')])]"/>
     </record>
-    <record id="product_template_attribute_line_36" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_36" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="product_tmpl_id" ref="product_template_veggie_supreme_pizza"/>
         <field name="attribute_id" ref="product_attribute_11"/>
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_15'), ref('product_attribute_value_14')])]"/>

--- a/team_sports_club/data/product_template.xml
+++ b/team_sports_club/data/product_template.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-  <record id="product_template_11" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_11" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="name">Additional Pack</field>
     <field name="list_price">70.0</field>
     <field name="is_favorite" eval="True"/>
@@ -10,7 +10,7 @@
     <field name="invoice_policy">order</field>
     <field name="website_sequence">10050</field>
   </record>
-  <record id="product_template_9" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_9" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="name">Contribution</field>
     <field name="type">service</field>
     <field name="list_price">350.0</field>
@@ -21,7 +21,7 @@
     <field name="invoice_policy">order</field>
     <field name="website_sequence">10040</field>
   </record>
-  <record id="product_template_10" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_10" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="name">Welcome Pack</field>
     <field name="list_price">70.0</field>
     <field name="is_favorite" eval="True"/>
@@ -31,7 +31,7 @@
     <field name="invoice_policy">order</field>
     <field name="website_sequence">10045</field>
   </record>
-  <record id="product_template_15" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_15" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="image_1920" type="base64" file="team_sports_club/static/src/binary/product_template/15-image_1920"/>
     <field name="name">Away Jersey</field>
     <field name="list_price">79.99</field>
@@ -45,7 +45,7 @@
     <field name="website_sequence">10065</field>
     <field name="public_categ_ids" eval="[(6, 0, [ref('product_public_category_4')])]"/>
   </record>
-  <record id="product_template_18" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_18" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="image_1920" type="base64" file="team_sports_club/static/src/binary/product_template/18-image_1920"/>
     <field name="name">Cap</field>
     <field name="list_price">24.99</field>
@@ -59,7 +59,7 @@
     <field name="website_sequence">10080</field>
     <field name="public_categ_ids" eval="[(6, 0, [ref('product_public_category_3')])]"/>
   </record>
-  <record id="product_template_14" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_14" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="image_1920" type="base64" file="team_sports_club/static/src/binary/product_template/14-image_1920"/>
     <field name="name">Home Jersey</field>
     <field name="list_price">79.99</field>
@@ -73,7 +73,7 @@
     <field name="website_sequence">10060</field>
     <field name="public_categ_ids" eval="[(6, 0, [ref('product_public_category_4')])]"/>
   </record>
-  <record id="product_template_19" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_19" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="image_1920" type="base64" file="team_sports_club/static/src/binary/product_template/19-image_1920"/>
     <field name="name">Hoodie</field>
     <field name="list_price">54.99</field>
@@ -87,7 +87,7 @@
     <field name="website_sequence">10085</field>
     <field name="public_categ_ids" eval="[(6, 0, [ref('product_public_category_1')])]"/>
   </record>
-  <record id="product_template_39" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_39" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="name">Registration</field>
     <field name="type">service</field>
     <field name="service_tracking">event</field>
@@ -97,7 +97,7 @@
     <field name="invoice_policy">order</field>
     <field name="website_sequence">10185</field>
   </record>
-  <record id="product_template_13" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_13" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="name">Registration + Bus</field>
     <field name="type">service</field>
     <field name="service_tracking">event</field>
@@ -107,7 +107,7 @@
     <field name="invoice_policy">order</field>
     <field name="website_sequence">10055</field>
   </record>
-  <record id="product_template_17" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_17" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="image_1920" type="base64" file="team_sports_club/static/src/binary/product_template/17-image_1920"/>
     <field name="name">Scarf</field>
     <field name="list_price">19.99</field>
@@ -121,7 +121,7 @@
     <field name="website_sequence">10075</field>
     <field name="public_categ_ids" eval="[(6, 0, [ref('product_public_category_3')])]"/>
   </record>
-  <record id="product_template_21" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_21" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="name">Sponsorship Gold</field>
     <field name="type">service</field>
     <field name="categ_id" ref="product_category_8"/>
@@ -133,7 +133,7 @@
     <field name="invoice_policy">order</field>
     <field name="website_sequence">10095</field>
   </record>
-  <record id="product_template_20" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_20" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="image_1920" type="base64" file="team_sports_club/static/src/binary/product_template/20-image_1920"/>
     <field name="name">Training Jersey</field>
     <field name="list_price">59.99</field>

--- a/textile_manufacturing/data/product_template.xml
+++ b/textile_manufacturing/data/product_template.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-  <record id="product_template_8" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_8" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="name">Sewing thread</field>
     <field name="is_storable" eval="True"/>
     <field name="purchase_method">receive</field>
@@ -8,28 +8,28 @@
     <field name="service_type">manual</field>
     <field name="invoice_policy">order</field>
   </record>
-  <record id="product_template_10" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_10" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="name">Clothing Label (Bottom)</field>
     <field name="is_storable" eval="True"/>
     <field name="purchase_method">receive</field>
     <field name="service_type">manual</field>
     <field name="invoice_policy">order</field>
   </record>
-  <record id="product_template_9" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_9" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="name">Clothing Label (Top)</field>
     <field name="is_storable" eval="True"/>
     <field name="purchase_method">receive</field>
     <field name="service_type">manual</field>
     <field name="invoice_policy">order</field>
   </record>
-  <record id="product_template_11" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_11" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="name">Clothing Label (Underwear)</field>
     <field name="is_storable" eval="True"/>
     <field name="purchase_method">receive</field>
     <field name="service_type">manual</field>
     <field name="invoice_policy">order</field>
   </record>
-  <record id="product_template_5" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_5" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="name">Custom Shirt (ETO)</field>
     <field name="purchase_ok" eval="False"/>
     <field name="is_storable" eval="True"/>
@@ -39,7 +39,7 @@
     <field name="service_type">manual</field>
     <field name="invoice_policy">order</field>
   </record>
-  <record id="product_template_16" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_16" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="name">Dyed Cotton Fabric Blue</field>
     <field name="is_storable" eval="True"/>
     <field name="purchase_method">receive</field>
@@ -47,7 +47,7 @@
     <field name="uom_id" ref="uom.product_uom_meter"/>
     <field name="invoice_policy">order</field>
   </record>
-  <record id="product_template_17" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_17" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="name">Interfacing (Woven)</field>
     <field name="is_storable" eval="True"/>
     <field name="purchase_method">receive</field>
@@ -55,21 +55,21 @@
     <field name="service_type">manual</field>
     <field name="invoice_policy">order</field>
   </record>
-  <record id="product_template_18" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_18" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="name">Plastic Buttons (11.4mm)</field>
     <field name="is_storable" eval="True"/>
     <field name="purchase_method">receive</field>
     <field name="service_type">manual</field>
     <field name="invoice_policy">order</field>
   </record>
-  <record id="product_template_19" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_19" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="name">Plastic Buttons (9.5mm)</field>
     <field name="is_storable" eval="True"/>
     <field name="purchase_method">receive</field>
     <field name="service_type">manual</field>
     <field name="invoice_policy">order</field>
   </record>
-  <record id="product_template_7" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_7" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="name">Pre-dyed Cotton fabric</field>
     <field name="is_storable" eval="True"/>
     <field name="purchase_method">receive</field>
@@ -77,7 +77,7 @@
     <field name="service_type">manual</field>
     <field name="invoice_policy">order</field>
   </record>
-  <record id="product_template_6" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_6" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="name">Raw White Cotton Fabric</field>
     <field name="categ_id" ref="product_category_9"/>
     <field name="is_storable" eval="True"/>
@@ -87,7 +87,7 @@
     <field name="service_type">manual</field>
     <field name="invoice_policy">order</field>
   </record>
-  <record id="product_template_15" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_15" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="name">T-shirt cotton Adult round neck L (MTS)</field>
     <field name="image_1920" type="base64" file="textile_manufacturing/static/src/binary/product_template/15-image_1920"/>
     <field name="list_price" eval="False"/>
@@ -100,7 +100,7 @@
     <field name="description_ecommerce"><![CDATA[<p><b>High Quality Cotton T-shirt available in the following variants:</b></p><p><b>Material:</b> Crafted from 100% Ring-Spun Combed Cotton for superior softness and durability. Our t-shirts are pre-shrunk to ensure a consistent fit.</p><p><b>Fit:</b></p><ul><li><b>Regular/Classic Fit:</b> A standard, comfortable, and timeless fit.</li><li><p><b>Slim/Modern Fit:</b> Tapered through the chest and waist for a more tailored look.</p></li><li><p><b>Relaxed/Oversized Fit:</b> A looser, more casual fit that is currently popular in streetwear.</p></li><li><p><b>Athletic Fit:</b> Designed to fit close to the body, often with raglan sleeves, to allow for movement</p></li></ul><p><strong>Neckline:&nbsp;</strong></p><ul><li><p><b>Crew Neck (Round Neck):</b> The most classic and popular style.</p></li><li><p><b>V-Neck:</b> A "V" shaped neckline that can be shallow or deep.</p></li><li><p><b>Scoop Neck:</b> A wider, U-shaped neckline, more common in women's styles.</p></li><li><p><b>Henley:</b> A crew neck with a placket of a few buttons, often without a collar.</p></li><li><p><b>Polo Collar:</b> A two-button placket and a soft, folded collar.</p></li><li><p><b>Boat Neck:</b> A wide, straight neckline that runs horizontally across the collarbone.</p></li></ul><p><b>Sleeve Cut:</b></p><ul><li><p><b>Set-in Sleeve:</b> The standard sleeve that is sewn into the armhole seam.</p></li><li><p><b>Raglan Sleeve:</b> Extends in one piece to the collar, creating a diagonal seam.</p></li><li><p><b>Dolman/Batwing Sleeve:</b> A very loose sleeve that gets narrower at the wrist.</p></li></ul><p><strong>Color:&nbsp;</strong></p><p><strong>Black, White, Heather Gray, Navy Blue, Olive Green, Maroon, Royal Blue, Pastel Pink</strong></p>]]></field>
     <field name="website_ribbon_id" ref="website_sale.new_ribbon"/>
   </record>
-  <record id="product_template_14" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_14" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="name">T-shirt cotton Adult round neck M (MTS)</field>
     <field name="image_1920" type="base64" file="textile_manufacturing/static/src/binary/product_template/14-image_1920"/>
     <field name="list_price" eval="False"/>
@@ -113,7 +113,7 @@
     <field name="description_ecommerce"><![CDATA[<p><b>High Quality Cotton T-shirt available in the following variants:</b></p><p><b>Material:</b> Crafted from 100% Ring-Spun Combed Cotton for superior softness and durability. Our t-shirts are pre-shrunk to ensure a consistent fit.</p><p><b>Fit:</b></p><ul><li><b>Regular/Classic Fit:</b> A standard, comfortable, and timeless fit.</li><li><p><b>Slim/Modern Fit:</b> Tapered through the chest and waist for a more tailored look.</p></li><li><p><b>Relaxed/Oversized Fit:</b> A looser, more casual fit that is currently popular in streetwear.</p></li><li><p><b>Athletic Fit:</b> Designed to fit close to the body, often with raglan sleeves, to allow for movement</p></li></ul><p><strong>Neckline:&nbsp;</strong></p><ul><li><p><b>Crew Neck (Round Neck):</b> The most classic and popular style.</p></li><li><p><b>V-Neck:</b> A "V" shaped neckline that can be shallow or deep.</p></li><li><p><b>Scoop Neck:</b> A wider, U-shaped neckline, more common in women's styles.</p></li><li><p><b>Henley:</b> A crew neck with a placket of a few buttons, often without a collar.</p></li><li><p><b>Polo Collar:</b> A two-button placket and a soft, folded collar.</p></li><li><p><b>Boat Neck:</b> A wide, straight neckline that runs horizontally across the collarbone.</p></li></ul><p><b>Sleeve Cut:</b></p><ul><li><p><b>Set-in Sleeve:</b> The standard sleeve that is sewn into the armhole seam.</p></li><li><p><b>Raglan Sleeve:</b> Extends in one piece to the collar, creating a diagonal seam.</p></li><li><p><b>Dolman/Batwing Sleeve:</b> A very loose sleeve that gets narrower at the wrist.</p></li></ul><p><strong>Color:&nbsp;</strong></p><p><strong>Black, White, Heather Gray, Navy Blue, Olive Green, Maroon, Royal Blue, Pastel Pink</strong></p>]]></field>
     <field name="website_ribbon_id" ref="website_sale.new_ribbon"/>
   </record>
-  <record id="product_template_3" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_3" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="name">T-shirt cotton Adult round neck S (MTS)</field>
     <field name="image_1920" type="base64" file="textile_manufacturing/static/src/binary/product_template/3-image_1920"/>
     <field name="list_price" eval="False"/>
@@ -126,7 +126,7 @@
     <field name="description_ecommerce"><![CDATA[<p><b>High Quality Cotton T-shirt available in the following variants:</b></p><p><b>Material:</b> Crafted from 100% Ring-Spun Combed Cotton for superior softness and durability. Our t-shirts are pre-shrunk to ensure a consistent fit.</p><p><b>Fit:</b></p><ul><li><b>Regular/Classic Fit:</b> A standard, comfortable, and timeless fit.</li><li><p><b>Slim/Modern Fit:</b> Tapered through the chest and waist for a more tailored look.</p></li><li><p><b>Relaxed/Oversized Fit:</b> A looser, more casual fit that is currently popular in streetwear.</p></li><li><p><b>Athletic Fit:</b> Designed to fit close to the body, often with raglan sleeves, to allow for movement</p></li></ul><p><strong>Neckline:&nbsp;</strong></p><ul><li><p><b>Crew Neck (Round Neck):</b> The most classic and popular style.</p></li><li><p><b>V-Neck:</b> A "V" shaped neckline that can be shallow or deep.</p></li><li><p><b>Scoop Neck:</b> A wider, U-shaped neckline, more common in women's styles.</p></li><li><p><b>Henley:</b> A crew neck with a placket of a few buttons, often without a collar.</p></li><li><p><b>Polo Collar:</b> A two-button placket and a soft, folded collar.</p></li><li><p><b>Boat Neck:</b> A wide, straight neckline that runs horizontally across the collarbone.</p></li></ul><p><b>Sleeve Cut:</b></p><ul><li><p><b>Set-in Sleeve:</b> The standard sleeve that is sewn into the armhole seam.</p></li><li><p><b>Raglan Sleeve:</b> Extends in one piece to the collar, creating a diagonal seam.</p></li><li><p><b>Dolman/Batwing Sleeve:</b> A very loose sleeve that gets narrower at the wrist.</p></li></ul><p><strong>Color:&nbsp;</strong></p><p><strong>Black, White, Heather Gray, Navy Blue, Olive Green, Maroon, Royal Blue, Pastel Pink</strong></p>]]></field>
     <field name="website_ribbon_id" ref="website_sale.new_ribbon"/>
   </record>
-  <record id="product_template_13" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_13" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="name">T-shirt cotton Adult round neck with Logo L (MTO)</field>
     <field name="image_1920" type="base64" file="textile_manufacturing/static/src/binary/product_template/13-image_1920"/>
     <field name="list_price" eval="False"/>
@@ -140,7 +140,7 @@
     <field name="description_ecommerce"><![CDATA[<p><b>High Quality Cotton T-shirt available in the following variants:</b></p><p><b>Material:</b> Crafted from 100% Ring-Spun Combed Cotton for superior softness and durability. Our t-shirts are pre-shrunk to ensure a consistent fit.</p><p><b>Fit:</b></p><ul><li><b>Regular/Classic Fit:</b> A standard, comfortable, and timeless fit.</li><li><p><b>Slim/Modern Fit:</b> Tapered through the chest and waist for a more tailored look.</p></li><li><p><b>Relaxed/Oversized Fit:</b> A looser, more casual fit that is currently popular in streetwear.</p></li><li><p><b>Athletic Fit:</b> Designed to fit close to the body, often with raglan sleeves, to allow for movement</p></li></ul><p><strong>Neckline:&nbsp;</strong></p><ul><li><p><b>Crew Neck (Round Neck):</b> The most classic and popular style.</p></li><li><p><b>V-Neck:</b> A "V" shaped neckline that can be shallow or deep.</p></li><li><p><b>Scoop Neck:</b> A wider, U-shaped neckline, more common in women's styles.</p></li><li><p><b>Henley:</b> A crew neck with a placket of a few buttons, often without a collar.</p></li><li><p><b>Polo Collar:</b> A two-button placket and a soft, folded collar.</p></li><li><p><b>Boat Neck:</b> A wide, straight neckline that runs horizontally across the collarbone.</p></li></ul><p><b>Sleeve Cut:</b></p><ul><li><p><b>Set-in Sleeve:</b> The standard sleeve that is sewn into the armhole seam.</p></li><li><p><b>Raglan Sleeve:</b> Extends in one piece to the collar, creating a diagonal seam.</p></li><li><p><b>Dolman/Batwing Sleeve:</b> A very loose sleeve that gets narrower at the wrist.</p></li></ul><p><strong>Color:&nbsp;</strong></p><p><strong>Black, White, Heather Gray, Navy Blue, Olive Green, Maroon, Royal Blue, Pastel Pink</strong></p>]]></field>
     <field name="website_ribbon_id" ref="website_sale.new_ribbon"/>
   </record>
-  <record id="product_template_12" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_12" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="name">T-shirt cotton Adult round neck with Logo M (MTO)</field>
     <field name="image_1920" type="base64" file="textile_manufacturing/static/src/binary/product_template/12-image_1920"/>
     <field name="list_price" eval="False"/>
@@ -154,7 +154,7 @@
     <field name="description_ecommerce"><![CDATA[<p><b>High Quality Cotton T-shirt available in the following variants:</b></p><p><b>Material:</b> Crafted from 100% Ring-Spun Combed Cotton for superior softness and durability. Our t-shirts are pre-shrunk to ensure a consistent fit.</p><p><b>Fit:</b></p><ul><li><b>Regular/Classic Fit:</b> A standard, comfortable, and timeless fit.</li><li><p><b>Slim/Modern Fit:</b> Tapered through the chest and waist for a more tailored look.</p></li><li><p><b>Relaxed/Oversized Fit:</b> A looser, more casual fit that is currently popular in streetwear.</p></li><li><p><b>Athletic Fit:</b> Designed to fit close to the body, often with raglan sleeves, to allow for movement</p></li></ul><p><strong>Neckline:&nbsp;</strong></p><ul><li><p><b>Crew Neck (Round Neck):</b> The most classic and popular style.</p></li><li><p><b>V-Neck:</b> A "V" shaped neckline that can be shallow or deep.</p></li><li><p><b>Scoop Neck:</b> A wider, U-shaped neckline, more common in women's styles.</p></li><li><p><b>Henley:</b> A crew neck with a placket of a few buttons, often without a collar.</p></li><li><p><b>Polo Collar:</b> A two-button placket and a soft, folded collar.</p></li><li><p><b>Boat Neck:</b> A wide, straight neckline that runs horizontally across the collarbone.</p></li></ul><p><b>Sleeve Cut:</b></p><ul><li><p><b>Set-in Sleeve:</b> The standard sleeve that is sewn into the armhole seam.</p></li><li><p><b>Raglan Sleeve:</b> Extends in one piece to the collar, creating a diagonal seam.</p></li><li><p><b>Dolman/Batwing Sleeve:</b> A very loose sleeve that gets narrower at the wrist.</p></li></ul><p><strong>Color:&nbsp;</strong></p><p><strong>Black, White, Heather Gray, Navy Blue, Olive Green, Maroon, Royal Blue, Pastel Pink</strong></p>]]></field>
     <field name="website_ribbon_id" ref="website_sale.new_ribbon"/>
   </record>
-  <record id="product_template_4" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_4" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="name">T-shirt cotton Adult round neck with Logo S (MTO)</field>
     <field name="image_1920" type="base64" file="textile_manufacturing/static/src/binary/product_template/4-image_1920"/>
     <field name="list_price" eval="False"/>
@@ -168,7 +168,7 @@
     <field name="description_ecommerce"><![CDATA[<p><b>High Quality Cotton T-shirt available in the following variants:</b></p><p><b>Material:</b> Crafted from 100% Ring-Spun Combed Cotton for superior softness and durability. Our t-shirts are pre-shrunk to ensure a consistent fit.</p><p><b>Fit:</b></p><ul><li><b>Regular/Classic Fit:</b> A standard, comfortable, and timeless fit.</li><li><p><b>Slim/Modern Fit:</b> Tapered through the chest and waist for a more tailored look.</p></li><li><p><b>Relaxed/Oversized Fit:</b> A looser, more casual fit that is currently popular in streetwear.</p></li><li><p><b>Athletic Fit:</b> Designed to fit close to the body, often with raglan sleeves, to allow for movement</p></li></ul><p><strong>Neckline:&nbsp;</strong></p><ul><li><p><b>Crew Neck (Round Neck):</b> The most classic and popular style.</p></li><li><p><b>V-Neck:</b> A "V" shaped neckline that can be shallow or deep.</p></li><li><p><b>Scoop Neck:</b> A wider, U-shaped neckline, more common in women's styles.</p></li><li><p><b>Henley:</b> A crew neck with a placket of a few buttons, often without a collar.</p></li><li><p><b>Polo Collar:</b> A two-button placket and a soft, folded collar.</p></li><li><p><b>Boat Neck:</b> A wide, straight neckline that runs horizontally across the collarbone.</p></li></ul><p><b>Sleeve Cut:</b></p><ul><li><p><b>Set-in Sleeve:</b> The standard sleeve that is sewn into the armhole seam.</p></li><li><p><b>Raglan Sleeve:</b> Extends in one piece to the collar, creating a diagonal seam.</p></li><li><p><b>Dolman/Batwing Sleeve:</b> A very loose sleeve that gets narrower at the wrist.</p></li></ul><p><strong>Color:&nbsp;</strong></p><p><strong>Black, White, Heather Gray, Navy Blue, Olive Green, Maroon, Royal Blue, Pastel Pink</strong></p>]]></field>
     <field name="website_ribbon_id" ref="website_sale.new_ribbon"/>
   </record>
-  <record id="product_template_20" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_20" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="name">Polo With Quality Level</field>
     <field name="list_price" eval="False"/>
     <field name="purchase_ok" eval="False"/>

--- a/textile_manufacturing/data/product_template_attribute_line.xml
+++ b/textile_manufacturing/data/product_template_attribute_line.xml
@@ -1,46 +1,46 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-  <record id="product_template_attribute_line_3" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_3" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_7"/>
     <field name="attribute_id" ref="product_barcodelookup.product_attribute_lookup_1"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_2'), ref('product_attribute_value_3'), ref('product_attribute_value_4'), ref('product_attribute_value_5'), ref('product_attribute_value_6'), ref('product_attribute_value_7'), ref('product_attribute_value_8'), ref('product_attribute_value_9'), ref('product_attribute_value_10'), ref('product_attribute_value_11'), ref('product_attribute_value_12'), ref('product_attribute_value_13'), ref('product_attribute_value_14'), ref('product_attribute_value_15'), ref('product_attribute_value_16')])]"/>
   </record>
-  <record id="product_template_attribute_line_4" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_4" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_3"/>
     <field name="attribute_id" ref="product_barcodelookup.product_attribute_lookup_1"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_2'), ref('product_attribute_value_3'), ref('product_attribute_value_4'), ref('product_attribute_value_5'), ref('product_attribute_value_6'), ref('product_attribute_value_7'), ref('product_attribute_value_8'), ref('product_attribute_value_9'), ref('product_attribute_value_10'), ref('product_attribute_value_11'), ref('product_attribute_value_12'), ref('product_attribute_value_13'), ref('product_attribute_value_14'), ref('product_attribute_value_15'), ref('product_attribute_value_16')])]"/>
   </record>
-  <record id="product_template_attribute_line_7" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_7" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_4"/>
     <field name="attribute_id" ref="product_barcodelookup.product_attribute_lookup_1"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_2'), ref('product_attribute_value_3'), ref('product_attribute_value_4'), ref('product_attribute_value_5'), ref('product_attribute_value_6'), ref('product_attribute_value_7'), ref('product_attribute_value_8'), ref('product_attribute_value_9'), ref('product_attribute_value_10'), ref('product_attribute_value_11'), ref('product_attribute_value_12'), ref('product_attribute_value_13'), ref('product_attribute_value_14'), ref('product_attribute_value_15'), ref('product_attribute_value_16')])]"/>
   </record>
-  <record id="product_template_attribute_line_11" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_11" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_12"/>
     <field name="attribute_id" ref="product_barcodelookup.product_attribute_lookup_1"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_2'), ref('product_attribute_value_3'), ref('product_attribute_value_4'), ref('product_attribute_value_5'), ref('product_attribute_value_6'), ref('product_attribute_value_7'), ref('product_attribute_value_8'), ref('product_attribute_value_9'), ref('product_attribute_value_10'), ref('product_attribute_value_11'), ref('product_attribute_value_12'), ref('product_attribute_value_13'), ref('product_attribute_value_14'), ref('product_attribute_value_15'), ref('product_attribute_value_16')])]"/>
   </record>
-  <record id="product_template_attribute_line_13" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_13" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_13"/>
     <field name="attribute_id" ref="product_barcodelookup.product_attribute_lookup_1"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_2'), ref('product_attribute_value_3'), ref('product_attribute_value_4'), ref('product_attribute_value_5'), ref('product_attribute_value_6'), ref('product_attribute_value_7'), ref('product_attribute_value_8'), ref('product_attribute_value_9'), ref('product_attribute_value_10'), ref('product_attribute_value_11'), ref('product_attribute_value_12'), ref('product_attribute_value_13'), ref('product_attribute_value_14'), ref('product_attribute_value_15'), ref('product_attribute_value_16')])]"/>
   </record>
-  <record id="product_template_attribute_line_15" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_15" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_14"/>
     <field name="attribute_id" ref="product_barcodelookup.product_attribute_lookup_1"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_2'), ref('product_attribute_value_3'), ref('product_attribute_value_4'), ref('product_attribute_value_5'), ref('product_attribute_value_6'), ref('product_attribute_value_7'), ref('product_attribute_value_8'), ref('product_attribute_value_9'), ref('product_attribute_value_10'), ref('product_attribute_value_11'), ref('product_attribute_value_12'), ref('product_attribute_value_13'), ref('product_attribute_value_14'), ref('product_attribute_value_15'), ref('product_attribute_value_16')])]"/>
   </record>
-  <record id="product_template_attribute_line_16" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_16" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_15"/>
     <field name="attribute_id" ref="product_barcodelookup.product_attribute_lookup_1"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_2'), ref('product_attribute_value_3'), ref('product_attribute_value_4'), ref('product_attribute_value_5'), ref('product_attribute_value_6'), ref('product_attribute_value_7'), ref('product_attribute_value_8'), ref('product_attribute_value_9'), ref('product_attribute_value_10'), ref('product_attribute_value_11'), ref('product_attribute_value_12'), ref('product_attribute_value_13'), ref('product_attribute_value_14'), ref('product_attribute_value_15'), ref('product_attribute_value_16')])]"/>
   </record>
-  <record id="product_template_attribute_line_17" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_17" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_20"/>
     <field name="attribute_id" ref="product_attribute_1"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_17'), ref('product_attribute_value_18'), ref('product_attribute_value_19')])]"/>
   </record>
-  <record id="product_template_attribute_line_18" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_18" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_20"/>
     <field name="attribute_id" ref="product_barcodelookup.product_attribute_lookup_1"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_2'), ref('product_attribute_value_3'), ref('product_attribute_value_4')])]"/>

--- a/thrift_store/data/product_template.xml
+++ b/thrift_store/data/product_template.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-    <record id="product_template_16" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_16" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="image_1920" type="base64" file="thrift_store/static/src/binary/product_template/16-image_1920"/>
         <field name="name">10</field>
         <field name="list_price">10.0</field>
@@ -9,7 +9,7 @@
         <field name="available_in_pos" eval="True"/>
         <field name="pos_sequence">16</field>
     </record>
-    <record id="product_template_17" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_17" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="image_1920" type="base64" file="thrift_store/static/src/binary/product_template/17-image_1920"/>
         <field name="name">15</field>
         <field name="list_price">15.0</field>
@@ -18,7 +18,7 @@
         <field name="available_in_pos" eval="True"/>
         <field name="pos_sequence">17</field>
     </record>
-    <record id="product_template_18" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_18" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="image_1920" type="base64" file="thrift_store/static/src/binary/product_template/18-image_1920"/>
         <field name="name">20</field>
         <field name="list_price">20.0</field>
@@ -27,7 +27,7 @@
         <field name="available_in_pos" eval="True"/>
         <field name="pos_sequence">18</field>
     </record>
-    <record id="product_template_14" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_14" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="image_1920" type="base64" file="thrift_store/static/src/binary/product_template/14-image_1920"/>
         <field name="name">3</field>
         <field name="list_price">3.0</field>
@@ -36,7 +36,7 @@
         <field name="available_in_pos" eval="True"/>
         <field name="pos_sequence">14</field>
     </record>
-    <record id="product_template_19" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_19" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="image_1920" type="base64" file="thrift_store/static/src/binary/product_template/19-image_1920"/>
         <field name="name">30</field>
         <field name="list_price">30.0</field>
@@ -45,7 +45,7 @@
         <field name="available_in_pos" eval="True"/>
         <field name="pos_sequence">19</field>
     </record>
-    <record id="product_template_15" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_15" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="image_1920" type="base64" file="thrift_store/static/src/binary/product_template/15-image_1920"/>
         <field name="name">5</field>
         <field name="list_price">5.0</field>
@@ -54,7 +54,7 @@
         <field name="available_in_pos" eval="True"/>
         <field name="pos_sequence">15</field>
     </record>
-    <record id="product_template_20" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_20" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="image_1920" type="base64" file="thrift_store/static/src/binary/product_template/20-image_1920"/>
         <field name="name">50</field>
         <field name="list_price">50.0</field>
@@ -63,7 +63,7 @@
         <field name="available_in_pos" eval="True"/>
         <field name="pos_sequence">20</field>
     </record>
-    <record id="product_template_12" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_12" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="image_1920" type="base64" file="thrift_store/static/src/binary/product_template/12-image_1920"/>
         <field name="name">Accessories</field>
         <field name="pos_categ_ids" eval="[(6, 0, [ref('pos_category_2')])]"/>
@@ -72,7 +72,7 @@
         <field name="available_in_pos" eval="True"/>
         <field name="pos_sequence">12</field>
     </record>
-    <record id="product_template_13" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_13" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="image_1920" type="base64" file="thrift_store/static/src/binary/product_template/13-image_1920"/>
         <field name="name">Jackets</field>
         <field name="pos_categ_ids" eval="[(6, 0, [ref('pos_category_2')])]"/>
@@ -81,7 +81,7 @@
         <field name="available_in_pos" eval="True"/>
         <field name="pos_sequence">13</field>
     </record>
-    <record id="product_template_9" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_9" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="image_1920" type="base64" file="thrift_store/static/src/binary/product_template/9-image_1920"/>
         <field name="name">Pants</field>
         <field name="pos_categ_ids" eval="[(6, 0, [ref('pos_category_2')])]"/>
@@ -90,7 +90,7 @@
         <field name="available_in_pos" eval="True"/>
         <field name="pos_sequence">9</field>
     </record>
-    <record id="product_template_8" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_8" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="image_1920" type="base64" file="thrift_store/static/src/binary/product_template/8-image_1920"/>
         <field name="name">Shirts</field>
         <field name="pos_categ_ids" eval="[(6, 0, [ref('pos_category_2')])]"/>
@@ -99,7 +99,7 @@
         <field name="available_in_pos" eval="True"/>
         <field name="pos_sequence">8</field>
     </record>
-    <record id="product_template_11" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_11" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="image_1920" type="base64" file="thrift_store/static/src/binary/product_template/11-image_1920"/>
         <field name="name">Shoes</field>
         <field name="pos_categ_ids" eval="[(6, 0, [ref('pos_category_2')])]"/>
@@ -108,7 +108,7 @@
         <field name="available_in_pos" eval="True"/>
         <field name="pos_sequence">11</field>
     </record>
-    <record id="product_template_10" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_10" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="image_1920" type="base64" file="thrift_store/static/src/binary/product_template/10-image_1920"/>
         <field name="name">Shorts</field>
         <field name="pos_categ_ids" eval="[(6, 0, [ref('pos_category_2')])]"/>
@@ -117,7 +117,7 @@
         <field name="available_in_pos" eval="True"/>
         <field name="pos_sequence">10</field>
     </record>
-    <record id="product_template_6" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_6" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="image_1920" type="base64" file="thrift_store/static/src/binary/product_template/6-image_1920"/>
         <field name="name">To Weight</field>
         <field name="list_price">15.0</field>
@@ -129,7 +129,7 @@
         <field name="to_weight" eval="True"/>
         <field name="pos_sequence">6</field>
     </record>
-    <record id="product_template_7" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_7" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="image_1920" type="base64" file="thrift_store/static/src/binary/product_template/7-image_1920"/>
         <field name="name">Tshirts</field>
         <field name="pos_categ_ids" eval="[(6, 0, [ref('pos_category_2')])]"/>

--- a/toy_store/data/product_template.xml
+++ b/toy_store/data/product_template.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-    <record id="product_template_10" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_10" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">[Example product] Wild Republic - Red Fox</field>
         <field name="description_ecommerce">While a red fox in the wild is typically a solitary creature the red fox plush by Wild Republic is the perfect partner in crime for any stuffed animal lover. At 12 long this plush toy is the perfect size to take on any adventure.</field>
         <field name="available_in_pos" eval="True"/>
@@ -13,7 +13,7 @@
         <field name="weight">0.28</field>
         <field name="invoice_policy">order</field>
     </record>
-    <record id="product_template_11" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_11" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">[Example product] My 1st Teddy Bear 15"</field>
         <field name="available_in_pos" eval="True"/>
         <field name="is_storable" eval="1"/>
@@ -26,7 +26,7 @@
         <field name="weight">35.0</field>
         <field name="invoice_policy">order</field>
     </record>
-    <record id="product_template_12" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_12" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">[Example product] Maple Wood Building Blocks</field>
         <field name="is_storable" eval="1"/>
         <field name="available_in_pos" eval="True"/>
@@ -39,7 +39,7 @@
         <field name="weight">1.19</field>
         <field name="invoice_policy">order</field>
     </record>
-    <record id="product_template_18" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_18" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">[Example product] 12 coloring pencils - STABILO</field>
         <field name="is_storable" eval="1"/>
         <field name="available_in_pos" eval="True"/>
@@ -51,7 +51,7 @@
         <field name="weight">0.07</field>
         <field name="invoice_policy">order</field>
     </record>
-    <record id="product_template_21" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_21" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">[Example product] Micro scooter</field>
         <field name="description_ecommerce"><![CDATA[Hyper lightweight 10 balance trainer with puncture-proof tires and a high-quality metal frame. The perfect toy to train your toddler gross motor skills balance and steering.
 <br />
@@ -70,7 +70,7 @@ Thanks to its lightweight frame your toddler can easily control the bike and in 
         <field name="standard_price">33.33</field>
         <field name="weight">3.47</field>
     </record>
-    <record id="product_template_22" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_22" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">[Example product] Chupa Chups</field>
         <field name="is_storable" eval="1"/>
         <field name="available_in_pos" eval="True"/>
@@ -80,7 +80,7 @@ Thanks to its lightweight frame your toddler can easily control the bike and in 
         <field name="service_type">manual</field>
         <field name="invoice_policy">order</field>
     </record>
-    <record id="product_template_23" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_23" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">[Example product] PEZ dispenser and candy</field>
         <field name="is_storable" eval="1"/>
         <field name="available_in_pos" eval="True"/>
@@ -91,7 +91,7 @@ Thanks to its lightweight frame your toddler can easily control the bike and in 
         <field name="weight">0.01</field>
         <field name="invoice_policy">order</field>
     </record>
-    <record id="product_template_26" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_26" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">[Example product] Calico Critters - Chocolate Rabbit Family</field>
         <field name="description_ecommerce"><![CDATA[Calico Critters miniature dollhouses playsets and figures are timeless and classic high-quality toys.
 <br />
@@ -110,7 +110,7 @@ fun with her family and friends. Brother Skip is a great soccer player and is on
         <field name="weight">0.46</field>
         <field name="invoice_policy">order</field>
     </record>
-    <record id="product_template_5" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_5" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">[Example product] Catan - 5-6 player extension</field>
         <field name="description_ecommerce">Let additional players join the fun with this Catan 5-6 Player Extension Strategy Board Game. It includes 11 new unique terrain lines for added variety and it has dedicated wooden settlements cities and roads for players 5 and 6.</field>
         <field name="is_storable" eval="1"/>
@@ -123,7 +123,7 @@ fun with her family and friends. Brother Skip is a great soccer player and is on
         <field name="weight">0.46</field>
         <field name="invoice_policy">order</field>
     </record>
-    <record id="product_template_4" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_4" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">[Example product] Catan - Base game</field>
         <field name="description_ecommerce">Embark on a thrilling quest for dominance in Catan! Settle the isle of Catan, trade resources, and build your way to victory. With a modular board for endless replayability and strategic gameplay balanced with luck, every game night is an exciting adventure. High-quality wooden pieces and easy-to-learn rules make this award-winning board game perfect for players 10 and up.</field>
         <field name="is_storable" eval="1"/>
@@ -139,10 +139,10 @@ fun with her family and friends. Brother Skip is a great soccer player and is on
         <field name="weight">0.91</field>
         <field name="invoice_policy">order</field>
     </record>
-    <record id="product_template_5" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_5" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="optional_product_ids" eval="[(6, 0, [ref('product_template_4')])]"/>
     </record>
-    <record id="product_template_6" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_6" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">[Example product] Monopoly</field>
         <field name="description_ecommerce"><![CDATA[Select a favorite Monopoly token, place it on Go and roll the dice to own it all!
 <br />
@@ -160,7 +160,7 @@ It's all about buying, selling, and trading properties to win. Chance or Communi
         <field name="weight">0.46</field>
         <field name="invoice_policy">order</field>
     </record>
-    <record id="product_template_7" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_7" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">[Example product] Pandemic</field>
         <field name="description_ecommerce"><![CDATA[As skilled members of a disease-fighting team, you and the other players work together to keep the world safe from outbreaks and epidemics. Only through teamwork will you have a chance to find a cure.
 <br />
@@ -178,7 +178,7 @@ Pandemic is a cooperative board game in which players work as a team to treat in
         <field name="weight">1.04</field>
         <field name="invoice_policy">order</field>
     </record>
-    <record id="product_template_9" model="product.template" context="{'create_product_product': False}">
+    <record id="product_template_9" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">[Example product] Harry Potter: The Marauder's Map Puzzle</field>
         <field name="description_ecommerce"><![CDATA[A 1 000 piece jigsaw featuring the Marauders Map.
 <br />

--- a/toy_store/data/product_template_attribute_line.xml
+++ b/toy_store/data/product_template_attribute_line.xml
@@ -1,121 +1,121 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-    <record id="product_template_attribute_line_11" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_11" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_10')])]"/>
         <field name="product_tmpl_id" ref="product_template_7"/>
         <field name="attribute_id" ref="product_attribute_2"/>
     </record>
-    <record id="product_template_attribute_line_12" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_12" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_20')])]"/>
         <field name="product_tmpl_id" ref="product_template_7"/>
         <field name="attribute_id" ref="product_attribute_3"/>
     </record>
-    <record id="product_template_attribute_line_16" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_16" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_39')])]"/>
         <field name="product_tmpl_id" ref="product_template_9"/>
         <field name="attribute_id" ref="product_attribute_2"/>
     </record>
-    <record id="product_template_attribute_line_18" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_18" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_1')])]"/>
         <field name="product_tmpl_id" ref="product_template_10"/>
         <field name="attribute_id" ref="product_attribute_2"/>
     </record>
-    <record id="product_template_attribute_line_2" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_2" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_12')])]"/>
         <field name="product_tmpl_id" ref="product_template_4"/>
         <field name="attribute_id" ref="product_attribute_2"/>
     </record>
-    <record id="product_template_attribute_line_20" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_20" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_1')])]"/>
         <field name="product_tmpl_id" ref="product_template_11"/>
         <field name="attribute_id" ref="product_attribute_2"/>
     </record>
-    <record id="product_template_attribute_line_22" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_22" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_3')])]"/>
         <field name="product_tmpl_id" ref="product_template_12"/>
         <field name="attribute_id" ref="product_attribute_2"/>
     </record>
-    <record id="product_template_attribute_line_26" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_26" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_46'), ref('product_attribute_value_50'), ref('product_attribute_value_47'), ref('product_attribute_value_51')])]"/>
         <field name="product_tmpl_id" ref="product_template_21"/>
         <field name="attribute_id" ref="product_attribute_4"/>
     </record>
-    <record id="product_template_attribute_line_27" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_27" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_24')])]"/>
         <field name="product_tmpl_id" ref="product_template_4"/>
         <field name="attribute_id" ref="product_attribute_3"/>
     </record>
-    <record id="product_template_attribute_line_28" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_28" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_27')])]"/>
         <field name="product_tmpl_id" ref="product_template_4"/>
         <field name="attribute_id" ref="product_attribute_3"/>
     </record>
-    <record id="product_template_attribute_line_34" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_34" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_24')])]"/>
         <field name="product_tmpl_id" ref="product_template_5"/>
         <field name="attribute_id" ref="product_attribute_3"/>
     </record>
-    <record id="product_template_attribute_line_36" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_36" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_27')])]"/>
         <field name="product_tmpl_id" ref="product_template_5"/>
         <field name="attribute_id" ref="product_attribute_3"/>
     </record>
-    <record id="product_template_attribute_line_37" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_37" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_54')])]"/>
         <field name="product_tmpl_id" ref="product_template_5"/>
         <field name="attribute_id" ref="product_attribute_3"/>
     </record>
-    <record id="product_template_attribute_line_38" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_38" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_55')])]"/>
         <field name="product_tmpl_id" ref="product_template_5"/>
         <field name="attribute_id" ref="product_attribute_3"/>
     </record>
-    <record id="product_template_attribute_line_39" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_39" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_24')])]"/>
         <field name="product_tmpl_id" ref="product_template_6"/>
         <field name="attribute_id" ref="product_attribute_3"/>
     </record>
-    <record id="product_template_attribute_line_40" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_40" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_27')])]"/>
         <field name="product_tmpl_id" ref="product_template_6"/>
         <field name="attribute_id" ref="product_attribute_3"/>
     </record>
-    <record id="product_template_attribute_line_41" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_41" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_54')])]"/>
         <field name="product_tmpl_id" ref="product_template_6"/>
         <field name="attribute_id" ref="product_attribute_3"/>
     </record>
-    <record id="product_template_attribute_line_42" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_42" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_55')])]"/>
         <field name="product_tmpl_id" ref="product_template_6"/>
         <field name="attribute_id" ref="product_attribute_3"/>
     </record>
-    <record id="product_template_attribute_line_43" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_43" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_24')])]"/>
         <field name="product_tmpl_id" ref="product_template_7"/>
         <field name="attribute_id" ref="product_attribute_3"/>
     </record>
-    <record id="product_template_attribute_line_44" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_44" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_27')])]"/>
         <field name="product_tmpl_id" ref="product_template_7"/>
         <field name="attribute_id" ref="product_attribute_3"/>
     </record>
-    <record id="product_template_attribute_line_5" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_5" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_12')])]"/>
         <field name="product_tmpl_id" ref="product_template_5"/>
         <field name="attribute_id" ref="product_attribute_2"/>
     </record>
-    <record id="product_template_attribute_line_51" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_51" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_5')])]"/>
         <field name="product_tmpl_id" ref="product_template_26"/>
         <field name="attribute_id" ref="product_attribute_2"/>
     </record>
-    <record id="product_template_attribute_line_8" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_8" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_10')])]"/>
         <field name="product_tmpl_id" ref="product_template_6"/>
         <field name="attribute_id" ref="product_attribute_2"/>
     </record>
-    <record id="product_template_attribute_line_9" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_9" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_20')])]"/>
         <field name="product_tmpl_id" ref="product_template_6"/>
         <field name="attribute_id" ref="product_attribute_3"/>

--- a/toy_store/demo/product_template_attribute_line.xml
+++ b/toy_store/demo/product_template_attribute_line.xml
@@ -1,51 +1,51 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-    <record id="product_template_attribute_line_1" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_1" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_30')])]"/>
         <field name="product_tmpl_id" ref="product_template_4"/>
         <field name="attribute_id" ref="product_attribute_1"/>
     </record>
-    <record id="product_template_attribute_line_10" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_10" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_36')])]"/>
         <field name="product_tmpl_id" ref="product_template_7"/>
         <field name="attribute_id" ref="product_attribute_1"/>
     </record>
-    <record id="product_template_attribute_line_15" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_15" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_37')])]"/>
         <field name="product_tmpl_id" ref="product_template_9"/>
         <field name="attribute_id" ref="product_attribute_1"/>
     </record>
-    <record id="product_template_attribute_line_17" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_17" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_42')])]"/>
         <field name="product_tmpl_id" ref="product_template_10"/>
         <field name="attribute_id" ref="product_attribute_1"/>
     </record>
-    <record id="product_template_attribute_line_19" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_19" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_43')])]"/>
         <field name="product_tmpl_id" ref="product_template_11"/>
         <field name="attribute_id" ref="product_attribute_1"/>
     </record>
-    <record id="product_template_attribute_line_21" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_21" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_44')])]"/>
         <field name="product_tmpl_id" ref="product_template_12"/>
         <field name="attribute_id" ref="product_attribute_1"/>
     </record>
-    <record id="product_template_attribute_line_23" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_23" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_45')])]"/>
         <field name="product_tmpl_id" ref="product_template_18"/>
         <field name="attribute_id" ref="product_attribute_1"/>
     </record>
-    <record id="product_template_attribute_line_4" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_4" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_30')])]"/>
         <field name="product_tmpl_id" ref="product_template_5"/>
         <field name="attribute_id" ref="product_attribute_1"/>
     </record>
-    <record id="product_template_attribute_line_50" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_50" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_66')])]"/>
         <field name="product_tmpl_id" ref="product_template_26"/>
         <field name="attribute_id" ref="product_attribute_1"/>
     </record>
-    <record id="product_template_attribute_line_7" model="product.template.attribute.line" context="{'create_product_product': False}">
+    <record id="product_template_attribute_line_7" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_32')])]"/>
         <field name="product_tmpl_id" ref="product_template_6"/>
         <field name="attribute_id" ref="product_attribute_1"/>

--- a/veterinary_clinic/data/product_template.xml
+++ b/veterinary_clinic/data/product_template.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-  <record id="product_template_2" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_2" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="name">Antibiotics</field>
     <field name="image_1920" type="base64" file="veterinary_clinic/static/src/binary/product_template/2-image_1920"/>
     <field name="categ_id" ref="product_category_4"/>
@@ -11,7 +11,7 @@
     <field name="service_type">manual</field>
     <field name="invoice_policy">order</field>
   </record>
-  <record id="product_template_5" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_5" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="name">Antifugal</field>
     <field name="image_1920" type="base64" file="veterinary_clinic/static/src/binary/product_template/5-image_1920"/>
     <field name="categ_id" ref="product_category_4"/>
@@ -22,7 +22,7 @@
     <field name="service_type">manual</field>
     <field name="invoice_policy">order</field>
   </record>
-  <record id="product_template_4" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_4" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="name">Antiparasitic</field>
     <field name="image_1920" type="base64" file="veterinary_clinic/static/src/binary/product_template/4-image_1920"/>
     <field name="categ_id" ref="product_category_4"/>
@@ -33,7 +33,7 @@
     <field name="service_type">manual</field>
     <field name="invoice_policy">order</field>
   </record>
-  <record id="product_template_7" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_7" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="name">Antiviral for Dogs</field>
     <field name="image_1920" type="base64" file="veterinary_clinic/static/src/binary/product_template/7-image_1920"/>
     <field name="categ_id" ref="product_category_4"/>
@@ -44,7 +44,7 @@
     <field name="service_type">manual</field>
     <field name="invoice_policy">order</field>
   </record>
-  <record id="product_template_3" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_3" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="name">Surgical Intervention</field>
     <field name="image_1920" type="base64" file="veterinary_clinic/static/src/binary/product_template/3-image_1920"/>
     <field name="type">service</field>
@@ -57,7 +57,7 @@
     <field name="invoice_policy">order</field>
     <field name="project_id" ref="project_project_1"/>
   </record>
-  <record id="product_template_6" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_6" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="name">Vaccination</field>
     <field name="image_1920" type="base64" file="veterinary_clinic/static/src/binary/product_template/6-image_1920"/>
     <field name="categ_id" ref="product_category_4"/>

--- a/veterinary_clinic/data/product_template_attribute_line.xml
+++ b/veterinary_clinic/data/product_template_attribute_line.xml
@@ -1,36 +1,36 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-  <record id="product_template_attribute_line_3" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_3" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_3"/>
     <field name="attribute_id" ref="product_attribute_9"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_1'), ref('product_attribute_value_2'), ref('product_attribute_value_3'), ref('product_attribute_value_4')])]"/>
   </record>
-  <record id="product_template_attribute_line_2" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_2" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_6"/>
     <field name="attribute_id" ref="product_attribute_10"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_5'), ref('product_attribute_value_6'), ref('product_attribute_value_7'), ref('product_attribute_value_8')])]"/>
   </record>
-  <record id="product_template_attribute_line_7" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_7" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_5"/>
     <field name="attribute_id" ref="product_attribute_11"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_9')])]"/>
   </record>
-  <record id="product_template_attribute_line_8" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_8" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_2"/>
     <field name="attribute_id" ref="product_attribute_11"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_9')])]"/>
   </record>
-  <record id="product_template_attribute_line_9" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_9" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_4"/>
     <field name="attribute_id" ref="product_attribute_11"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_9')])]"/>
   </record>
-  <record id="product_template_attribute_line_10" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_10" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_7"/>
     <field name="attribute_id" ref="product_attribute_11"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_9')])]"/>
   </record>
-  <record id="product_template_attribute_line_11" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_11" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_6"/>
     <field name="attribute_id" ref="product_attribute_11"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_9')])]"/>

--- a/wine_merchant/data/product_template.xml
+++ b/wine_merchant/data/product_template.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-  <record id="product_template_14" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_14" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="image_1920" type="base64" file="wine_merchant/static/src/binary/product_template/14-image_1920"/>
     <field name="name">Corskcrew</field>
     <field name="list_price">50.0</field>
@@ -14,7 +14,7 @@
     <field name="website_sequence">10065</field>
     <field name="public_categ_ids" eval="[(6, 0, [ref('product_public_category_13')])]"/>
   </record>
-  <record id="event_product.product_product_event_product_template" model="product.template" context="{'create_product_product': False}" forcecreate="1">
+  <record id="event_product.product_product_event_product_template" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}" forcecreate="1">
     <field name="name">Event Registration</field>
     <field name="type">service</field>
     <field name="service_tracking">event</field>
@@ -28,7 +28,7 @@
     <field name="invoice_policy">order</field>
     <field name="website_sequence">10020</field>
   </record>
-  <record id="product_template_8" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_8" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="name">Gift Card</field>
     <field name="type">service</field>
     <field name="sale_ok" eval="False"/>
@@ -40,7 +40,7 @@
     <field name="invoice_policy">order</field>
     <field name="website_sequence">10035</field>
   </record>
-  <record id="product_template_10" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_10" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="image_1920" type="base64" file="wine_merchant/static/src/binary/product_template/10-image_1920"/>
     <field name="name">Golden Dragon - Legendary Vineyards - 2023</field>
     <field name="list_price">18.0</field>
@@ -55,7 +55,7 @@
     <field name="website_sequence">10045</field>
     <field name="public_categ_ids" eval="[(6, 0, [ref('product_public_category_10')])]"/>
   </record>
-  <record id="product_template_13" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_13" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="image_1920" type="base64" file="wine_merchant/static/src/binary/product_template/13-image_1920"/>
     <field name="name">Juniper's Enigma - 2024</field>
     <field name="list_price">18.0</field>
@@ -69,7 +69,7 @@
     <field name="website_sequence">10060</field>
     <field name="public_categ_ids" eval="[(6, 0, [ref('product_public_category_6')])]"/>
   </record>
-  <record id="product_template_12" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_12" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="name">Lost Secrets Cuvée - Mystery Château - 2024</field>
     <field name="image_1920" type="base64" file="wine_merchant/static/src/binary/product_template/12-image_1920"/>
     <field name="list_price">22.0</field>
@@ -84,7 +84,7 @@
     <field name="website_sequence">10055</field>
     <field name="public_categ_ids" eval="[(6, 0, [ref('product_public_category_9'), ref('product_public_category_10'), ref('product_public_category_11')])]"/>
   </record>
-  <record id="product_template_9" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_9" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="image_1920" type="base64" file="wine_merchant/static/src/binary/product_template/9-image_1920"/>
     <field name="name">Starlight - Celestial Vineyard - 2023</field>
     <field name="list_price">20.0</field>
@@ -99,7 +99,7 @@
     <field name="website_sequence">10040</field>
     <field name="public_categ_ids" eval="[(6, 0, [ref('product_public_category_9')])]"/>
   </record>
-  <record id="product_template_11" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_11" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="image_1920" type="base64" file="wine_merchant/static/src/binary/product_template/11-image_1920"/>
     <field name="name">Whispering Pines - Enchanted Vines - 2024</field>
     <field name="list_price">15.0</field>
@@ -114,7 +114,7 @@
     <field name="website_sequence">10050</field>
     <field name="public_categ_ids" eval="[(6, 0, [ref('product_public_category_10')])]"/>
   </record>
-  <record id="product_template_15" model="product.template" context="{'create_product_product': False}">
+  <record id="product_template_15" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="name">[Delivery_008] On site Picking</field>
     <field name="type">service</field>
     <field name="sale_ok" eval="False"/>

--- a/wine_merchant/data/product_template_attribute_line.xml
+++ b/wine_merchant/data/product_template_attribute_line.xml
@@ -1,131 +1,131 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-  <record id="product_template_attribute_line_1" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_1" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_9"/>
     <field name="attribute_id" ref="website_sale.product_attribute_brand"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_1')])]"/>
   </record>
-  <record id="product_template_attribute_line_7" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_7" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_10"/>
     <field name="attribute_id" ref="website_sale.product_attribute_brand"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_1')])]"/>
   </record>
-  <record id="product_template_attribute_line_13" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_13" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_11"/>
     <field name="attribute_id" ref="website_sale.product_attribute_brand"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_1')])]"/>
   </record>
-  <record id="product_template_attribute_line_19" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_19" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_12"/>
     <field name="attribute_id" ref="website_sale.product_attribute_brand"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_1')])]"/>
   </record>
-  <record id="product_template_attribute_line_25" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_25" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_13"/>
     <field name="attribute_id" ref="website_sale.product_attribute_brand"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_2')])]"/>
   </record>
-  <record id="product_template_attribute_line_6" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_6" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_9"/>
     <field name="attribute_id" ref="product_barcodelookup.product_attribute_lookup_5"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_19')])]"/>
   </record>
-  <record id="product_template_attribute_line_12" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_12" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_10"/>
     <field name="attribute_id" ref="product_barcodelookup.product_attribute_lookup_5"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_24')])]"/>
   </record>
-  <record id="product_template_attribute_line_18" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_18" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_11"/>
     <field name="attribute_id" ref="product_barcodelookup.product_attribute_lookup_5"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_24')])]"/>
   </record>
-  <record id="product_template_attribute_line_24" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_24" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_12"/>
     <field name="attribute_id" ref="product_barcodelookup.product_attribute_lookup_5"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_19'), ref('product_attribute_value_21'), ref('product_attribute_value_24')])]"/>
   </record>
-  <record id="product_template_attribute_line_2" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_2" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_9"/>
     <field name="attribute_id" ref="product_barcodelookup.product_attribute_lookup_1"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_5')])]"/>
   </record>
-  <record id="product_template_attribute_line_8" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_8" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_10"/>
     <field name="attribute_id" ref="product_barcodelookup.product_attribute_lookup_1"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_6')])]"/>
   </record>
-  <record id="product_template_attribute_line_14" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_14" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_11"/>
     <field name="attribute_id" ref="product_barcodelookup.product_attribute_lookup_1"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_6')])]"/>
   </record>
-  <record id="product_template_attribute_line_20" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_20" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_12"/>
     <field name="attribute_id" ref="product_barcodelookup.product_attribute_lookup_1"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_6')])]"/>
   </record>
-  <record id="product_template_attribute_line_3" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_3" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_9"/>
     <field name="attribute_id" ref="product_barcodelookup.product_attribute_lookup_2"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_9')])]"/>
   </record>
-  <record id="product_template_attribute_line_9" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_9" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_10"/>
     <field name="attribute_id" ref="product_barcodelookup.product_attribute_lookup_2"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_9')])]"/>
   </record>
-  <record id="product_template_attribute_line_15" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_15" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_11"/>
     <field name="attribute_id" ref="product_barcodelookup.product_attribute_lookup_2"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_10')])]"/>
   </record>
-  <record id="product_template_attribute_line_21" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_21" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_12"/>
     <field name="attribute_id" ref="product_barcodelookup.product_attribute_lookup_2"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_10')])]"/>
   </record>
-  <record id="product_template_attribute_line_27" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_27" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_13"/>
     <field name="attribute_id" ref="product_barcodelookup.product_attribute_lookup_2"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_10')])]"/>
   </record>
-  <record id="product_template_attribute_line_4" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_4" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_9"/>
     <field name="attribute_id" ref="product_barcodelookup.product_attribute_lookup_3"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_13')])]"/>
   </record>
-  <record id="product_template_attribute_line_10" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_10" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_10"/>
     <field name="attribute_id" ref="product_barcodelookup.product_attribute_lookup_3"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_14')])]"/>
   </record>
-  <record id="product_template_attribute_line_16" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_16" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_11"/>
     <field name="attribute_id" ref="product_barcodelookup.product_attribute_lookup_3"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_14')])]"/>
   </record>
-  <record id="product_template_attribute_line_22" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_22" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_12"/>
     <field name="attribute_id" ref="product_barcodelookup.product_attribute_lookup_3"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_14')])]"/>
   </record>
-  <record id="product_template_attribute_line_5" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_5" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_9"/>
     <field name="attribute_id" ref="product_barcodelookup.product_attribute_lookup_4"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_16')])]"/>
   </record>
-  <record id="product_template_attribute_line_11" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_11" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_10"/>
     <field name="attribute_id" ref="product_barcodelookup.product_attribute_lookup_4"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_17')])]"/>
   </record>
-  <record id="product_template_attribute_line_17" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_17" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_11"/>
     <field name="attribute_id" ref="product_barcodelookup.product_attribute_lookup_4"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_18')])]"/>
   </record>
-  <record id="product_template_attribute_line_23" model="product.template.attribute.line" context="{'create_product_product': False}">
+  <record id="product_template_attribute_line_23" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_12"/>
     <field name="attribute_id" ref="product_barcodelookup.product_attribute_lookup_4"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_23')])]"/>

--- a/yoga_pilates/data/product_product.xml
+++ b/yoga_pilates/data/product_product.xml
@@ -122,10 +122,10 @@
     <field name="website_sequence">10085</field>
     <field name="standard_price">10.0</field>
   </record>
-  <record id="loyalty.gift_card_product_50_product_template" model="product.template" context="{'create_product_product': False}" forcecreate="0">
+  <record id="loyalty.gift_card_product_50_product_template" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}" forcecreate="0">
     <field name="active" eval="False"/>
   </record>
-  <record id="loyalty.ewallet_product_50_product_template" model="product.template" context="{'create_product_product': False}" forcecreate="0">
+  <record id="loyalty.ewallet_product_50_product_template" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}" forcecreate="0">
     <field name="active" eval="False"/>
   </record>
   <record id="appointment_account_payment.default_booking_product" model="product.product" forcecreate="0">


### PR DESCRIPTION
This commit https://github.com/odoo/odoo/pull/254323 changed the way product( template)s are created, which now decouples the logic into two context attributes instead of one. This commit fixes this by adding the second one.