### PR TITLE
[IMP] booking_engine: add resource tag on partner view from pos

### DIFF
--- a/booking_engine/data/ir_ui_view.xml
+++ b/booking_engine/data/ir_ui_view.xml
@@ -401,17 +401,17 @@
   <record id="booking_engine_order_search" model="ir.ui.view">
     <field name="arch" type="xml">
         <xpath expr="//filter[@name='my_sale_orders_filter']" position="before">
-          <filter domain="['|', 
-            '&amp;', '&amp;', '&amp;', 
-            ('rental_status', '=', 'return'), 
-            ('rental_return_date', '&gt;=', datetime.datetime.combine(context_today(), datetime.time(0, 0, 0)).to_utc().strftime('%Y-%m-%d %H:%M:%S')), 
-            ('rental_return_date', '&lt;', datetime.datetime.combine(context_today() + relativedelta(days = 1), datetime.time(0, 0, 0)).to_utc().strftime('%Y-%m-%d %H:%M:%S')), 
-            ('state', '=', 'sale'), 
-            '&amp;', '&amp;', '&amp;', 
-            ('rental_status', '=', 'pickup'), 
-            ('rental_start_date', '&gt;=', datetime.datetime.combine(context_today(), datetime.time(0, 0, 0)).to_utc().strftime('%Y-%m-%d %H:%M:%S')), 
-            ('rental_start_date', '&lt;', datetime.datetime.combine(context_today() + relativedelta(days = 1), datetime.time(0, 0, 0)).to_utc().strftime('%Y-%m-%d %H:%M:%S')), 
-            ('state', '=', 'sale')]" 
+          <filter domain="['|',
+            '&amp;', '&amp;', '&amp;',
+            ('rental_status', '=', 'return'),
+            ('rental_return_date', '&gt;=', datetime.datetime.combine(context_today(), datetime.time(0, 0, 0)).to_utc().strftime('%Y-%m-%d %H:%M:%S')),
+            ('rental_return_date', '&lt;', datetime.datetime.combine(context_today() + relativedelta(days = 1), datetime.time(0, 0, 0)).to_utc().strftime('%Y-%m-%d %H:%M:%S')),
+            ('state', '=', 'sale'),
+            '&amp;', '&amp;', '&amp;',
+            ('rental_status', '=', 'pickup'),
+            ('rental_start_date', '&gt;=', datetime.datetime.combine(context_today(), datetime.time(0, 0, 0)).to_utc().strftime('%Y-%m-%d %H:%M:%S')),
+            ('rental_start_date', '&lt;', datetime.datetime.combine(context_today() + relativedelta(days = 1), datetime.time(0, 0, 0)).to_utc().strftime('%Y-%m-%d %H:%M:%S')),
+            ('state', '=', 'sale')]"
             name="filter_today" string="Today"/>
           <separator/>
         </xpath>
@@ -567,7 +567,7 @@
       (0, 0, {'view_mode': 'gantt', 'view_id': ref('booking_engine_planning_gantt_view')}),
       (0, 0, {'view_mode': 'form', 'view_id': ref('booking_engine_schedule_form')}),
       (0, 0, {'view_mode': 'list', 'view_id': ref('booking_engine_planning_list_view')}),
-      
+
     ]"/>
   </record>
   <record id="booking_engine_rooms_order_action" model="ir.actions.act_window">
@@ -581,7 +581,7 @@
   </record>
   <record id="booking_engine_rooms_offers_action" model="ir.actions.act_window">
     <field name="search_view_id" ref="booking_engine_offers_search"/>
-    <field name="view_ids" eval="[  
+    <field name="view_ids" eval="[
       (5, 0, 0),
       (0, 0, {'view_mode': 'kanban', 'view_id': ref('product.product_template_kanban_view')}),
       (0, 0, {'view_mode': 'list', 'view_id': ref('booking_engine_offers_list')}),
@@ -659,7 +659,7 @@
                             </div>
                         </div>
                         <footer class="align-items-end">
-                            
+
                         </footer>
                     </t>
                 </templates>

--- a/campsite/__manifest__.py
+++ b/campsite/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Campsite',
-    'version': '1.5',
+    'version': '1.6',
     'category': 'Hospitality',
     'author': 'Odoo S.A.',
     'depends': [

--- a/campsite/data/views.xml
+++ b/campsite/data/views.xml
@@ -4,4 +4,15 @@
     <field name="web_icon_data" type="base64" file="campsite/static/description/icon.png"/>
     <field name="name">Campsite</field>
   </record>
+  <record id="view_partner_form_pos_ui" model="ir.ui.view">
+    <field name="name">res.partner.form.pos.ui.inherit.campsite</field>
+    <field name="model">res.partner</field>
+    <field name="inherit_id" ref="point_of_sale.view_partner_form_pos_ui"/>
+    <field name="active" eval="True"/>
+    <field name="arch" type="xml">
+        <xpath expr="//field[@name='image_1920']/parent::div" position="inside">
+          <field name="x_ongoing_bookings" widget="many2many_tags" invisible="not x_ongoing_bookings"/>
+        </xpath>
+    </field>
+  </record>
 </odoo>

--- a/hotel/__manifest__.py
+++ b/hotel/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Hotel',
-    'version': '1.6',
+    'version': '1.7',
     'category': 'Hospitality',
     'author': 'Odoo S.A.',
     'depends': [

--- a/hotel/data/views.xml
+++ b/hotel/data/views.xml
@@ -4,4 +4,15 @@
     <field name="web_icon_data" type="base64" file="hotel/static/description/icon.png"/>
     <field name="name">Hotel</field>
   </record>
+  <record id="view_partner_form_pos_ui" model="ir.ui.view">
+    <field name="name">res.partner.form.pos.ui.inherit.hotel</field>
+    <field name="model">res.partner</field>
+    <field name="inherit_id" ref="point_of_sale.view_partner_form_pos_ui"/>
+    <field name="active" eval="True"/>
+    <field name="arch" type="xml">
+        <xpath expr="//field[@name='image_1920']/parent::div" position="inside">
+          <field name="x_ongoing_bookings" widget="many2many_tags" invisible="not x_ongoing_bookings"/>
+        </xpath>
+    </field>
+  </record>
 </odoo>


### PR DESCRIPTION
Before this commit, the new light form view of res.partner accessible from the POS was not extended to display the new custom fields. Since the resource (the room number) is an important information to display, this commit adds it to the view.

task-6126922