### PR TITLE
[FIX] booking_engine: prevent duplicate slot creation and ensure SOL linkage

### DIFF
--- a/booking_engine/__manifest__.py
+++ b/booking_engine/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Booking Engine',
-    'version': '1.11',
+    'version': '1.12',
     'category': 'Hidden/Tools',
     'author': 'Odoo S.A.',
     'depends': [

--- a/booking_engine/data/ir_ui_view.xml
+++ b/booking_engine/data/ir_ui_view.xml
@@ -56,7 +56,6 @@
         <xpath expr="//field[@name='is_rental_order']" position="after">
           <button string="City Tax" type="action" name="%(open_x_city_tax_action)d" context="{'search_default_x_sale_order_id': id, 'default_x_sale_order_id': id}"/>
         </xpath>
-        <xpath expr="/form/sheet/notebook/page[@name='order_lines']/field[@name='order_line']/list//field[@name='planning_slot_ids']" position="replace"/>
         <xpath expr="//form[1]/sheet[1]/notebook[1]" position="inside">
           <page string="Guests">
             <field name="x_guest_line_ids">


### PR DESCRIPTION
Before this PR we replaced the `planning_slot_ids` (one2many) field in our 
code which was in relation with `sale_line_id` field due to which slots were 
created twice and also `sale_line_id` was not linked to the slot.

**Cause:**
- Since planning_slot_ids field is not in the form view of rental order, the 
  form view cannot set the context in the SOL created by the context that's why 
  the shift is no longer related to the SOL and the system is looking for an 
  available resource instead of setting the slot in which we create that rental 
  order.

**Fix:**
- We removed the code which was removing/replacing the planning_slot_ids field 
  from the view to ensure proper context propogation and avoid duplicate slot 
creation.

**opw - 5958916**