### PR TITLE
[FIX] escape_rooms: fix appointment page broken xpath

### DIFF
--- a/escape_rooms/demo/website_view.xml
+++ b/escape_rooms/demo/website_view.xml
@@ -87,9 +87,10 @@
           <attribute name="class">o_wappointment_wrap h-100 overflow-x-hidden</attribute>
         </xpath>
         <xpath expr="//t[@t-set='o_portal_fullwidth_alert']" position="replace"/>
-        <xpath expr="//t[@t-set='selectionPossible']" position="after">
-          <!-- Selection is no longer possible if a selection screen was shown beforehand -->
-          <t t-set="selectionPossible" t-value="selectionPossible and not (is_manual_assign_user_resource_first and appointment_type.show_avatars)"/>
+        <xpath expr="//t[@t-call='appointment.appointment_details_column']" position="attributes">
+          <attribute name="selectionPossible">
+              selectionPossible and not (is_manual_assign_user_resource_first and appointment_type.show_avatars)
+          </attribute>
         </xpath>
       </data>
     </field>


### PR DESCRIPTION
This PR resolves an issue with a broken XPath on the appointment page that was causing an internal server error. The XPath became invalid due to changes in the standard view

Related PR - https://github.com/odoo/enterprise/pull/97933 
**Task-6180236**