### PR TITLE
[FIX] booking_engine: fix product form view layout

### DIFF
--- a/booking_engine/data/ir_ui_view.xml
+++ b/booking_engine/data/ir_ui_view.xml
@@ -232,7 +232,10 @@
   </record>
   <record id="product_product_form_view" model="ir.ui.view">
     <field name="arch" type="xml">
-      <xpath expr="//label[@for='list_price']" position="attributes">
+      <xpath expr="//label[@for='lst_price']" position="attributes">
+        <attribute name="invisible">x_is_a_room_offer</attribute>
+      </xpath>
+      <xpath expr="//div[@name='list_price_per_uom_id']" position="attributes">
         <attribute name="invisible">x_is_a_room_offer</attribute>
       </xpath>
     </field>


### PR DESCRIPTION
Previously, the label of `list_price` was targeted via XPath, which was broken due to standard changes.

This commit updates the fix by targeting `lst_price` instead of `list_price`, and adds an additional XPath on `list_price_per_uom_id` to preserve the layout and ensure a consistent UI.

Related PR - https://github.com/odoo/odoo/pull/257417