### PR TITLE
[FIX] booking_engine: fix product form view layout

### DIFF
--- a/booking_engine/data/ir_ui_view.xml
+++ b/booking_engine/data/ir_ui_view.xml
@@ -238,6 +238,9 @@
       <xpath expr="//label[@for='lst_price']" position="attributes">
         <attribute name="invisible">x_is_a_room_offer</attribute>
       </xpath>
+      <xpath expr="//div[@name='list_price_uom']" position="attributes">
+        <attribute name="invisible">x_is_a_room_offer</attribute>
+      </xpath>
     </field>
     <field name="inherit_id" ref="product.product_normal_form_view"/>
     <field name="mode">extension</field>


### PR DESCRIPTION
Previously, only the label of lst_price was targeted via XPath, which was insufficient and resulted in a broken or inconsistent layout.

This commit enhances the fix by also applying an XPath on list_price_uom, ensuring the UI structure remains consistent and the design is properly aligned.