### PR TITLE
[FIX] booking_engine: fix cron not working after the first time

### DIFF
--- a/booking_engine/__manifest__.py
+++ b/booking_engine/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Booking Engine',
-    'version': '1.9',
+    'version': '1.10',
     'category': 'Hidden/Tools',
     'author': 'Odoo S.A.',
     'depends': [

--- a/booking_engine/data/ir_actions_server.xml
+++ b/booking_engine/data/ir_actions_server.xml
@@ -289,10 +289,13 @@ today, target_dates = datetime.date.today(), set(datetime.date.today() + datetim
 env['x_availability'].search([('x_date', '<', today), ('x_active', '=', True)]).write({'x_active': False})
 
 if (offers := env['product.template'].search([('x_is_a_room_offer', '=', True)])):
-    existing_dates_by_offer = env['x_availability']._read_group(
-        [('x_stay_offer_id', 'in', offers.ids), ('x_date', '>=', today), ('x_date', '<', today + datetime.timedelta(days=500))],
-        groupby=['x_stay_offer_id'], aggregates=['x_date:array_agg']
-    )
+
+    existing_dates_by_offer = {
+        offer.id: set(dates)
+        for offer, dates in env['x_availability']._read_group(
+            [('x_stay_offer_id', 'in', offers.ids), ('x_date', '>=', today), ('x_date', '<', today + datetime.timedelta(days=500))],
+            ['x_stay_offer_id'], ['x_date:array_agg']
+    )}
 
     # Create availabilities only for dates that don't exist
     to_create = [{'x_stay_offer_id': offer_id, 'x_date': d, 'x_to_recompute': True}

--- a/tests/test_booking_engine/tests/test_action_server.py
+++ b/tests/test_booking_engine/tests/test_action_server.py
@@ -669,6 +669,10 @@ class BookingEngineAutomationsTestCase(TransactionCase):
             ('x_date', '=', target_date),
         ])
 
+        # test from a bugfix: cron has to work twice
+        self.env.ref('booking_engine.server_action_create_500_days_availability').run()
+        self.env.ref('booking_engine.server_action_create_500_days_availability').run()
+
         # --- INITIAL STATE CHECK ---
         self.assertEqual(avail.x_total_units, 2, "There are 2 physical rooms linked to the offer.")
         self.assertEqual(avail.x_booked, 0, "No bookings yet, booked count should be 0.")


### PR DESCRIPTION
Before this commit, the `ir_cron_create_500_days_availability` cron could only work the first time. The code was correct when no availabilities were returned by the _read_group but incorrect when not empty. This commit fixes this and adds a test to validate that the cron can run twice.