### PR TITLE
[CLN] tests: default test tag is post_install

### DIFF
--- a/tests/test_3pl_logistic_company/tests/test_action_server.py
+++ b/tests/test_3pl_logistic_company/tests/test_action_server.py
@@ -4,10 +4,9 @@ from dateutil.relativedelta import relativedelta
 
 from odoo import Command, fields
 from odoo.tests.common import TransactionCase
-from odoo.tests import Form, tagged
+from odoo.tests import Form
 
 
-@tagged('post_install', '-at_install')
 class AutomationsTestCase(TransactionCase):
     @classmethod
     def setUpClass(cls):
@@ -63,7 +62,6 @@ class AutomationsTestCase(TransactionCase):
         self.assertFalse(stock_picking_1.owner_id, "Owner should NOT be updated if products have different owners.")
 
 
-@tagged('post_install', '-at_install')
 class ServerActionTestCase(TransactionCase):
     @classmethod
     def setUpClass(cls):

--- a/tests/test_3pl_logistic_company/tests/test_computed_fields.py
+++ b/tests/test_3pl_logistic_company/tests/test_computed_fields.py
@@ -4,10 +4,8 @@ from dateutil.relativedelta import relativedelta
 
 from odoo import fields
 from odoo.tests.common import TransactionCase
-from odoo.tests import tagged
 
 
-@tagged('post_install', '-at_install')
 class ComputedFieldsTestCase(TransactionCase):
 
     @classmethod

--- a/tests/test_beverage_distributor/tests/test_action_server.py
+++ b/tests/test_beverage_distributor/tests/test_action_server.py
@@ -4,10 +4,9 @@ from dateutil.relativedelta import relativedelta
 
 from odoo import fields
 from odoo.tests.common import TransactionCase
-from odoo.tests import Form, tagged
+from odoo.tests import Form
 
 
-@tagged('post_install', '-at_install')
 class ServerActionsTestCase(TransactionCase):
 
     @classmethod

--- a/tests/test_booking_engine/tests/test_action_server.py
+++ b/tests/test_booking_engine/tests/test_action_server.py
@@ -5,11 +5,10 @@ from datetime import datetime, timedelta
 from odoo import Command
 from odoo.exceptions import UserError
 from odoo.fields import Datetime
-from odoo.tests import tagged, Form, freeze_time
+from odoo.tests import Form, freeze_time
 from odoo.tests.common import TransactionCase
 
 
-@tagged("post_install", "-at_install")
 class BookingEngineAutomationsTestCase(TransactionCase):
 
     @classmethod

--- a/tests/test_booking_engine/tests/test_computed_fields.py
+++ b/tests/test_booking_engine/tests/test_computed_fields.py
@@ -4,11 +4,9 @@ from datetime import timedelta
 
 from odoo import Command
 from odoo.fields import Datetime
-from odoo.tests import tagged
 from odoo.tests.common import TransactionCase
 
 
-@tagged("post_install", "-at_install")
 class ComputedFieldsTestCase(TransactionCase):
 
     @classmethod

--- a/tests/test_bookstore/tests/test_action_server.py
+++ b/tests/test_bookstore/tests/test_action_server.py
@@ -2,10 +2,9 @@
 
 from odoo import fields
 from odoo.tests.common import TransactionCase
-from odoo.tests import tagged, Form
+from odoo.tests import Form
 
 
-@tagged('post_install', '-at_install')
 class BookstoreAutomationsTestCase(TransactionCase):
     @classmethod
     def setUpClass(cls):

--- a/tests/test_condominium/tests/test_acquisition.py
+++ b/tests/test_condominium/tests/test_acquisition.py
@@ -1,9 +1,8 @@
 from unittest.mock import patch
 
-from odoo.tests import HttpCase, tagged
+from odoo.tests import HttpCase
 
 
-@tagged('post_install', '-at_install')
 class TestUi(HttpCase):
 
     def test_condominium_acquisition(self):

--- a/tests/test_construction_developer/tests/test_action_server.py
+++ b/tests/test_construction_developer/tests/test_action_server.py
@@ -1,8 +1,7 @@
 from odoo.tests.common import TransactionCase
-from odoo.tests import Form, tagged
+from odoo.tests import Form
 
 
-@tagged('post_install', '-at_install')
 class ActionServerTestCase(TransactionCase):
 
     @classmethod

--- a/tests/test_construction_developer/tests/test_cost_nature_analysis_report.py
+++ b/tests/test_construction_developer/tests/test_cost_nature_analysis_report.py
@@ -1,10 +1,9 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo.tests import float_compare, tagged
+from odoo.tests import float_compare
 from odoo.tests.common import TransactionCase
 
 
-@tagged('post_install', '-at_install')
 class TestCostNatureAnalysisReport(TransactionCase):
 
     def test_table_values_sale_order(self):

--- a/tests/test_construction_developer/tests/test_cost_nature_analysis_report_tour.py
+++ b/tests/test_construction_developer/tests/test_cost_nature_analysis_report_tour.py
@@ -1,7 +1,6 @@
-from odoo.tests import HttpCase, tagged
+from odoo.tests import HttpCase
 
 
-@tagged('post_install', '-at_install')
 class TestCostNatureAnalysisReportTour(HttpCase):
     def test_cost_nature_tour(self):
         if not self.env['ir.module.module'].search_count([('demo', '=', True)], limit=1):

--- a/tests/test_excise_management/tests/test_action_server.py
+++ b/tests/test_excise_management/tests/test_action_server.py
@@ -2,11 +2,10 @@
 from dateutil.relativedelta import relativedelta
 
 from odoo import fields
-from odoo.tests import tagged, Form
+from odoo.tests import Form
 from odoo.tests.common import TransactionCase
 
 
-@tagged('post_install', '-at_install')
 class ActionServerTestCase(TransactionCase):
 
     @classmethod

--- a/tests/test_generic/tests/test_industry_mail_behavior.py
+++ b/tests/test_generic/tests/test_industry_mail_behavior.py
@@ -2,8 +2,6 @@
 
 import logging
 
-
-from odoo.tests import tagged
 from .industry_case import IndustryCase
 
 _logger = logging.getLogger(__name__)
@@ -38,7 +36,6 @@ EXCEPTION_MODELS = [
 ]
 
 
-@tagged('post_install', '-at_install')
 class IndustryMailBehaviorTestCase(IndustryCase):
 
     def test_generic_mail_message_generated(self):

--- a/tests/test_generic/tests/test_industry_requirements.py
+++ b/tests/test_generic/tests/test_industry_requirements.py
@@ -3,7 +3,6 @@
 import logging
 import re
 
-from odoo.tests import tagged
 from odoo.tools import cloc
 
 from .industry_case import IndustryCase
@@ -11,7 +10,6 @@ from .industry_case import IndustryCase
 _logger = logging.getLogger(__name__)
 
 
-@tagged('post_install', '-at_install')
 class TestEnv(IndustryCase):
 
     def test_payment_demo(self):

--- a/tests/test_generic/tests/test_mandatory_files.py
+++ b/tests/test_generic/tests/test_mandatory_files.py
@@ -6,7 +6,6 @@ from pathlib import Path
 import re
 import io
 
-from odoo.tests import tagged
 from odoo.tools.translate import trans_export
 
 from .industry_case import IndustryCase, get_industry_path
@@ -14,7 +13,6 @@ from .industry_case import IndustryCase, get_industry_path
 _logger = logging.getLogger(__name__)
 
 
-@tagged('post_install', '-at_install')
 class FileTest(IndustryCase):
 
     def test_required_files(self):

--- a/tests/test_generic/tests/test_manifest.py
+++ b/tests/test_generic/tests/test_manifest.py
@@ -7,7 +7,6 @@ from pathlib import Path
 
 from odoo.addons.test_lint.tests.test_manifests import ManifestLinter
 from odoo.modules.module import MANIFEST_NAMES, Manifest
-from odoo.tests.common import tagged
 
 from .industry_case import CATEGORIES, IndustryCase, get_industry_path
 
@@ -32,7 +31,6 @@ MANDATORY_KEYS_INDUSTRIES = {
 }
 
 
-@tagged('post_install', '-at_install')
 class ManifestTest(ManifestLinter, IndustryCase):
 
     def _load_manifest(self, module):

--- a/tests/test_generic/tests/test_xml.py
+++ b/tests/test_generic/tests/test_xml.py
@@ -9,7 +9,6 @@ import re
 from lxml import etree
 from collections import defaultdict
 
-from odoo.tests import tagged
 from odoo.tools.mail import single_email_re
 from .industry_case import IndustryCase, get_industry_path
 
@@ -136,7 +135,6 @@ def _has_valid_search(eval_string):
     return True
 
 
-@tagged('post_install', '-at_install')
 class TestEnv(IndustryCase):
 
     def test_xml_files(self):

--- a/tests/test_hair_salon/tests/test_action_server.py
+++ b/tests/test_hair_salon/tests/test_action_server.py
@@ -3,11 +3,9 @@
 import datetime
 from dateutil.relativedelta import relativedelta
 
-from odoo.tests import tagged
 from odoo.tests.common import TransactionCase
 
 
-@tagged('post_install', '-at_install')
 class ActionServerTestCase(TransactionCase):
 
     @classmethod

--- a/tests/test_handyman/tests/test_action_server.py
+++ b/tests/test_handyman/tests/test_action_server.py
@@ -1,11 +1,10 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo.tests import tagged, Form
+from odoo.tests import Form
 from odoo.tests.common import TransactionCase
 from odoo import fields, Command
 
 
-@tagged('post_install', '-at_install')
 class ActionServerTestCase(TransactionCase):
 
     @classmethod

--- a/tests/test_hvac_services/tests/test_action_server.py
+++ b/tests/test_hvac_services/tests/test_action_server.py
@@ -2,11 +2,9 @@
 
 from odoo import fields, Command
 from odoo.tests.common import TransactionCase
-from odoo.tests import tagged
 from odoo.exceptions import UserError
 
 
-@tagged('post_install', '-at_install')
 class AutomationsTestCase(TransactionCase):
 
     @classmethod

--- a/tests/test_hvac_services/tests/test_computed_fields.py
+++ b/tests/test_hvac_services/tests/test_computed_fields.py
@@ -2,10 +2,8 @@
 
 from odoo import Command
 from odoo.tests.common import TransactionCase
-from odoo.tests import tagged
 
 
-@tagged('post_install', '-at_install')
 class ComputedFieldsTestCase(TransactionCase):
 
     @classmethod

--- a/tests/test_industry_real_estate/tests/test_computed_fields.py
+++ b/tests/test_industry_real_estate/tests/test_computed_fields.py
@@ -2,11 +2,9 @@
 
 import datetime
 
-from odoo.tests import tagged
 from odoo.tests.common import TransactionCase
 
 
-@tagged('post_install', '-at_install')
 class ComputedFieldsTestCase(TransactionCase):
 
     def test_x_rental_contract_id_computation(self):

--- a/tests/test_library/tests/test_action_server.py
+++ b/tests/test_library/tests/test_action_server.py
@@ -1,11 +1,10 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import Command
-from odoo.tests import Form, tagged
+from odoo.tests import Form
 from odoo.tests.common import TransactionCase
 
 
-@tagged('post_install', '-at_install')
 class LibraryAutomationsTestCase(TransactionCase):
     @classmethod
     def setUpClass(cls):

--- a/tests/test_library/tests/test_tour.py
+++ b/tests/test_library/tests/test_tour.py
@@ -1,7 +1,6 @@
-from odoo.tests import HttpCase, tagged
+from odoo.tests import HttpCase
 
 
-@tagged('post_install', '-at_install')
 class LibraryTourTestCase(HttpCase):
     def test_return_tour(self):
         # skip test if demo data is not loaded

--- a/tests/test_real_estate/tests/test_action_server.py
+++ b/tests/test_real_estate/tests/test_action_server.py
@@ -1,12 +1,10 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo.tests.common import TransactionCase
-from odoo.tests import tagged
 import logging
 _logger = logging.getLogger(__name__)
 
 
-@tagged('post_install', '-at_install')
 class RealEstateAutomationsTestCase(TransactionCase):
     @classmethod
     def setUpClass(cls):

--- a/tests/test_shoe_maker/tests/test_action_server.py
+++ b/tests/test_shoe_maker/tests/test_action_server.py
@@ -2,10 +2,8 @@
 
 from odoo import fields, Command
 from odoo.tests.common import TransactionCase
-from odoo.tests import tagged
 
 
-@tagged('post_install', '-at_install')
 class ShoeMakerAutomationsTestCase(TransactionCase):
     @classmethod
     def setUpClass(cls):

--- a/tests/test_tattoo_shop/tests/test_action_server.py
+++ b/tests/test_tattoo_shop/tests/test_action_server.py
@@ -2,10 +2,9 @@
 
 from odoo import fields
 from odoo.tests.common import TransactionCase
-from odoo.tests import tagged, Form
+from odoo.tests import Form
 
 
-@tagged('post_install', '-at_install')
 class TattooShopAutomationsTestCase(TransactionCase):
     @classmethod
     def setUpClass(cls):

--- a/tests/test_team_sports_club/tests/test_action_server.py
+++ b/tests/test_team_sports_club/tests/test_action_server.py
@@ -3,10 +3,9 @@
 from odoo import Command
 from odoo.exceptions import UserError
 from odoo.tests.common import TransactionCase
-from odoo.tests import tagged, Form
+from odoo.tests import Form
 
 
-@tagged('post_install', '-at_install')
 class TeamSportsClubActionServerTestCase(TransactionCase):
     @classmethod
     def setUpClass(cls):


### PR DESCRIPTION
Since saas-19.1*, default tag for tests is post_install, where it was at_install before.
This commit removes the useless post_install redefinition of the tag.

*https://github.com/odoo/odoo/commit/18a725879777699984d77211f523171dad28d881