### PR TITLE
[IMP] test_generic: add warning when templates is noupdate

### DIFF
--- a/3pl_logistic_company/__manifest__.py
+++ b/3pl_logistic_company/__manifest__.py
@@ -1,7 +1,7 @@
 {
     'name': '3PL Logistic Company',
     'author': 'Odoo S.A.',
-    'version': '1.0',
+    'version': '1.1',
     'category': 'Services',
     'depends': [
         'base_industry_data',

--- a/3pl_logistic_company/data/portal_templates.xml
+++ b/3pl_logistic_company/data/portal_templates.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<odoo noupdate="1">
+<odoo>
     <template id="portal_my_home_products" name="Your products" inherit_id="portal.portal_my_home">
         <div id="portal_common_category" position="inside">
             <t t-call="portal.portal_docs_entry">

--- a/tests/test_generic/tests/test_xml.py
+++ b/tests/test_generic/tests/test_xml.py
@@ -71,6 +71,7 @@ MODELS_TO_UPDATE = {
     "ir.ui.menu",
     "ir.ui.view",
     "knowledge.article",
+    "template",
     "theme.utils",
     "website.assets",
     "website.controller.page",
@@ -359,8 +360,8 @@ class TestEnv(IndustryCase):
             )
 
     def _check_update_status(self, root, filename):
-        for record in root.xpath("//record") + root.xpath("//function"):
-            model = record.get('model')
+        for record in root.xpath("//record") + root.xpath("//function") + root.xpath("//template"):
+            model = record.get('model') or record.tag
             noupdate = False
             parent = record.getparent()
             data_tag = False


### PR DESCRIPTION
Templates should be updated.
This PR modifies the generic test _check_update_status to also test templates,
and raise a warning if those are marked as noupdate="1".
It also removes the noupdate attributes found for the templates.

TASK-6064474