### PR TITLE
[IMP] condominium: remove VAT dependency for condominium button visibility

### DIFF
--- a/condominium/data/ir_ui_view.xml
+++ b/condominium/data/ir_ui_view.xml
@@ -215,7 +215,7 @@
     <field name="arch" type="xml">
       <xpath expr="//sheet" position="before">
         <header>
-          <button string="Create Condominium" name="%(ir_action_create_condominium)d" type="action" invisible="not vat or ref_company_ids"/>
+          <button string="Create Condominium" name="%(ir_action_create_condominium)d" type="action" invisible="ref_company_ids or x_companies"/>
         </header>
       </xpath>
       <xpath expr="//button[@name='action_open_employees']" position="after">


### PR DESCRIPTION
`Before this commit`

The `Create Condominium` button in `res.partner` form view is visible based on the presence of a VAT number to identify a company.

`After this commit`

The button is now displayed only when both `ref_company_ids` and `x_companies` are empty.

`Purpose:`

VAT is a real business field, but here it's being used as a dummy value. instead of using a dummy VAT number, we want to change the logic to decide when to show the button properly.

TASK: 6064101