### PR TITLE
[IMP] .*: customer satisfaction survey & automation

### DIFF
--- a/booking_engine/__manifest__.py
+++ b/booking_engine/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Booking Engine',
-    'version': '1.10',
+    'version': '1.11',
     'category': 'Hidden/Tools',
     'author': 'Odoo S.A.',
     'depends': [
@@ -9,6 +9,7 @@
         'knowledge',
         'planning_hr_skills',
         'sale_project',
+        'survey',
         'web_gantt',
         'web_studio',
         'website_appointment',
@@ -38,6 +39,9 @@
         'data/product_category.xml',
         'data/product_attribute.xml',
         'data/product_attribute_value.xml',
+        'data/survey_survey.xml',
+        'data/survey_question.xml',
+        'data/survey_question_answer.xml',
     ],
     'demo': [
         'demo/website_menu.xml',

--- a/booking_engine/data/base_automation.xml
+++ b/booking_engine/data/base_automation.xml
@@ -159,4 +159,11 @@
         <field name="trigger">on_unlink</field>
         <field name="action_server_ids" eval="[(6, 0, [ref('booking_engine.server_action_update_availability_for_product_template_delete')])]"/>
     </record>
+    <record id="automation_to_archive_existing_surveys" model="base.automation">
+        <field name="name">Archive previous survey with is customer satisfaction survey</field>
+        <field name="model_id" ref="survey.model_survey_survey"/>
+        <field name="trigger">on_create_or_write</field>
+        <field name="trigger_field_ids" eval="[(6, 0, [ref('x_is_customer_satisfaction_survey_field')])]"/>
+        <field name="action_server_ids" eval="[(6, 0, [ref('server_action_to_archive_surveys')])]"/>
+    </record>
 </odoo>

--- a/booking_engine/data/ir_actions_server.xml
+++ b/booking_engine/data/ir_actions_server.xml
@@ -527,4 +527,49 @@ if (new_offers := records.filtered(lambda r: r.x_is_a_room_offer and r.active) -
 env.ref('booking_engine.server_action_update_availabilities').run()
 ]]></field>
     </record>
+    <record id="server_action_to_archive_surveys" model="ir.actions.server">
+        <field name="name">Archive previous survey with is customer satisfaction survey</field>
+        <field name="code"><![CDATA[
+if record.x_is_customer_satisfaction_survey:
+    other_surveys = env['survey.survey'].search([('id', '!=', record.id), ('x_is_customer_satisfaction_survey', '=', True), ('active', '=', True)])
+    other_surveys.write({'active': False, 'x_is_customer_satisfaction_survey': False})
+]]></field>
+        <field name="model_id" ref="survey.model_survey_survey"/>
+        <field name="state">code</field>
+    </record>
+    <record id="ir_actions_server_send_survey" model="ir.actions.server">
+        <field name="name">Booking Engine: Send Customer Satisfaction Survey</field>
+        <field name="model_id" ref="sale.model_sale_order"/>
+        <field name="state">code</field>
+        <field name="usage">ir_cron</field>
+        <field name="code"><![CDATA[
+survey = env['survey.survey'].search([
+    ('x_is_customer_satisfaction_survey', '=', True),
+], limit=1)
+
+if survey:
+    delay_days = survey.x_email_delay or 0
+    today = datetime.datetime.today()
+
+    # Only include orders whose rental_return_date + x_email_delay has passed
+    orders = env['sale.order'].search([
+        ('state', '=', 'sale'),
+        ('x_order_involves_room', '=', True),
+        ('x_is_survey_sent', '=', False),
+        ('rental_return_date', '!=', False),
+        ('partner_id', '!=', False),
+    ])
+
+    orders_to_survey = orders.filtered(lambda o: today >= o.rental_return_date + datetime.timedelta(days=delay_days))
+    if orders_to_survey:
+        vals_list = [{
+            'survey_id': survey.id,
+            'partner_ids': [(6, 0, [order.partner_id.id])],
+            'send_email': True,
+        } for order in orders_to_survey]
+
+        invites = env['survey.invite'].create(vals_list)
+        invites.action_invite()
+        orders_to_survey.write({'x_is_survey_sent': True})]]></field>
+    </record>
 </odoo>

--- a/booking_engine/data/ir_cron.xml
+++ b/booking_engine/data/ir_cron.xml
@@ -19,4 +19,13 @@
         <field name="ir_actions_server_id" ref="server_action_create_500_days_availability"/>
         <field name="nextcall" model="ir.cron" eval="(datetime.now(pytz.timezone(obj().env.user.tz or 'UTC')).replace(hour=1, minute=0, second=0) + timedelta(days=1)).astimezone(pytz.utc).strftime('%Y-%m-%d %H:%M:%S')"/>
     </record>
+    <record id="ir_cron_send_survey" model="ir.cron">
+        <field name="name">Booking Engine: Send Customer Satisfaction Survey</field>
+        <field name="model_id" ref="sale.model_sale_order"/>
+        <field name="interval_number">1</field>
+        <field name="interval_type">days</field>
+        <field name="nextcall" eval="datetime.today().date()+relativedelta(days=1)"/>
+        <field name="state">code</field>
+        <field name="ir_actions_server_id" ref="ir_actions_server_send_survey"/>
+    </record>
 </odoo>

--- a/booking_engine/data/ir_default.xml
+++ b/booking_engine/data/ir_default.xml
@@ -16,4 +16,12 @@
     <field name="field_id" ref="x_booked_field_x_availability"/>
     <field name="json_value">"0"</field>
   </record>
+  <record id="default_x_is_customer_satisfaction_survey" model="ir.default">
+      <field name="field_id" ref="x_is_customer_satisfaction_survey_field"/>
+      <field name="json_value">true</field>
+  </record>
+  <record id="default_x_email_delay" model="ir.default">
+      <field name="field_id" ref="x_email_delay_field"/>
+      <field name="json_value">2</field>
+  </record>
 </odoo>

--- a/booking_engine/data/ir_model_fields.xml
+++ b/booking_engine/data/ir_model_fields.xml
@@ -769,4 +769,24 @@ for r in self:
     <field name="relation">x_availability</field>
     <field name="readonly" eval="True"/>
   </record>
+  <record id="x_is_customer_satisfaction_survey_field" model="ir.model.fields">
+      <field name="name">x_is_customer_satisfaction_survey</field>
+      <field name="field_description">Is Customer Satisfaction Survey</field>
+      <field name="model_id" ref="survey.model_survey_survey"/>
+      <field name="ttype">boolean</field>
+      <field name="help"><![CDATA[When set, the survey email will be sent automatically to rental order customers.
+Note that saving a new survey with this set will archive previous survey with this setting to become the default satisfaction survey.]]></field>
+  </record>
+  <record id="x_email_delay_field" model="ir.model.fields">
+      <field name="name">x_email_delay</field>
+      <field name="field_description">Email Delay</field>
+      <field name="model_id" ref="survey.model_survey_survey"/>
+      <field name="ttype">integer</field>
+  </record>
+  <record id="x_is_survey_sent_field" model="ir.model.fields">
+      <field name="name">x_is_survey_sent</field>
+      <field name="field_description">Is Survey Sent</field>
+      <field name="model_id" ref="sale.model_sale_order"/>
+      <field name="ttype">boolean</field>
+  </record>
 </odoo>

--- a/booking_engine/data/ir_ui_view.xml
+++ b/booking_engine/data/ir_ui_view.xml
@@ -989,4 +989,21 @@
         (0, 0, {'view_mode': 'gantt', 'view_id': ref('view_x_availability_occupancy_gantt')}),
     ]"/>
   </record>
+  <record id="survey_survey_view_form" model="ir.ui.view">
+      <field name="name">survey.survey.view.form.inherit.booking.engine</field>
+      <field name="model">survey.survey</field>
+      <field name="inherit_id" ref="survey.survey_survey_view_form"/>
+      <field name="active" eval="True"/>
+      <field name="type">form</field>
+      <field name="arch" type="xml">
+          <xpath expr="//page[@name='options']//group[@name='participants']/div" position="after">
+              <field name="x_is_customer_satisfaction_survey"/>
+              <label for="x_email_delay" invisible="not x_is_customer_satisfaction_survey"/>
+              <div name="x_email_delay_display" invisible="not x_is_customer_satisfaction_survey">
+                  <field name="x_email_delay" class="oe_inline"/>
+                  <span>Days</span>
+              </div>
+          </xpath>
+      </field>
+  </record>
 </odoo>

--- a/booking_engine/data/survey_question.xml
+++ b/booking_engine/data/survey_question.xml
@@ -1,0 +1,36 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<odoo noupdate="1" auto_sequence="True">
+    <record id="survey_question_1" model="survey.question">
+        <field name="title">How likely are you to recommend us to a friend?</field>
+        <field name="question_type">scale</field>
+        <field name="survey_id" ref="survey_survey_1"/>
+        <field name="scale_min_label">Not at all</field>
+        <field name="scale_max_label">Definitely</field>
+        <field name="constr_mandatory" eval="True"/>
+    </record>
+    <record id="survey_question_2" model="survey.question">
+        <field name="title">Please rate the basics:</field>
+        <field name="question_type">matrix</field>
+        <field name="survey_id" ref="survey_survey_1"/>
+        <field name="constr_mandatory" eval="True"/>
+    </record>
+    <record id="survey_question_3" model="survey.question">
+        <field name="title">Did you experience any issues during your stay?</field>
+        <field name="question_type">multiple_choice</field>
+        <field name="survey_id" ref="survey_survey_1"/>
+        <field name="comments_allowed" eval="True"/>
+        <field name="comment_count_as_answer" eval="True"/>
+    </record>
+    <record id="survey_question_4" model="survey.question">
+        <field name="title">Name one thing we could add to make your next stay better.</field>
+        <field name="question_type">char_box</field>
+        <field name="question_placeholder">ex. Gym</field>
+        <field name="survey_id" ref="survey_survey_1"/>
+    </record>
+    <record id="survey_question_5" model="survey.question">
+        <field name="title">Would you like a manager to contact you about your stay?</field>
+        <field name="question_type">simple_choice</field>
+        <field name="survey_id" ref="survey_survey_1"/>
+        <field name="constr_mandatory" eval="True"/>
+    </record>
+</odoo>

--- a/booking_engine/data/survey_question_answer.xml
+++ b/booking_engine/data/survey_question_answer.xml
@@ -1,0 +1,47 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<odoo noupdate="1" auto_sequence="1">
+    <record id="survey_question_answer_1" model="survey.question.answer">
+        <field name="question_id" ref="survey_question_2"/>
+        <field name="value">☹️</field>
+    </record>
+    <record id="survey_question_answer_2" model="survey.question.answer">
+        <field name="question_id" ref="survey_question_2"/>
+        <field name="value">😐</field>
+    </record>
+    <record id="survey_question_answer_3" model="survey.question.answer">
+        <field name="question_id" ref="survey_question_2"/>
+        <field name="value">🙂</field>
+    </record>
+    <record id="survey_question_answer_7" model="survey.question.answer">
+        <field name="question_id" ref="survey_question_3"/>
+        <field name="value">Wi-Fi / Connectivity</field>
+    </record>
+    <record id="survey_question_answer_8" model="survey.question.answer">
+        <field name="question_id" ref="survey_question_3"/>
+        <field name="value">Noise</field>
+    </record>
+    <record id="survey_question_answer_9" model="survey.question.answer">
+        <field name="question_id" ref="survey_question_3"/>
+        <field name="value">Check-in Wait Time</field>
+    </record>
+    <record id="survey_question_answer_10" model="survey.question.answer">
+        <field name="question_id" ref="survey_question_5"/>
+        <field name="value">Yes</field>
+    </record>
+    <record id="survey_question_answer_11" model="survey.question.answer">
+        <field name="question_id" ref="survey_question_5"/>
+        <field name="value">No</field>
+    </record>
+    <record id="survey_question_answer_4" model="survey.question.answer">
+        <field name="matrix_question_id" ref="survey_question_2"/>
+        <field name="value">Cleanliness</field>
+    </record>
+    <record id="survey_question_answer_5" model="survey.question.answer">
+        <field name="matrix_question_id" ref="survey_question_2"/>
+        <field name="value">Staff Friendliness</field>
+    </record>
+    <record id="survey_question_answer_6" model="survey.question.answer">
+        <field name="matrix_question_id" ref="survey_question_2"/>
+        <field name="value">Bed Comfort</field>
+    </record>
+</odoo>

--- a/booking_engine/data/survey_survey.xml
+++ b/booking_engine/data/survey_survey.xml
@@ -1,0 +1,10 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
+    <record id="survey_survey_1" model="survey.survey">
+        <field name="survey_type">survey</field>
+        <field name="title">Customer Satisfaction</field>
+        <field name="questions_layout">one_page</field>
+        <field name="scoring_type">no_scoring</field>
+        <field name="user_id" ref="base.user_admin"/>
+    </record>
+</odoo>

--- a/campsite/__manifest__.py
+++ b/campsite/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Campsite',
-    'version': '1.4',
+    'version': '1.5',
     'category': 'Hospitality',
     'author': 'Odoo S.A.',
     'depends': [

--- a/campsite/data/knowledge_article.xml
+++ b/campsite/data/knowledge_article.xml
@@ -236,12 +236,42 @@
             <br/>
         </div><p>
             <em>Don't forget to thank your guests with a warm goodbye!</em>
-        </p><p>
+        </p>
+        <h4>Keep your guests satisfied</h4>
+        <ul>
+            <li>Open the Survey App to find the customer satisfaction survey.</li>
+            <li>In the Options tab, you can see it is made the customer satisfaction survey in the participants section.</li>
+        </ul>
+        <div
+            class="o_editor_banner user-select-none o-contenteditable-false lh-1 d-flex align-items-center alert alert-success pb-0 pt-3"
+            data-oe-role="status">
+            <i class="o_editor_banner_icon mb-3 fst-normal" data-oe-aria-label="Banner Success">✅</i>
+            <div class="o_editor_banner_content o-contenteditable-true w-100 px-3">
+                <p>
+                    Any time you create a new survey and save it with the setting "is customer satisfaction survey", previous ones
+                    will be archived so that it becomes your new default survey.
+                </p>
+            </div>
+        </div>
+        <ul>
+            <li>Configure the email delay as you wish the email to be sent after the guest checkout.</li>
+            <li>An automation is setup for an email to be sent automatically for you.</li>
+            <li>You can find the participants and answers from the smart buttons of the survey.</li>
+        </ul>
+        <div class="o_editor_banner user-select-none o-contenteditable-false lh-1 d-flex align-items-center alert alert-info pb-0 pt-3" data-oe-role="status">
+            <i class="o_editor_banner_icon mb-3 fst-normal" data-oe-aria-label="Banner Info">💡</i>
+            <div class="o_editor_banner_content o-contenteditable-true w-100 px-3">
+                <p>To ensure your guests no longer receive the satisfaction survey, you can easily archive it at any time.</p>
+            </div>
+        </div>
+        <p><em>Don't forget to check the results from time to time to make your guests happier!</em></p>
+        <p>
             <a class="btn btn-secondary" href="https://www.odoo.com/documentation/latest/applications/finance/accounting/taxes.html">🎓
                 Taxes</a>
             <a href="https://www.odoo.com/documentation/latest/applications/finance/accounting.html" class="btn btn-secondary">🎓
                 Invoicing</a>
             <a class="btn btn-fill-secondary" href="https://www.odoo.com/documentation/latest/applications/sales/point_of_sale.html">🎓 POS</a>
+            <a href="https://www.odoo.com/documentation/latest/applications/marketing/surveys.html" class="btn btn-secondary">🎓Surveys</a>
         </p><p><br/></p>
         <h3>🚀 Strategic Oversight</h3>
         <hr/>

--- a/campsite/static/description/index.html
+++ b/campsite/static/description/index.html
@@ -29,4 +29,7 @@
     <li>
         House keeping module provides a dedicated board and tasks.
     </li>
+    <li>
+        <strong>Satisfaction Survey:</strong> Automatically send emails to your guests few days after their stay to measure their satisfaction.
+    </li>
 </ul>

--- a/guest_house/__manifest__.py
+++ b/guest_house/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Guest House',
-    'version': '1.5',
+    'version': '1.6',
     'category': 'Hospitality',
     'author': 'Odoo S.A.',
     'depends': [

--- a/guest_house/data/knowledge_article.xml
+++ b/guest_house/data/knowledge_article.xml
@@ -281,12 +281,41 @@
         <p>
             <em>Don't forget to thank your guests with a warm goodbye!</em>
         </p>
+        <h4>Keep your guests satisfied</h4>
+        <ul>
+            <li>Open the Survey App to find the customer satisfaction survey.</li>
+            <li>In the Options tab, you can see it is made the customer satisfaction survey in the participants section.</li>
+        </ul>
+        <div
+            class="o_editor_banner user-select-none o-contenteditable-false lh-1 d-flex align-items-center alert alert-success pb-0 pt-3"
+            data-oe-role="status">
+            <i class="o_editor_banner_icon mb-3 fst-normal" data-oe-aria-label="Banner Success">✅</i>
+            <div class="o_editor_banner_content o-contenteditable-true w-100 px-3">
+                <p>
+                    Any time you create a new survey and save it with the setting "is customer satisfaction survey", previous ones
+                    will be archived so that it becomes your new default survey.
+                </p>
+            </div>
+        </div>
+        <ul>
+            <li>Configure the email delay as you wish the email to be sent after the guest checkout.</li>
+            <li>An automation is setup for an email to be sent automatically for you.</li>
+            <li>You can find the participants and answers from the smart buttons of the survey.</li>
+        </ul>
+        <div class="o_editor_banner user-select-none o-contenteditable-false lh-1 d-flex align-items-center alert alert-info pb-0 pt-3" data-oe-role="status">
+            <i class="o_editor_banner_icon mb-3 fst-normal" data-oe-aria-label="Banner Info">💡</i>
+            <div class="o_editor_banner_content o-contenteditable-true w-100 px-3">
+                <p>To ensure your guests no longer receive the satisfaction survey, you can easily archive it at any time.</p>
+            </div>
+        </div>
+        <p><em>Don't forget to check the results from time to time to make your guests happier!</em></p>
         <p>
             <a class="btn btn-secondary"
                 href="https://www.odoo.com/documentation/latest/applications/finance/accounting/taxes.html">🎓
             Taxes</a> <a
                 href="https://www.odoo.com/documentation/latest/applications/finance/accounting.html"
                 class="btn btn-secondary">🎓 Invoicing</a>
+            <a href="https://www.odoo.com/documentation/latest/applications/marketing/surveys.html" class="btn btn-secondary">🎓Surveys</a>
         </p>
         <p><br/></p>
         <h3>🚀 Strategic Oversight</h3>

--- a/guest_house/static/description/index.html
+++ b/guest_house/static/description/index.html
@@ -29,4 +29,7 @@
     <li>
         House keeping module provides a dedicated board and tasks.
     </li>
+    <li>
+        <strong>Satisfaction Survey:</strong> Automatically send emails to your guests few days after their stay to measure their satisfaction.
+    </li>
 </ul>

--- a/holiday_house/__manifest__.py
+++ b/holiday_house/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Holiday House',
-    'version': '1.4',
+    'version': '1.5',
     'category': 'Hospitality',
     'author': 'Odoo S.A.',
     'depends': [

--- a/holiday_house/data/knowledge_article.xml
+++ b/holiday_house/data/knowledge_article.xml
@@ -231,9 +231,38 @@ The Holiday House App relies on the Rental and Planning Apps binding, with a few
     <p>
         <em>Don't forget to thank your guests with a warm goodbye!</em>
     </p>
+    <h4>Keep your guests satisfied</h4>
+    <ul>
+        <li>Open the Survey App to find the customer satisfaction survey.</li>
+        <li>In the Options tab, you can see it is made the customer satisfaction survey in the participants section.</li>
+    </ul>
+    <div
+        class="o_editor_banner user-select-none o-contenteditable-false lh-1 d-flex align-items-center alert alert-success pb-0 pt-3"
+        data-oe-role="status">
+        <i class="o_editor_banner_icon mb-3 fst-normal" data-oe-aria-label="Banner Success">✅</i>
+        <div class="o_editor_banner_content o-contenteditable-true w-100 px-3">
+            <p>
+                Any time you create a new survey and save it with the setting "is customer satisfaction survey", previous ones
+                will be archived so that it becomes your new default survey.
+            </p>
+        </div>
+    </div>
+    <ul>
+        <li>Configure the email delay as you wish the email to be sent after the guest checkout.</li>
+        <li>An automation is setup for an email to be sent automatically for you.</li>
+        <li>You can find the participants and answers from the smart buttons of the survey.</li>
+    </ul>
+    <div class="o_editor_banner user-select-none o-contenteditable-false lh-1 d-flex align-items-center alert alert-info pb-0 pt-3" data-oe-role="status">
+        <i class="o_editor_banner_icon mb-3 fst-normal" data-oe-aria-label="Banner Info">💡</i>
+        <div class="o_editor_banner_content o-contenteditable-true w-100 px-3">
+            <p>To ensure your guests no longer receive the satisfaction survey, you can easily archive it at any time.</p>
+        </div>
+    </div>
+    <p><em>Don't forget to check the results from time to time to make your guests happier!</em></p>
     <p>
         <a href="https://www.odoo.com/documentation/latest/applications/finance/accounting/taxes.html" class="btn btn-secondary">🎓 Taxes</a>
         <a class="btn btn-secondary" href="https://www.odoo.com/documentation/latest/applications/finance/accounting.html">🎓 Invoicing</a>
+        <a href="https://www.odoo.com/documentation/latest/applications/marketing/surveys.html" class="btn btn-secondary">🎓Surveys</a>
     </p>
     <p><br/></p>
     <h3>🚀 Strategic Oversight</h3>

--- a/holiday_house/static/description/index.html
+++ b/holiday_house/static/description/index.html
@@ -29,4 +29,7 @@
     <li>
         House keeping module provides a dedicated board and tasks.
     </li>
+    <li>
+        <strong>Satisfaction Survey:</strong> Automatically send emails to your guests few days after their stay to measure their satisfaction.
+    </li>
 </ul>

--- a/hotel/__manifest__.py
+++ b/hotel/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Hotel',
-    'version': '1.5',
+    'version': '1.6',
     'category': 'Hospitality',
     'author': 'Odoo S.A.',
     'depends': [

--- a/hotel/data/knowledge_article.xml
+++ b/hotel/data/knowledge_article.xml
@@ -349,6 +349,34 @@
         <p>
             <em>Don't forget to thank your guests with a warm goodbye!</em>
         </p>
+        <h4>Keep your guests satisfied</h4>
+        <ul>
+            <li>Open the Survey App to find the customer satisfaction survey.</li>
+            <li>In the Options tab, you can see it is made the customer satisfaction survey in the participants section.</li>
+        </ul>
+        <div
+            class="o_editor_banner user-select-none o-contenteditable-false lh-1 d-flex align-items-center alert alert-success pb-0 pt-3"
+            data-oe-role="status">
+            <i class="o_editor_banner_icon mb-3 fst-normal" data-oe-aria-label="Banner Success">✅</i>
+            <div class="o_editor_banner_content o-contenteditable-true w-100 px-3">
+                <p>
+                    Any time you create a new survey and save it with the setting "is customer satisfaction survey", previous ones
+                    will be archived so that it becomes your new default survey.
+                </p>
+            </div>
+        </div>
+        <ul>
+            <li>Configure the email delay as you wish the email to be sent after the guest checkout.</li>
+            <li>An automation is setup for an email to be sent automatically for you.</li>
+            <li>You can find the participants and answers from the smart buttons of the survey.</li>
+        </ul>
+        <div class="o_editor_banner user-select-none o-contenteditable-false lh-1 d-flex align-items-center alert alert-info pb-0 pt-3" data-oe-role="status">
+            <i class="o_editor_banner_icon mb-3 fst-normal" data-oe-aria-label="Banner Info">💡</i>
+            <div class="o_editor_banner_content o-contenteditable-true w-100 px-3">
+                <p>To ensure your guests no longer receive the satisfaction survey, you can easily archive it at any time.</p>
+            </div>
+        </div>
+        <p><em>Don't forget to check the results from time to time to make your guests happier!</em></p>
         <p>
             <a
                 href="https://www.odoo.com/documentation/latest/applications/finance/accounting/taxes.html"
@@ -359,6 +387,7 @@
                 Invoicing</a>
             <a href="https://www.odoo.com/documentation/latest/applications/sales/point_of_sale.html"
                 class="btn btn-fill-secondary">🎓 POS</a>
+            <a href="https://www.odoo.com/documentation/latest/applications/marketing/surveys.html" class="btn btn-secondary">🎓Surveys</a>
         </p>
         <p><br/></p>
         <h3>🚀 Strategic Oversight</h3>

--- a/hotel/static/description/index.html
+++ b/hotel/static/description/index.html
@@ -65,6 +65,9 @@
     <li>
         House keeping module provides a dedicated board and tasks.
     </li>
+    <li>
+        <strong>Satisfaction Survey:</strong> Automatically send emails to your guests few days after their stay to measure their satisfaction.
+    </li>
 </ul>
 <h2>Pricing</h2>
 <p>


### PR DESCRIPTION
This PR introduces the survey dependency into the `booking_engine` module and implements customer satisfaction survey automation for accommodation industries (guest house, holiday house, hotel).

Main changes:
- Add `survey` as a dependency to the `booking_engine` module.
- Add a default Customer Satisfaction Survey (with questions) to module data.
- Add custom fields (`x_is_customer_satisfaction_survey`, `x_email_delay`).
- Add "Days" label next to Email Delay field for better UX.

- Implement automation to manage default satisfaction survey:
  - When a survey is saved with `x_is_customer_satisfaction_survey = True`, all other surveys with the same flag are automatically archived.
  - Ensures only one active satisfaction survey at a time.

- Implement scheduled action to send survey emails:
  - Triggered after `x_email_delay` days.
  - Applies only to confirmed sale orders involving stay offer products.
  - Sends one survey per order.
  - Uses active (non-archived) satisfaction survey.

- Update knowledge article for all accommodation industries.

Task: 5910788