### PR TITLE
[IMP] *: add inventory for industries

### DIFF
--- a/bar_industry/__manifest__.py
+++ b/bar_industry/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Bar & Pub',
-    'version': '1.2',
+    'version': '1.3',
     'category': 'Hospitality',
     'depends': [
         'base_industry_data',
@@ -10,6 +10,7 @@
         'planning',
         'pos_restaurant',
         'pos_self_order',
+        'pos_stock',
         'project_enterprise',
         'purchase',
     ],

--- a/bowling/__manifest__.py
+++ b/bowling/__manifest__.py
@@ -1,13 +1,13 @@
 {
     'name': 'Bowling Alley',
-    'version': '1.1',
+    'version': '1.2',
     'category': 'Hospitality',
     'depends': [
         'base_industry_data',
         'knowledge',
         'planning',
-        'pos_enterprise',
         'pos_restaurant',
+        'pos_stock',
         'website_appointment',
     ],
     'data': [

--- a/concert_halls/__manifest__.py
+++ b/concert_halls/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Concert Halls',
-    'version': '1.1',
+    'version': '1.2',
     'category': 'Hospitality',
     'author': 'Odoo S.A.',
     'depends': [
@@ -8,6 +8,7 @@
         'event_sale',
         'knowledge',
         'pos_event',
+        'pos_stock',
         'project_enterprise',
         'social',
         'website_crm',

--- a/escape_rooms/__manifest__.py
+++ b/escape_rooms/__manifest__.py
@@ -1,12 +1,13 @@
 {
     'name': 'Escape Rooms',
-    'version': '1.1',
+    'version': '1.2',
     'category': 'Hospitality',
     'author': 'Odoo S.A.',
     'depends': [
         'base_industry_data',
         'knowledge',
         'pos_loyalty',
+        'pos_stock',
         'sale_crm',
         'sale_planning',
         'website_appointment',

--- a/fitness/__manifest__.py
+++ b/fitness/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Fitness Center',
-    'version': '1.3',
+    'version': '1.4',
     'category': 'Health and Fitness',
     'depends': [
         'base_industry_data',
@@ -12,6 +12,7 @@
         'partnership',
         'planning',
         'pos_sale',
+        'pos_stock',
         'purchase',
         'sale_project',
         'sale_subscription',

--- a/florist/__manifest__.py
+++ b/florist/__manifest__.py
@@ -1,16 +1,14 @@
 {
     'name': 'Florist',
-    'version': '1.1',
+    'version': '1.2',
     'category': 'Retail',
     'author': 'Odoo S.A.',
     'depends': [
         'base_industry_data',
         'crm_enterprise',
         'knowledge',
-        'pos_enterprise',
-        'pos_hr',
-        'pos_loyalty',
         'pos_online_payment',
+        'pos_stock',
         'project_enterprise',
         'sale_crm',
         'sale_loyalty',

--- a/gallery/__manifest__.py
+++ b/gallery/__manifest__.py
@@ -1,12 +1,13 @@
 {
     'name': 'Gallery',
-    'version': '1.1',
+    'version': '1.2',
     'category': 'Retail',
     'depends': [
         'base_industry_data',
         'knowledge',
         'partner_commission',
         'pos_sale',
+        'pos_stock',
         'sale_purchase_project',
         'sign',
         'website_event_sale'

--- a/guided_tours/__manifest__.py
+++ b/guided_tours/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Guided Tours',
-    'version': '1.1',
+    'version': '1.2',
     'category': 'Hospitality',
     'author': 'Odoo S.A.',
     'depends': [
@@ -9,7 +9,7 @@
         'contacts',
         'event_sale',
         'knowledge',
-        'pos_enterprise',
+        'pos_stock',
         'website_appointment',
         'website_event',
         'website_sale',

--- a/night_clubs/__manifest__.py
+++ b/night_clubs/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Night Clubs',
-    'version': '1.1',
+    'version': '1.2',
     'category': 'Hospitality',
     'author': 'Odoo S.A.',
     'depends': [
@@ -9,6 +9,7 @@
         'event_sale',
         'knowledge',
         'pos_restaurant',
+        'pos_stock',
         'purchase',
         'sale',
         'social',

--- a/outdoor_activities/__manifest__.py
+++ b/outdoor_activities/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Outdoor Activities',
-    'version': '1.1',
+    'version': '1.2',
     'category': 'Health and Fitness',
     'depends': [
         'appointment_account_payment',
@@ -8,6 +8,7 @@
         'event_crm',
         'knowledge',
         'pos_sale',
+        'pos_stock',
         'sale_service',
         'website_crm',
         'website_event_sale',

--- a/spa_resort/__manifest__.py
+++ b/spa_resort/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Spa Resort',
-    'version': '1.2',
+    'version': '1.3',
     'category': 'Hospitality',
     'author': 'Odoo S.A.',
     'depends': [
@@ -9,6 +9,7 @@
         'contacts',
         'knowledge',
         'pos_loyalty',
+        'pos_stock',
         'sale_planning',
         'website_sale',
     ],

--- a/student_organization/__manifest__.py
+++ b/student_organization/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Student Organization',
-    'version': '1.1',
+    'version': '1.2',
     'category': 'Hospitality',
     'author': 'Odoo S.A.',
     'depends': [
@@ -10,7 +10,7 @@
         'hr_expense',
         'knowledge',
         'partnership',
-        'pos_enterprise',
+        'pos_stock',
         'project_enterprise',
         'purchase',
         'social',

--- a/theater/__manifest__.py
+++ b/theater/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Theater',
-    'version': '1.1',
+    'version': '1.2',
     'category': 'Hospitality',
     'author': 'Odoo S.A.',
     'depends': [
@@ -10,6 +10,7 @@
         'partnership',
         'pos_event',
         'pos_self_order',
+        'pos_stock',
         'project',
         'website_event_sale',
         'website_sale_loyalty',

--- a/veterinary_clinic/__manifest__.py
+++ b/veterinary_clinic/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Veterinary Clinic',
-    'version': '1.1',
+    'version': '1.2',
     'category': 'Health and Fitness',
     'author': 'Odoo S.A.',
     'depends': [
@@ -10,6 +10,7 @@
         'knowledge',
         'planning_field_service_worksheet',
         'pos_online_payment',
+        'pos_stock',
         'sale_planning',
         'sale_timesheet',
         'web_studio',


### PR DESCRIPTION
   * = ['account_pos_settle_due', 'bar_industry', 'bowling', 'campsite', 'concert_halls', 'escape_rooms', 'fitness', 'florist', 'food_trucks', 'gallery', 'guided_tours', 'hotel', 'night_clubs', 'outdoor_activities', 'spa_resort', 'student_organization', 'theater', 'veterinary_clinic']


Before version 19.3, some industries were automatically getting the Inventory because of other modules like point of sales.

Now in 19.3, those dependencies are removed [1], so Inventory is no longer added automatically.

Link [1]: https://github.com/odoo/odoo/commit/6a56bd10cec73eabd78b3ab7ba09fe4ab3789243

Task ID - 6152529