### PR TITLE
[FIX] real_estate: store related address fields to prevent cache issues

### DIFF
--- a/real_estate/data/ir_model_fields.xml
+++ b/real_estate/data/ir_model_fields.xml
@@ -36,7 +36,6 @@
         <field name="related">x_technical_partner_id.street</field>
         <field name="field_description">Street</field>
         <field name="model_id" ref="product.model_product_template"/>
-        <field name="store" eval="False"/>
     </record>
     <record id="field_product_template_zip" model="ir.model.fields">
         <field name="name">x_zip_code</field>
@@ -44,7 +43,6 @@
         <field name="related">x_technical_partner_id.zip</field>
         <field name="field_description">Zip Code</field>
         <field name="model_id" ref="product.model_product_template"/>
-        <field name="store" eval="False"/>
     </record>
     <record id="field_product_template_city" model="ir.model.fields">
         <field name="name">x_city</field>
@@ -52,7 +50,6 @@
         <field name="related">x_technical_partner_id.city</field>
         <field name="field_description">City</field>
         <field name="model_id" ref="product.model_product_template"/>
-        <field name="store" eval="False"/>
     </record>
     <record id="field_product_template_country" model="ir.model.fields">
         <field name="name">x_country</field>
@@ -61,7 +58,6 @@
         <field name="field_description">Country</field>
         <field name="model_id" ref="product.model_product_template"/>
         <field name="relation">res.country</field>
-        <field name="store" eval="False"/>
     </record>
     <record id="field_product_template_owner_id" model="ir.model.fields">
         <field name="name">x_owner_id</field>


### PR DESCRIPTION
Before this commit, the fields x_street, x_city, x_zip_code, and x_country were unstored on properties (products), and values were only stored on the linked partner. When creating a new property, these fields values were cached and added to the technical partner after its creation by an automation.

Due to recent changes in the ORM*, these fields were not cached anymore, leading to blank values.

This commit sets these related fields to stored ones to ensure their values are properly stored.

*https://github.com/odoo/odoo/commit/42df5cf312dcc4947cc9065d36fe1ed52145e016