### PR TITLE
[FIX] .*: fix non-stored fields in related field definitions

### DIFF
--- a/architects/__manifest__.py
+++ b/architects/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Architecture Firm',
-    'version': '1.0',
+    'version': '1.1',
     'category': 'Services',
     'depends': [
         'account_followup',

--- a/architects/data/ir_model_fields.xml
+++ b/architects/data/ir_model_fields.xml
@@ -39,14 +39,6 @@
         <field name="field_description">Project type</field>
         <field name="selection">[('peb', "PEB analysis"), ('design', "Architectural design")]</field>
     </record>
-    <record id="project_project_type" model="ir.model.fields">
-        <field name="name">x_project_type</field>
-        <field name="model_id" ref="project.model_project_project" />
-        <field name="readonly" eval="False"/>
-        <field name="related">sale_order_id.opportunity_id.x_project_type</field>
-        <field name="field_description">Project type</field>
-        <field name="ttype">selection</field>
-    </record>
     <record id="project_cadastral_number" model="ir.model.fields">
         <field name="name">x_cadastral_number</field>
         <field name="model_id" ref="project.model_project_project" />

--- a/art_craft/__manifest__.py
+++ b/art_craft/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Arts & Crafts Store',
-    'version': '1.0',
+    'version': '1.1',
     'category': 'Retail',
     'depends': [
         'hr_hourly_cost',

--- a/art_craft/data/base_automation.xml
+++ b/art_craft/data/base_automation.xml
@@ -4,8 +4,8 @@
     <record id="automation_assign_owner_for_consignement_purchase" model="base.automation">
         <field name="name">Set Vendor Name in Assign Owner</field>
         <field name="trigger">on_create_or_write</field>
-        <field name="filter_pre_domain">[("x_is_consignee", "=", False)]</field>
-        <field name="filter_domain">[("x_is_consignee", "=", True)]</field>
+        <field name="filter_pre_domain">[("purchase_id.x_is_consignee", "=", False)]</field>
+        <field name="filter_domain">[("purchase_id.x_is_consignee", "!=", False)]</field>
         <field name="model_id" ref="stock.model_stock_picking"/>
     </record>
 

--- a/art_craft/data/ir_model_fields.xml
+++ b/art_craft/data/ir_model_fields.xml
@@ -6,12 +6,4 @@
         <field name="ttype">boolean</field>
         <field name="field_description">Is consignee</field>
     </record>
-    <record id="field_stock_picking_x_is_it_consignee" model="ir.model.fields">
-        <field name="name">x_is_consignee</field>
-        <field name="model_id" ref="stock.model_stock_picking"/>
-        <field name="ttype">boolean</field>
-        <field name="readonly" eval="True"/>
-        <field name="related">purchase_id.x_is_consignee</field>
-        <field name="field_description">Is Consignee</field>
-    </record>
 </odoo>

--- a/bookstore/__manifest__.py
+++ b/bookstore/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Bookstore',
-    'version': '1.0',
+    'version': '1.1',
     'category': 'Retail',
     'depends': [
         'account_followup',

--- a/bookstore/data/ir_model_fields.xml
+++ b/bookstore/data/ir_model_fields.xml
@@ -18,8 +18,12 @@ for template in self:
         <field name="name">x_last_sale_stock</field>
         <field name="field_description">Last Sale</field>
         <field name="ttype">date</field>
-        <field name="related">product_tmpl_id.x_last_sale_date</field>
+        <field name="depends">product_tmpl_id.x_last_sale_date</field>
         <field name="model_id" ref="stock.model_stock_warehouse_orderpoint"/>
+        <field name="compute"><![CDATA[
+for orderpoint in self:
+    orderpoint['x_last_sale_stock'] = orderpoint.product_tmpl_id.x_last_sale_date
+]]></field>
     </record>
     <record id="x_last_vendor_template_field" model="ir.model.fields">
         <field name="name">x_last_vendor</field>


### PR DESCRIPTION
Before this commit we were using the non store field in the related field definitions but due to recent fix in standard* we are now unable to use those fields in the related definitions.

So in this commit we are replacing the related non store field reference as a computed field .

*https://github.com/odoo/odoo/commit/fe83265417217bb01b82fe777fb33a42650eb74b