### PR TITLE
[IMP] construction_developer: create pickings from procurement view

### DIFF
--- a/construction/data/knowledge_article.xml
+++ b/construction/data/knowledge_article.xml
@@ -128,7 +128,7 @@
         <p>
              <br/>
         </p>
-        <h3>💲 Easily create beautiful quotations </h3>
+        <h3>✨ Easily create beautiful quotations </h3>
         <hr/>
         <p>The <strong>Sales App</strong> enables rapid creation of professional quotations.
             You can use product kits for materials, apply discounts, and send polished proposals
@@ -203,7 +203,7 @@
                 href="https://www.odoo.com/documentation/latest/applications/sales/sales.html">&#xFEFF;🎓
             Sales&#xFEFF;</a>&#xFEFF;</p>
 
-        <h5>⏳ First quote in record time leveraging the work items (Construction Developer)</h5>
+        <h5>First quote in record time leveraging the work items (Construction Developer)</h5>
         <p>Making sure you don't waste time generating quotes which may never be signed is paramount
             to run your business efficiently. <br/>To help you with this aspects, we configured the <strong>
             Sales App</strong> with work items to be leveraged straight from
@@ -259,7 +259,7 @@
         <div class="o-paragraph">
              <br/>
         </div>
-        <h5>🧮 Advanced quote computations with the calculator</h5>
+        <h5>Advanced quote computations with the calculator</h5>
         <p>In some cases, you might look for more advanced computations to fine tune your quotes... <br/>We
             got you covered here with the quote calculator!</p>
         <p>
@@ -288,7 +288,7 @@
                     &#xFEFF;here&#xFEFF;</a>&#xFEFF;.</div>
             </div>
         </div>
-        <h5>⚖️ Specify the contract type (Construction Developer)</h5>
+        <h5>Specify the contract type (Construction Developer)</h5>
         <p>
             Construction may not always go as planned and quotations may be built based on estimates. The question when it takes more time or consumes more material due to erroneous estimates is who owns the risk?<br/>
             To help you with that, the construction industry comes with a contract type which helps you clarifying that upfront any issue, directly in your quote.
@@ -311,7 +311,7 @@
                 <p>This information reflects straight away in your quotations, whether send as pdf file or with a preview.</p>
             </div>
         </div>
-        <h5>📊 Cost nature analysis (Construction Developer)</h5>
+        <h5>Cost nature analysis (Construction Developer)</h5>
         <p>
             You setup a quote and now want to know how it breaks down in terms of cost nature, it is available at your finger tips!
         </p>
@@ -331,7 +331,7 @@
                 <p>You not only have access to cost nature break down here, but can drill into product categories, work items and products to capture where to be more competitive or marge more!</p>
             </div>
         </div>
-        <h5>✨ Change orders &amp; extras</h5>
+        <h5>Change orders &amp; extras</h5>
         <p>
             Do your construction projects go always according to plan?
             If not, here is how to handle change orders and extras.
@@ -351,7 +351,7 @@
                 <p>When selling change order, make sure not to use service products creating new projects to keep things in order in a single project.</p>
             </div>
         </div>
-        <h5>🏦 Specific tax discount</h5>
+        <h5>Specific tax discount</h5>
         <p>
             In some countries, specific tax discount may apply in construction.
             To handle this, you can use the fiscal position and adjust by which tax replacing one.
@@ -378,7 +378,7 @@
             <br/>
         </p>
 
-        <h3>📝 Centralize all the important information </h3>
+        <h3>📂 Centralize all the important information </h3>
         <hr/>
         <p>Starting a construction project implies a lot of important documents such as contracts,
             building plans, instructions for use, subcontracting agreements, etc. Instead of
@@ -420,7 +420,7 @@
         <p>
              <br/>
         </p>
-        <h3>Manage your construction project with ease </h3>
+        <h3>✅ Manage your construction project with ease </h3>
         <hr/>
         <p> The <strong>Projects App</strong> allows you to manage tasks, assign resources, and
             create milestones for each construction project.
@@ -515,14 +515,16 @@
             <div class="o_editor_banner_content o-contenteditable-true w-100 px-3"
                 contenteditable="true">
                 <div class="o-paragraph">
-                    To automatically set a remark to "Done" or "Cancelled" state when they reach a given stage, create an automation from the Kanban view:
-                    <ul>
-                        <li>Open the remarks Kanban view of a given project.</li>
-                        <li>Near the stage name (when unfolded), click the gear icon and then Automation.</li>
-                        <li>Create a new automation and add an action.</li>
-                        <li>Select the Update Record action and set the state to the desired value.</li>
-                    </ul>
-                    This works for task stages as well!
+                    <p>
+                        To automatically set a remark to "Done" or "Cancelled" state when they reach a given stage, create an automation from the Kanban view:
+                        <ul>
+                            <li>Open the remarks Kanban view of a given project.</li>
+                            <li>Near the stage name (when unfolded), click the gear icon and then Automation.</li>
+                            <li>Create a new automation and add an action.</li>
+                            <li>Select the Update Record action and set the state to the desired value.</li>
+                        </ul>
+                        This works for task stages as well!
+                    </p>
                 </div>
             </div>
         </div>
@@ -740,7 +742,7 @@
             </div>
         </div>
 
-        <h5>Planning purchase and dropshipping orders</h5>
+        <strong>Planning purchase and dropshipping orders</strong>
         <p>
             Select lines and hit the Purchase button to create a purchase order for those lines, or alternatively
             the Dropship button to create a dropshipping RFQ with a delivery straight to the work site.
@@ -759,7 +761,7 @@
             </div>
         </div>
 
-        <h5>Planning transfers and managing on-site inventory</h5>
+        <strong>Planning transfers and managing on-site inventory</strong>
         <p>
             Select lines and fire the Transfer button to create a picking for the corresponding products from your warehouse stock to the work site.
         </p>
@@ -858,7 +860,7 @@
         <p>
              <br/>
         </p>
-        <h3>📈 Invoice the right amount at the right time </h3>
+        <h3>🏁 Invoice the right amount at the right time </h3>
         <hr/>
         <p>
             <strong>Invoicing App</strong> ensures timely billing, automates recurring invoices, and
@@ -904,7 +906,7 @@
         <p>&#xFEFF;<a
                 href="https://www.odoo.com/documentation/latest/applications/finance/accounting/customer_invoices.html"
                 class="btn btn-fill-secondary">&#xFEFF;🎓 Invoicing&#xFEFF;</a>&#xFEFF; </p>
-        <h5>🏁 Manual delivery progress management (Construction Developer)</h5>
+        <h5>Manual delivery progress management (Construction Developer)</h5>
         <p>Typically, work items products are priced in a scale-able fashion and billed based on
             delivered quantity.<br/>Those are defined as service products with invoicing based on
             manual delivery.</p>
@@ -940,7 +942,7 @@
                     sale order, in the Progress tab!</div>
             </div>
         </div>
-        <h5>⏲️ Time sheet based progress management</h5>
+        <h5>Time sheet based progress management</h5>
         <p>Some other work items will be invoiced given the amount of time spent. The time sheet do
             not only help you to keep track of your costs, they as well are the lever to charge your
             customers<br/>Those are defined as service products with invoicing based on time sheets.</p>
@@ -955,7 +957,7 @@
                     time is used as delivery metric!</p>
             </div>
         </div>
-        <h5>🧾 Multiple orders turning into one bill</h5>
+        <h5>Multiple orders turning into one bill</h5>
         <p>
             You may have signed multiple orders for a given contract and may not want to bill those one by one to your customer.
             Odoo comes with a capability for consolidated billing in such cases!

--- a/construction/data/knowledge_article.xml
+++ b/construction/data/knowledge_article.xml
@@ -420,7 +420,7 @@
         <p>
              <br/>
         </p>
-        <h3>🏗️ Manage your construction project with ease </h3>
+        <h3>Manage your construction project with ease </h3>
         <hr/>
         <p> The <strong>Projects App</strong> allows you to manage tasks, assign resources, and
             create milestones for each construction project.
@@ -433,9 +433,6 @@
                 <strong>Task Creation:</strong> Break down construction phases into actionable items.
             </li>
             <li>
-                <strong>Milestones:</strong> Define major project achievements.
-            </li>
-            <li>
                 <strong>Assignments:</strong> Allocate engineers, site managers, and subcontractors.
             </li>
             <li>
@@ -445,31 +442,14 @@
         <p>&#xFEFF;<a
                 href="https://www.odoo.com/documentation/latest/applications/services/project.html"
                 class="btn btn-fill-secondary">&#xFEFF;🎓 Project&#xFEFF;</a>&#xFEFF;</p>
-        <h5>📐 Project template</h5>
+        <h5>Project template</h5>
         <p>
             On sale order confirmation, the project template is duplicated for the new project to
             start (triggered by the Project Management product). 
             <br/>
             It comes with some predefined tasks and some additional ones directly coming
-            from the sold products:
+            from the sold products: Down Payment, Planification, Work, Receipt
         </p>
-        <ul>
-            <li>
-                Architect
-            </li>
-            <li>
-                Down Payment
-            </li>
-            <li>
-                Planification
-            </li>
-            <li>
-                Work
-            </li>
-            <li>
-                Receipt
-            </li>
-        </ul>
         <div
             class="o_editor_banner user-select-none o-contenteditable-false lh-1 d-flex align-items-center alert alert-info pb-0 pt-3"
             data-oe-role="status" contenteditable="false" role="status">
@@ -484,41 +464,7 @@
                 </div>
             </div>
         </div>
-        <h5>🛒 Material Shopping List (Construction Developer)</h5>
-        <p>
-            Eliminate manual entry and guesswork by transforming your technical quotes into actionable procurement data.
-            This feature automatically extracts every bolt, brick, and beam required for your project by decomposing your Work Items into a consolidated shopping list.
-        </p>
-        <p>
-            <strong>How to use it:</strong>
-        </p>
-        <ul>
-            <li>
-                Prepare your Sale Order with structured sections and articles containing Work Items.
-            </li>
-            <li>
-                Access your consolidated requirements via the Procurement smart button as well as from the <strong>Inventory App</strong> and the Project Top Bar <strong>"Needs" button</strong>
-            </li>
-        </ul>
-        <div
-            class="o_editor_banner user-select-none o-contenteditable-false lh-1 d-flex align-items-center alert alert-info pb-0 pt-3"
-            data-oe-role="status" contenteditable="false" role="status">
-            <i class="o_editor_banner_icon mb-3 fst-normal" data-oe-aria-label="Banner Info"
-                aria-label="Banner Info">💡</i>
-            <div class="o_editor_banner_content o-contenteditable-true w-100 px-3"
-                contenteditable="true">
-                <p>Automated extraction:</p>
-                <ul>
-                    <li>
-                        Odoo scans every component within your Work Items to find underlying needs, filtering components by the Material Cost Nature, ensuring your list isn't cluttered with labor or equipment hours.
-                    </li>
-                    <li>
-                        Identical materials across different sections are summed up, giving you total volumes for better supplier negotiations.
-                    </li>
-                </ul>
-            </div>
-        </div>
-        <h5>🧙‍♂️ Project management</h5>
+        <h5>Project management</h5>
         <p>
             Efficient project management comes with every needed input at your fingertips, simple ways to handle work and follow up.
         </p>
@@ -538,7 +484,7 @@
                 </ul>
             </li>
         </ul>
-        <h5>📅 Delivery remarks (Construction Developer) </h5>
+        <h5>Delivery remarks (Construction Developer) </h5>
         <p>
             Capturing remarks during on-site visits and easily following up on them is 
             paramount for clarity with stakeholders and workers.
@@ -586,40 +532,65 @@
         <h3>📦 Keep an eye on materials </h3>
         <hr/>
         <p>
-            <strong>Inventory App</strong> manages materials, tracks deliveries, and monitors site
-            stock to prevent delays or shortages.</p>
+            Odoo comes with powerful automated flows to plan deliveries, purchases, and maintain an up-to-date inventory. 
+            In the meantime, you might not want to handle the burden of stock management or, on the opposite side, 
+            methodically monitor on-site inventory. 
+            For all those use cases, we've got you covered.
+        </p>
+        <h5>Immediate deliveries on order confirmation</h5>
+        <p>
+            This is the most straightforward approach, perfect for small renovations or quick-turnaround trades 
+            where materials are shipped as soon as the deal is struck.
+        </p>
         <p>
             <strong>How to use it:</strong>
         </p>
         <ul>
             <li>
-                <strong>Stock Monitoring:</strong> Check available materials and reserve them for
-                    projects.
+                Simply configure your products as Goods.
             </li>
             <li>
-                <strong>Reordering:</strong> Automate purchase orders for low-stock items.
+                Once the Sale Order is confirmed, a delivery order (picking) is automatically generated and available from the smart buttons.
             </li>
             <li>
-                <strong>Site Transfers:</strong> Allocate materials to specific construction
-                    sites.
+                Your warehouse team receives the notification to prepare the shipment immediately.
             </li>
         </ul>
-        <p>&#xFEFF;<a class="btn btn-fill-secondary"
-                href="https://www.odoo.com/documentation/latest/applications/inventory_and_mrp/inventory.html">&#xFEFF;🎓
-            Inventory&#xFEFF;</a>&#xFEFF;</p>
-        <p><strong>Purchase App </strong>helps you managing requests for proposal, your suppliers
-            and contractors.</p>
+        <div data-oe-role="status"
+            class="o_editor_banner user-select-none lh-1 d-flex align-items-center alert alert-warning pb-0 pt-3 o-contenteditable-false"
+            contenteditable="false" role="status">
+            <i data-oe-aria-label="Banner Warning" class="o_editor_banner_icon mb-3 fst-normal"
+                aria-label="Banner Warning">⚠️</i>
+            <div class="w-100 px-3 o_editor_banner_content o-contenteditable-true"
+                contenteditable="true">
+                <p>This flow may not be relevant for large and long projects.</p>
+                <p>You likely don't want the entire structural timber and the kitchen sinks delivered on-site the day after the contract is signed!</p>
+                <p>Use this for small kits or immediate "start-up" materials.</p>
+            </div>
+        </div>
+
+
+
+        <h5>Planned purchases &amp; dropshippings</h5>
+        <p>
+            Managing heavy materials like concrete or specialized machinery requires timing.
+            In fact, why store it at your warehouse when it can go straight to the site?
+        </p>
         <p>
             <strong>How to use it:</strong>
         </p>
         <ul>
             <li>
-                <strong>Purchase Orders:</strong> Create purchase order for needed products
-                    and services.
+                Create a new request for quotation (RFQ) selecting your supplier and add your products.
             </li>
             <li>
-                <strong>Product Prices:</strong> Capture prices by suppliers to make the
-                    best moves.
+                Send the RFQ the same way you do as quotations with your prospects, and iterate with your supplier on pricing.
+            </li>
+            <li>
+                On confirmation, this turns into a purchase order and create a receipt available from the smart button waiting for the delivery.
+            </li>
+            <li>
+                When the supplier trucks arrives, open the receipt and proceed to reception.
             </li>
         </ul>
         <div
@@ -629,39 +600,209 @@
                 aria-label="Banner Info">💡</i>
             <div class="o_editor_banner_content o-contenteditable-true w-100 px-3"
                 contenteditable="true">
-                <p>When ordering materials and services, fill in the analytic distribution to wire
-                    the expenses to specific projects.</p>
+                <p>For goods products tracked by quantity, your inventory gets updated on reception!</p>
             </div>
         </div>
-        <p>&#xFEFF;<a class="btn btn-fill-secondary"
-                href="https://www.odoo.com/documentation/latest/applications/inventory_and_mrp/purchase.html">&#xFEFF;🎓
-            Purchase&#xFEFF;</a>&#xFEFF;</p>
-        <p>
-             <br/>
-        </p>
-        <h3>💱 Automated cost update (Construction Developer)</h3>
-        <hr/>
-        <p>In some cases, suppliers may have products with heavily volatile prices.<br/>So that you can at best compute project costs during quoting, you need most up to date product costs.</p>
-        <p>We setup an automation so that your product costs and purchase opportunities reflect your last purchases as follow:</p>
         <ul>
-            <li>Triggers:</li>
-            <li class="oe-nested">
-                <ul>
-                    <li>On vendor bill confirmation.</li>
-                    <li>On purchase order confirmation.</li>
-                </ul>
+            <li>
+                Create a new order from your favorite vendor but this time, select the the Dropship option in the Deliver To field to bypass your local warehouse.
             </li>
-            <li>Cost updates:</li>
-            <li class="oe-nested">
-                <ul>
-                    <li>The product cost gets updated.</li>
-                    <li>The vendor price list accounts for this new price in product Purchase tab to capture better deals (on cost and quantity).</li>
-                </ul>
+            <li>
+                Point to the address you then want the delivery to take place and confirm the order as previously.
             </li>
         </ul>
+        <div
+            class="o_editor_banner user-select-none o-contenteditable-false lh-1 d-flex align-items-center alert alert-success pb-0 pt-3"
+            data-oe-role="status" contenteditable="false" role="status">
+            <i class="o_editor_banner_icon mb-3 fst-normal" data-oe-aria-label="Banner Success"
+                aria-label="Banner Success">✅</i>
+            <div class="o_editor_banner_content o-contenteditable-true w-100 px-3"
+                contenteditable="true">
+                <p>Drop shipping is the most efficient way to handle "just-in-time" heavy materials, reducing double-handling and transport risks.</p>
+            </div>
+        </div>
+        <p>&#xFEFF;<a
+                href="https://www.odoo.com/documentation/latest/applications/inventory_and_mrp/purchase.html"
+                class="btn btn-fill-secondary">&#xFEFF;🎓 Purchase&#xFEFF;</a>&#xFEFF;</p>
+
+
+        <h5>Replenishment made simple</h5>
         <p>
-             <br/>
+            Don't let a lack of screws or gloves stall a million-euro project.
+            Automated reordering rules take the mental burden off the inventory manager.
         </p>
+        <p>
+            <strong>How to use it:</strong>
+        </p>
+        <ul>
+            <li>
+                Open your product form and click the Reordering Rules smart button.
+            </li>
+            <li>
+                Hit the new button and define a minimum quantity (safety stock) and a maximum quantity (to avoid filling up your warehouse).
+            </li>
+            <li>
+                On a regular basis, open the Replenishment view from Inventory app Operations menu to follow up on what to reoder.
+            </li>
+            <li>
+                When the supplier trucks arrives, open the receipt and proceed to reception.
+            </li>
+        </ul>
+        <div
+            class="o_editor_banner user-select-none o-contenteditable-false lh-1 d-flex align-items-center alert alert-info pb-0 pt-3"
+            data-oe-role="status" contenteditable="false" role="status">
+            <i class="o_editor_banner_icon mb-3 fst-normal" data-oe-aria-label="Banner Info"
+                aria-label="Banner Info">💡</i>
+            <div class="o_editor_banner_content o-contenteditable-true w-100 px-3"
+                contenteditable="true">
+                <p>Automate the replenishment rules to create new RFQ as soon as your stock level reach the low limit!</p>
+            </div>
+        </div>
+        <div
+            class="o_editor_banner user-select-none o-contenteditable-false lh-1 d-flex align-items-center alert alert-success pb-0 pt-3"
+            data-oe-role="status" contenteditable="false" role="status">
+            <i class="o_editor_banner_icon mb-3 fst-normal" data-oe-aria-label="Banner Success"
+                aria-label="Banner Success">✅</i>
+            <div class="o_editor_banner_content o-contenteditable-true w-100 px-3"
+                contenteditable="true">
+                <p>This removes the administrative burden for low-cost, high-volume materials, ensuring your teams always have the essentials without manual counting.</p>
+            </div>
+        </div>
+        <p>&#xFEFF;<a
+                href="https://www.odoo.com/documentation/latest/applications/inventory_and_mrp/inventory.html"
+                class="btn btn-fill-secondary">&#xFEFF;🎓 Inventory&#xFEFF;</a>&#xFEFF;</p>
+
+
+        <h5>Automated cost update (Construction Developer)</h5>
+        <p>
+            In some cases, suppliers may have products with heavily volatile prices.
+            So that you can at best compute project costs during quoting, you need most up to date product costs.
+        </p>
+        <p>
+            Your product costs are updated on confirmed purchase orders and vendor bills to maintain your costs up to date.
+            This comes as well with the update of product vendor list accounting for new prices in product Purchase tab to capture better deals (on cost and quantity).
+        </p>
+        <div
+            class="o_editor_banner user-select-none o-contenteditable-false lh-1 d-flex align-items-center alert alert-success pb-0 pt-3"
+            data-oe-role="status" contenteditable="false" role="status">
+            <i class="o_editor_banner_icon mb-3 fst-normal" data-oe-aria-label="Banner Success"
+                aria-label="Banner Success">✅</i>
+            <div class="o_editor_banner_content o-contenteditable-true w-100 px-3"
+                contenteditable="true">
+                <p>All your future quotations leverage up to date product costs, helping you to secure your margin.</p>
+            </div>
+        </div>
+
+
+        <h5>Work item procurement (Construction Developer)</h5>
+        <p>
+            When leveraging the work items in your quotations, you disconnect from the standard Odoo flow and pause to plan the procurement.
+            Let's see how this works!
+        </p>
+        <p>
+            <strong>How to use it:</strong>
+        </p>
+        <ul>
+            <li>
+                Build your quotation using work items products.
+            </li>
+            <li>
+                From the sale order or project, open the Procurement view.
+                Here, you see the "shopping list" of all work item components required for the project.
+            </li>
+        </ul>
+        <div
+            class="o_editor_banner user-select-none o-contenteditable-false lh-1 d-flex align-items-center alert alert-success pb-0 pt-3"
+            data-oe-role="status" contenteditable="false" role="status">
+            <i class="o_editor_banner_icon mb-3 fst-normal" data-oe-aria-label="Banner Success"
+                aria-label="Banner Success">✅</i>
+            <div class="o_editor_banner_content o-contenteditable-true w-100 px-3"
+                contenteditable="true">
+                <p>
+                    Pro-tip leveraging the Work Breakdown Structure: Use the filters on Task Start Date to identify
+                    which materials are needed for the very next phase and plan for those items specifically.
+                </p>
+                <p>
+                    By aligning procurement with the project schedule, you avoid site congestion and ensure that 
+                    upcoming tasks are never delayed due to missing components.
+                </p>
+            </div>
+        </div>
+        <div data-oe-role="status"
+            class="o_editor_banner user-select-none lh-1 d-flex align-items-center alert alert-warning pb-0 pt-3 o-contenteditable-false"
+            contenteditable="false" role="status">
+            <i data-oe-aria-label="Banner Warning" class="o_editor_banner_icon mb-3 fst-normal"
+                aria-label="Banner Warning">⚠️</i>
+            <div class="w-100 px-3 o_editor_banner_content o-contenteditable-true"
+                contenteditable="true">
+                <p>Procurement actions are disabled for Work Items already marked as fully delivered on the Sale Order to prevent over-ordering.</p>
+                <p>When associated work items are partially delivered, the requested quantity is adjusted according to remaining delivery.</p>
+            </div>
+        </div>
+
+        <h5>Planning purchase and dropshipping orders</h5>
+        <p>
+            Select lines and hit the Purchase button to create a purchase order for those lines, or alternatively
+            the Dropship button to create a dropshipping RFQ with a delivery straight to the work site.
+        </p>
+        <div data-oe-role="status"
+            class="o_editor_banner user-select-none lh-1 d-flex align-items-center alert alert-warning pb-0 pt-3 o-contenteditable-false"
+            contenteditable="false" role="status">
+            <i data-oe-aria-label="Banner Warning" class="o_editor_banner_icon mb-3 fst-normal"
+                aria-label="Banner Warning">⚠️</i>
+            <div class="w-100 px-3 o_editor_banner_content o-contenteditable-true"
+                contenteditable="true">
+                <p>
+                    Creation of RFQ from the procurement view require you to define vendors for those products ahead,
+                    similarly to automated replenishment rules.
+                </p>
+            </div>
+        </div>
+
+        <h5>Planning transfers and managing on-site inventory</h5>
+        <p>
+            Select lines and fire the Transfer button to create a picking for the corresponding products from your warehouse stock to the work site.
+        </p>
+        <div
+            class="o_editor_banner user-select-none o-contenteditable-false lh-1 d-flex align-items-center alert alert-info pb-0 pt-3"
+            data-oe-role="status" contenteditable="false" role="status">
+            <i class="o_editor_banner_icon mb-3 fst-normal" data-oe-aria-label="Banner Info"
+                aria-label="Banner Info">💡</i>
+            <div class="o_editor_banner_content o-contenteditable-true w-100 px-3"
+                contenteditable="true">
+                <p>This capability requires the Construction On Site Inventory setting to be active.</p>
+            </div>
+        </div>
+        <p>
+            When projects last months, the "site" becomes a mini-warehouse.
+            This flow allows you to track exactly what is on the ground and what value is sitting at the job site.
+        </p>
+        <ul>
+            <li>
+                As materials arrive (via dropshippings or transfers), they are placed in the worksite location.
+            </li>
+            <li>
+                Monitor your <strong>on-site inventory</strong> in real-time from the Inventory app, Operations menu, Physical Inventory view. Group by or filter on location to easily get a project insights.
+            </li>
+            <li>
+                At the end of the project, easily retrieve a list of leftovers to transfer them back to your main warehouse.
+            </li>
+        </ul>
+        <div
+            class="o_editor_banner user-select-none o-contenteditable-false lh-1 d-flex align-items-center alert alert-success pb-0 pt-3"
+            data-oe-role="status" contenteditable="false" role="status">
+            <i class="o_editor_banner_icon mb-3 fst-normal" data-oe-aria-label="Banner Success"
+                aria-label="Banner Success">✅</i>
+            <div class="o_editor_banner_content o-contenteditable-true w-100 px-3"
+                contenteditable="true">
+                <p>
+                    This provides financial integrity by showing the real-time valuation of materials currently "at risk"
+                    on-site and allows for professional management of surplus stock at the end of the project.
+                </p>
+            </div>
+        </div>
+
+
         <h3>📆 Efficiently schedule the work </h3>
         <hr/>
         <p> The <strong>Planning app</strong> schedules tasks, allocates employees, and coordinates

--- a/construction/data/res_config_settings.xml
+++ b/construction/data/res_config_settings.xml
@@ -15,6 +15,7 @@
         <field name="group_analytic_accounting" eval="1"/>
         <field name="group_uom" eval="1"/>
         <field name="group_sale_order_template" eval="1"/>
+        <field name="module_stock_dropshipping" eval="True"/>
     </record>
 
     <function name="execute" model="res.config.settings">

--- a/construction_developer/__manifest__.py
+++ b/construction_developer/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Construction Developer',
-    'version': '1.12',
+    'version': '1.13',
     'category': 'Construction',
     'depends': [
         'base_industry_data',
@@ -9,6 +9,7 @@
     ],
     'data': [
         'data/res_config_settings.xml',
+        'data/stock_location.xml',
         'data/ir_model.xml',
         'data/ir_model_access.xml',
         'data/ir_model_fields.xml',

--- a/construction_developer/__manifest__.py
+++ b/construction_developer/__manifest__.py
@@ -5,9 +5,11 @@
     'depends': [
         'base_industry_data',
         'construction',
+        'stock_dropshipping',
         'web_studio',
     ],
     'data': [
+        'data/res_groups.xml',
         'data/res_config_settings.xml',
         'data/stock_location.xml',
         'data/ir_model.xml',
@@ -31,6 +33,7 @@
         'data/sale_order_template.xml',
         'data/sale_order_template_line.xml',
         'data/x_remark_category.xml',
+        'data/res_config_settings_post.xml',
     ],
     'demo': [
         'demo/res_partner.xml',
@@ -42,6 +45,7 @@
         'demo/x_remark_stage.xml',
         'demo/x_remark.xml',
         'demo/sale_order_post.xml',
+        'demo/purchase_order.xml',
         'demo/ir_attachment.xml',
     ],
     'assets': {

--- a/construction_developer/data/base_automation.xml
+++ b/construction_developer/data/base_automation.xml
@@ -129,6 +129,13 @@
         <field name="trigger_field_ids" eval="[(6, 0, [ref('x_is_margin_fixed_field_x_work_item')])]"/>
         <field name="filter_domain">[('x_is_margin_fixed', '=', False)]</field>
     </record>
+    <record id="automation_on_stock_move_create_or_write" model="base.automation">
+        <field name="name">Construction Developer: On stock move create or write</field>
+        <field name="model_id" ref="stock.model_stock_move"/>
+        <field name="action_server_ids" eval="[(6, 0, [ref('action_check_stock_move_validity')])]"/>
+        <field name="trigger">on_create_or_write</field>
+        <field name="on_change_field_ids" eval="[(6, 0, [ref('stock.field_stock_move__product_id')])]"/>
+    </record>
     <!-- 
     this is needed to set a default stage based on the project's
     -->

--- a/construction_developer/data/base_automation.xml
+++ b/construction_developer/data/base_automation.xml
@@ -15,12 +15,19 @@
         <field name="name">Construction Developer: Initialize Sales Order Line Sequence on Sales Order create or write</field>
         <field name="trigger_field_ids" eval="[(6, 0, [ref('sale.field_sale_order__order_line')])]"/>
     </record>
-    <record id="automation_create_delivery_location_on_so_confirm" model="base.automation">
+    <record id="automation_on_so_confirm" model="base.automation">
         <field name="model_id" ref="sale.model_sale_order"/>
         <field name="action_server_ids" eval="[(6, 0, [ref('action_create_delivery_location_on_sales_order_confirm')])]"/>
         <field name="trigger">on_create_or_write</field>
-        <field name="name">Construction Developer: Create delivery location on Sales Order confirm</field>
+        <field name="name">Construction Developer: On Sales Order confirm</field>
         <field name="trigger_field_ids" eval="[(6, 0, [ref('sale.field_sale_order__state')])]"/>
+    </record>
+    <record id="automation_on_so_analytic_account_change" model="base.automation">
+        <field name="model_id" ref="sale.model_sale_order"/>
+        <field name="action_server_ids" eval="[(6, 0, [ref('action_link_orphan_po_account')])]"/>
+        <field name="trigger">on_create_or_write</field>
+        <field name="name">Construction Developer: On Sales Order confirm</field>
+        <field name="trigger_field_ids" eval="[(6, 0, [ref('sale_project.field_sale_order__project_id'), ref('sale_project.field_sale_order__project_ids')])]"/>
     </record>
     <record id="automation_update_progress_increment_on_change" model="base.automation">
         <field name="name">Construction Developer: Update Sale Order Line Progress Increment on Quantity Increment change</field>

--- a/construction_developer/data/base_automation.xml
+++ b/construction_developer/data/base_automation.xml
@@ -15,6 +15,13 @@
         <field name="name">Construction Developer: Initialize Sales Order Line Sequence on Sales Order create or write</field>
         <field name="trigger_field_ids" eval="[(6, 0, [ref('sale.field_sale_order__order_line')])]"/>
     </record>
+    <record id="automation_create_delivery_location_on_so_confirm" model="base.automation">
+        <field name="model_id" ref="sale.model_sale_order"/>
+        <field name="action_server_ids" eval="[(6, 0, [ref('action_create_delivery_location_on_sales_order_confirm')])]"/>
+        <field name="trigger">on_create_or_write</field>
+        <field name="name">Construction Developer: Create delivery location on Sales Order confirm</field>
+        <field name="trigger_field_ids" eval="[(6, 0, [ref('sale.field_sale_order__state')])]"/>
+    </record>
     <record id="automation_update_progress_increment_on_change" model="base.automation">
         <field name="name">Construction Developer: Update Sale Order Line Progress Increment on Quantity Increment change</field>
         <field name="model_id" ref="sale.model_sale_order_line"/>

--- a/construction_developer/data/base_automation.xml
+++ b/construction_developer/data/base_automation.xml
@@ -135,6 +135,7 @@
         <field name="action_server_ids" eval="[(6, 0, [ref('action_check_stock_move_validity')])]"/>
         <field name="trigger">on_create_or_write</field>
         <field name="on_change_field_ids" eval="[(6, 0, [ref('stock.field_stock_move__product_id')])]"/>
+        <field name="filter_domain">[('picking_id', '!=', False)]</field>
     </record>
     <!-- 
     this is needed to set a default stage based on the project's

--- a/construction_developer/data/ir_actions_server.xml
+++ b/construction_developer/data/ir_actions_server.xml
@@ -395,18 +395,18 @@ if so_ids != [0]:
         <field name="model_id" ref="sale.model_sale_order"/>
         <field name="state">code</field>
         <field name="name">Construction Developer: Create Delivery Location</field>
-        <field name="code"><![CDATA[
-for so in records.filtered(lambda so: so.state != 'draft' and not so.partner_shipping_id.x_ws_location_id):
+        <field name="code">
+for so in records.filtered(lambda so: (so.state != 'draft' or env.context.get('force_loc', False)) and not so.partner_shipping_id.x_ws_location_id):
     wh = env['ir.model.data']._xmlid_to_res_id('construction_developer.stock_location_1')
     action = env['stock.location'].create({'name': f"{so.name} - {so.partner_id.name}", 'usage': 'internal', 'company_id': env.company.id, 'location_id': wh})
     so.partner_shipping_id['x_ws_location_id'] = action
-]]></field>
+</field>
     </record>
     <record id="action_wil_create_picking" model="ir.actions.server">
         <field name="model_id" ref="x_work_item_line_model"/>
         <field name="state">code</field>
         <field name="name">Construction Developer: Create Picking from Procurement</field>
-        <field name="code"><![CDATA[
+        <field name="code">
 pickings_by_so = {}
 picking_ids = set()
 moves_vals = []
@@ -418,251 +418,137 @@ for wil in records:
     # 1. Check demand
     if float_compare((delta := wil.x_demand - wil.x_consumed), 0, precision_digits=2) != 1:
         continue
-        
+
     so = wil.x_work_item_id.x_sale_order_line_id.order_id
-    so_id = so.id
-    worksite_loc = so.partner_shipping_id.x_ws_location_id
-    if not worksite_loc:
-        worksite_loc = env.ref('construction_developer.action_create_delivery_location_on_sales_order_confirm').with_context(force_loc=True, active_model='sale.order', active_ids=[so_id]).run()
-    
-    # 2. Find an open picking or create a new one
-    if so_id not in pickings_by_so:
+
+    # The SO's worksite is the picking destination
+    if not (worksite_loc := so.partner_shipping_id.x_ws_location_id):
+        worksite_loc = env.ref('construction_developer.action_create_delivery_location_on_sales_order_confirm') \
+                        .with_context(force_loc=True, active_model='sale.order', active_ids=[so.id]) \
+                        .run()
+
+    # Find an open picking for this SO or create a new one
+    # We need one picking per SO because the destination is the SO's worksite
+    if so.id not in pickings_by_so:
         existing_picking = env['stock.picking'].search([
             ('picking_type_id', '=', internal_type.id),
             ('location_dest_id', '=', worksite_loc.id),
             ('origin', '=', so.name), # Ensure it belongs to this specific SO
-            ('state', 'in', ['draft', 'waiting', 'confirmed']) # Do not add to 'assigned' (Ready) or 'done'
+            ('state', 'in', ['draft', 'waiting', 'confirmed']) # Do not add to 'assigned' (Ready) or 'done'/'cancelled'
         ], limit=1)
-        
-        if existing_picking:
-            pickings_by_so[so_id] = existing_picking
-        else:
-            pickings_by_so[so_id] = env['stock.picking'].create({
-                'picking_type_id': internal_type.id,
-                'location_id': stock_loc.id,
-                'location_dest_id': worksite_loc.id,
-                'origin': so.name,
-            })
-            
-        picking_ids.add(pickings_by_so[so_id].id)
 
-    # 3. Link the Work Item Line to the Picking via your Many2many field
-    pickings_by_so[so_id]['x_work_item_line_ids'] = [Command.link(wil.id)]
+        pickings_by_so[so.id] = existing_picking or env['stock.picking'].create({
+            'picking_type_id': internal_type.id,
+            'location_id': stock_loc.id,
+            'location_dest_id': worksite_loc.id,
+            'origin': so.name,
+        })
+        pickings_by_so[so.id]['x_work_item_line_ids'] = [Command.link(wil.id)]
     
+        picking_ids.add(pickings_by_so[so.id].id)
+
     # 4. Prepare the Stock Move
     moves_vals.append({
         'product_id': wil.x_product_id.id,
         'product_uom_qty': delta,
         'product_uom': wil.x_unit_id.id,
         'sale_line_id': wil.x_work_item_id.x_sale_order_line_id.id,
-        'picking_id': pickings_by_so[so_id].id,
+        'picking_id': pickings_by_so[so.id].id,
         'location_id': stock_loc.id,
         'location_dest_id': worksite_loc.id,
     })
 
-# 5. Bulk create the moves
-if moves_vals:
-    env['stock.move'].create(moves_vals)
+if moves_vals: env['stock.move'].create(moves_vals)
 
-# 6. Route the user
 if (picking_list := list(picking_ids)):
-    action = {
-        'type': 'ir.actions.act_window', 
-        'res_model': 'stock.picking', 
-        'name': 'Procurement Internal Transfer(s)',
-        'view_mode': 'list,form' if len(picking_list) > 1 else 'form',
-    } | ({'res_id': picking_list[0]} if len(picking_list) == 1 else {'domain': [('id', 'in', picking_list)]})
+    action = {'type': 'ir.actions.act_window', 'res_model': 'stock.picking', 'name': 'Procurement Internal Transfer(s)',
+              'view_mode': 'list,form' if len(picking_list) > 1 else 'form',
+             } | ({'res_id': picking_list[0]} if len(picking_list) == 1 else {'domain': [('id', 'in', picking_list)]})
 else:
-    action = {
-        'type': 'ir.actions.client', 
-        'tag': 'display_notification', 
-        'params': {
-            'message': 'No transfers needed (demand already fulfilled).', 
-            'type': 'warning', 
-            'next': {'type': 'ir.actions.client', 'tag': 'soft_reload'}
-        }
-    }
-]]></field>
+    action = {'type': 'ir.actions.client', 'tag': 'display_notification', 
+              'params': {'message': 'No transfers needed (demand already fulfilled).', 'type': 'warning', 'next': {'type': 'ir.actions.client', 'tag': 'soft_reload'}}}
+</field>
     </record>
     <record id="action_wil_create_purchase" model="ir.actions.server">
         <field name="model_id" ref="x_work_item_line_model"/>
         <field name="state">code</field>
         <field name="name">Construction Developer: Create Purchase Order from Procurement</field>
-        <field name="code"><![CDATA[
-pos_by_vendor = {}
-po_ids = set()
-po_lines_vals = []
-
-for wil in records:
-    # 1. Calculate delta and skip if no demand
-    if float_compare((delta := wil.x_demand - wil.x_consumed), 0, precision_digits=2) != 1:
-        continue
-        
-    product = wil.x_product_id
-    
-    # 2. Find the primary vendor for the product. 
-    # (If the product has no vendor configured under the 'Purchase' tab, we skip it)
-    vendor = product.seller_ids[0].partner_id if product.seller_ids else False
-    if not vendor:
-        continue
-        
-    vendor_id = vendor.id
-
-    # 1. Safely find the standard Receipt operation type for this specific company
-    so = wil.x_work_item_id.x_sale_order_line_id.order_id
-    receipt_picking_type = env['stock.picking.type'].search([
-        ('code', '=', 'incoming'),
-        ('company_id', '=', so.company_id.id)
-    ], limit=1)
-
-    if vendor_id not in pos_by_vendor:
-        # 2. Search for an open PO, making sure it is a STANDARD receipt, not a dropship
-        domain = [
-            ('partner_id', '=', vendor_id),
-            ('state', 'in', ['draft', 'sent'])
-        ]
-        if receipt_picking_type:
-            domain.append(('picking_type_id', '=', receipt_picking_type.id))
-            
-        existing_po = env['purchase.order'].search(domain, limit=1)
-        
-        if existing_po:
-            pos_by_vendor[vendor_id] = existing_po
-        else:
-            # 3. Create the new PO with the correct picking type
-            po_vals = {
-                'partner_id': vendor_id,
-            }
-            if receipt_picking_type:
-                po_vals['picking_type_id'] = receipt_picking_type.id
-                
-            pos_by_vendor[vendor_id] = env['purchase.order'].create(po_vals)
-            
-        po_ids.add(pos_by_vendor[vendor_id].id)
-        
-    # Link the PO back to the work item line if you created a field for it
-    pos_by_vendor[vendor_id]['x_work_item_line_ids'] = [Command.link(wil.id)]
-
-    # 4. Prepare the PO Line values
-    po_lines_vals.append({
-        'order_id': pos_by_vendor[vendor_id].id,
-        'product_id': product.id,
-        'product_qty': delta,
-        'product_uom_id': wil.x_unit_id.id,
-        'name': product.display_name, # The description is mandatory on PO lines
-    })
-
-# 5. Create all PO lines in bulk
-if po_lines_vals:
-    env['purchase.order.line'].create(po_lines_vals)
-
-# 6. Route the user
-if (po_list := list(po_ids)):
-    action = {
-        'type': 'ir.actions.act_window', 
-        'res_model': 'purchase.order', 
-        'name': 'Procurement Purchase Order(s)',
-        'view_mode': 'list,form' if len(po_list) > 1 else 'form',
-    } | ({'res_id': po_list[0]} if len(po_list) == 1 else {'domain': [('id', 'in', po_list)]})
-else:
-    # No POs created (delta was 0, or products had no vendors configured)
-    action = {
-        'type': 'ir.actions.client', 
-        'tag': 'display_notification', 
-        'params': {
-            'message': 'No Purchase Orders created. Check demand or ensure products have vendors configured.', 
-            'type': 'warning', 
-            'next': {'type': 'ir.actions.client', 'tag': 'soft_reload'}
-        }
-    }
-]]></field>
-    </record>
-    <record id="action_wil_create_dropshipping" model="ir.actions.server">
-        <field name="model_id" ref="x_work_item_line_model"/>
-        <field name="state">code</field>
-        <field name="name">Construction Developer: Create Dropshipping Order from Procurement</field>
-        <field name="code"><![CDATA[
-# Dictionary key will now be a tuple: (vendor_id, so_id)
+        <field name="code">
+dropship = env.context.get('dropship')
 pos_by_group = {}
 po_ids = set()
 po_lines_vals = []
 
-# Fetch the standard Odoo Dropship operation type
-dropship_picking_type = env['stock.picking.type'].search([('code', '=', 'dropship')], limit=1)
-
 for wil in records:
+    # Skip if no demand
     if float_compare((delta := wil.x_demand - wil.x_consumed), 0, precision_digits=2) != 1:
         continue
-        
+
     product = wil.x_product_id
-    
+
     vendor = product.seller_ids[0].partner_id if product.seller_ids else False
     if not vendor:
         continue
-        
-    so = wil.x_work_item_id.x_sale_order_line_id.order_id
-    group_key = (vendor.id, so.id)
-    
-    # Check for an open PO for this Vendor AND this specific Delivery Address
-    if group_key not in pos_by_group:
-        existing_po = env['purchase.order'].search([
-            ('partner_id', '=', vendor.id),
-            ('state', 'in', ['draft', 'sent']),
-            ('dest_address_id', '=', so.partner_shipping_id.id) # Crucial: Must match the destination!
-        ], limit=1)
-        
-        if existing_po:
-            pos_by_group[group_key] = existing_po
-        else:
-            po_vals = {
-                'partner_id': vendor.id,
-                'origin': so.name,
-                # Standard Odoo dropshipping maps the delivery to the Partner Address
-                'dest_address_id': so.partner_shipping_id.id, 
-            }
-            # Set Deliver To = "Dropship"
-            dropship_picking_type = env['stock.picking.type'].search([
-                ('code', '=', 'dropship'),
-                ('company_id', '=', so.company_id.id)
-            ], limit=1)
-            if dropship_picking_type:
-                po_vals['picking_type_id'] = dropship_picking_type.id
 
-            pos_by_group[group_key] = env['purchase.order'].create(po_vals)
-            
-        po_ids.add(pos_by_group[group_key].id)
-    
-    # Link the Work Item Line to the Dropship PO
+    so = wil.x_work_item_id.x_sale_order_line_id.order_id
+
+    # If not dropship: picking type = 'Receipts'
+    picking_type = env['stock.picking.type'].search([
+        ('code', '=', 'dropship' if dropship else 'incoming'),
+        ('company_id', '=', so.company_id.id),
+    ], limit=1)
+
+    # For dropshipping: grouped by Vendor + Specific Sale Order (for the unique address)
+    # For standard: grouped by Vendor + Company (to safely combine SOs in the same company)
+    group_key = (vendor.id, so.id) if dropship else (vendor.id, so.company_id.id)
+
+    if group_key not in pos_by_group:
+        # Search for an open PO
+        domain = [('partner_id', '=', vendor.id), ('state', 'in', ['draft', 'sent'])]
+        if dropship:
+            # Check for an open PO for this Vendor AND this specific Delivery Address
+            domain += [('dest_address_id', '=', so.partner_shipping_id.id)]
+        if picking_type:
+            domain += [('picking_type_id', '=', picking_type.id)]
+
+        existing_po = env['purchase.order'].search(domain, limit=1)
+
+        if not (po := existing_po):
+            po_vals = {'partner_id': vendor.id}
+            if dropship:
+                # Standard Odoo dropshipping maps the delivery to the Partner Address
+                po_vals |= {'origin': so.name, 'dest_address_id': so.partner_shipping_id.id}
+            if picking_type:
+                po_vals |= {'picking_type_id': picking_type.id}
+            po = env['purchase.order'].create(po_vals)
+
+        # Link existing or new PO
+        pos_by_group[group_key] = po
+        po_ids.add(po.id)
+
     pos_by_group[group_key]['x_work_item_line_ids'] = [Command.link(wil.id)]
 
     po_lines_vals.append({
         'order_id': pos_by_group[group_key].id,
         'product_id': product.id,
         'product_qty': delta,
-        'product_uom_id': wil.x_unit_id.id, 
+        'product_uom_id': wil.x_unit_id.id,
         'name': product.display_name,
+        'sale_order_id': so.id,
+        'sale_line_id': wil.x_work_item_id.x_sale_order_line_id.id,
     })
 
 if po_lines_vals:
     env['purchase.order.line'].create(po_lines_vals)
 
 if (po_list := list(po_ids)):
-    action = {
-        'type': 'ir.actions.act_window', 
-        'res_model': 'purchase.order', 
-        'name': 'Procurement Dropship PO(s)',
-        'view_mode': 'list,form' if len(po_list) > 1 else 'form',
-    } | ({'res_id': po_list[0]} if len(po_list) == 1 else {'domain': [('id', 'in', po_list)]})
+    action = {'type': 'ir.actions.act_window', 'res_model': 'purchase.order', 'name': 'Procurement Order(s)',
+              'view_mode': 'list,form' if len(po_list) > 1 else 'form',
+             } | ({'domain': [('id', 'in', po_list)]} if len(po_list) > 1 else {'res_id': po_list[0]})
 else:
-    action = {
-        'type': 'ir.actions.client', 
-        'tag': 'display_notification', 
-        'params': {
-            'message': 'No Purchase Orders created. Check demand or ensure products have vendors configured.', 
-            'type': 'warning', 
-            'next': {'type': 'ir.actions.client', 'tag': 'soft_reload'}
-        }
-    }
-]]></field>
+    # No POs created (delta was 0, or products had no vendors configured)
+    action = {'type': 'ir.actions.client', 'tag': 'display_notification', 
+              'params': {'message': 'No Purchase Orders created. Check demand or ensure products have vendors configured.', 'type': 'warning', 'next': {'type': 'ir.actions.client', 'tag': 'soft_reload'}}}
+</field>
     </record>
 </odoo>

--- a/construction_developer/data/ir_actions_server.xml
+++ b/construction_developer/data/ir_actions_server.xml
@@ -398,7 +398,8 @@ if so_ids != [0]:
         <field name="code"><![CDATA[
 for so in records.filtered(lambda so: so.state != 'draft' and not so.partner_shipping_id.x_ws_location_id):
     wh = env['ir.model.data']._xmlid_to_res_id('construction_developer.stock_location_1')
-    so.partner_shipping_id['x_ws_location_id'] = env['stock.location'].create({'name': f"{so.name} - {so.partner_id.name}", 'usage': 'internal', 'company_id': env.company.id, 'location_id': wh})
+    action = env['stock.location'].create({'name': f"{so.name} - {so.partner_id.name}", 'usage': 'internal', 'company_id': env.company.id, 'location_id': wh})
+    so.partner_shipping_id['x_ws_location_id'] = action
 ]]></field>
     </record>
     <record id="action_wil_create_picking" model="ir.actions.server">
@@ -406,49 +407,262 @@ for so in records.filtered(lambda so: so.state != 'draft' and not so.partner_shi
         <field name="state">code</field>
         <field name="name">Construction Developer: Create Picking from Procurement</field>
         <field name="code"><![CDATA[
-# For all selected work item lines: find the SO's address.
-# If the delivery address has a location, use it, otherwise create and link one
-pickings_per_so = {}
-created_pickings_per_so = {}
-
-for so in records.x_work_item_id.x_sale_order_line_id.order_id:
-    worksite_loc = so.partner_shipping_id.x_ws_location_id
-
-    pickings_per_so[so.id] = {
-        'picking_type_id': env.ref('stock.picking_type_internal').id,
-        'location_id': env.ref('stock.stock_location_stock').id,
-        'location_dest_id': worksite_loc.id,
-    }
-
+pickings_by_so = {}
+picking_ids = set()
 moves_vals = []
+
+internal_type = env.ref('stock.picking_type_internal')
+stock_loc = env.ref('stock.stock_location_stock')
+
 for wil in records:
-    so_id = wil.x_work_item_id.x_sale_order_line_id.order_id.id
+    # 1. Check demand
+    if float_compare((delta := wil.x_demand - wil.x_consumed), 0, precision_digits=2) != 1:
+        continue
+        
+    so = wil.x_work_item_id.x_sale_order_line_id.order_id
+    so_id = so.id
+    worksite_loc = so.partner_shipping_id.x_ws_location_id
+    if not worksite_loc:
+        worksite_loc = env.ref('construction_developer.action_create_delivery_location_on_sales_order_confirm').with_context(force_loc=True, active_model='sale.order', active_ids=[so_id]).run()
     
-    picking_vals = pickings_per_so[so_id]
-    
-    if float_compare((delta := wil.x_demand - wil.x_consumed), 0, precision_digits=2) == 1:
-        # 3. Create the picking if we haven't yet for this SO
-        if so_id not in created_pickings_per_so:
-            created_pickings_per_so[so_id] = env['stock.picking'].create(picking_vals)
+    # 2. Find an open picking or create a new one
+    if so_id not in pickings_by_so:
+        existing_picking = env['stock.picking'].search([
+            ('picking_type_id', '=', internal_type.id),
+            ('location_dest_id', '=', worksite_loc.id),
+            ('origin', '=', so.name), # Ensure it belongs to this specific SO
+            ('state', 'in', ['draft', 'waiting', 'confirmed']) # Do not add to 'assigned' (Ready) or 'done'
+        ], limit=1)
+        
+        if existing_picking:
+            pickings_by_so[so_id] = existing_picking
+        else:
+            pickings_by_so[so_id] = env['stock.picking'].create({
+                'picking_type_id': internal_type.id,
+                'location_id': stock_loc.id,
+                'location_dest_id': worksite_loc.id,
+                'origin': so.name,
+            })
             
-        created_pickings_per_so[so_id]['x_work_item_line_ids'] = [Command.link(wil.id)]
-        moves_vals.append({
-            'product_id': wil.x_product_id.id,
-            'product_uom_qty': delta,
-            'product_uom': wil.x_unit_id.id,
-            'picking_id': created_pickings_per_so[so_id].id,
-        })
+        picking_ids.add(pickings_by_so[so_id].id)
 
-moves = env['stock.move'].create(moves_vals)
+    # 3. Link the Work Item Line to the Picking via your Many2many field
+    pickings_by_so[so_id]['x_work_item_line_ids'] = [Command.link(wil.id)]
+    
+    # 4. Prepare the Stock Move
+    moves_vals.append({
+        'product_id': wil.x_product_id.id,
+        'product_uom_qty': delta,
+        'product_uom': wil.x_unit_id.id,
+        'sale_line_id': wil.x_work_item_id.x_sale_order_line_id.id,
+        'picking_id': pickings_by_so[so_id].id,
+        'location_id': stock_loc.id,
+        'location_dest_id': worksite_loc.id,
+    })
 
-if (pickings := [p.id for p in created_pickings_per_so.values()]):
+# 5. Bulk create the moves
+if moves_vals:
+    env['stock.move'].create(moves_vals)
+
+# 6. Route the user
+if (picking_list := list(picking_ids)):
     action = {
-        'type': 'ir.actions.act_window', 'res_model': 'stock.picking', 'name': 'Created Internal Transfer(s)',
-        'view_mode': ('list,' * (len(pickings) > 1)) + 'form',
-    } | ({'res_id': pickings[0]} if len(pickings) == 1 else {'domain': [('id', 'in', pickings)]})
+        'type': 'ir.actions.act_window', 
+        'res_model': 'stock.picking', 
+        'name': 'Procurement Internal Transfer(s)',
+        'view_mode': 'list,form' if len(picking_list) > 1 else 'form',
+    } | ({'res_id': picking_list[0]} if len(picking_list) == 1 else {'domain': [('id', 'in', picking_list)]})
 else:
-    # no pickings created (delta was 0 for all lines)
-    action = {'type': 'ir.actions.client', 'tag': 'display_notification', 'params': {'message': 'No transfers needed (demand already fulfilled).', 'type': 'warning', 'next': {'type': 'ir.actions.client', 'tag': 'soft_reload'}}}
+    action = {
+        'type': 'ir.actions.client', 
+        'tag': 'display_notification', 
+        'params': {
+            'message': 'No transfers needed (demand already fulfilled).', 
+            'type': 'warning', 
+            'next': {'type': 'ir.actions.client', 'tag': 'soft_reload'}
+        }
+    }
+]]></field>
+    </record>
+    <record id="action_wil_create_purchase" model="ir.actions.server">
+        <field name="model_id" ref="x_work_item_line_model"/>
+        <field name="state">code</field>
+        <field name="name">Construction Developer: Create Purchase Order from Procurement</field>
+        <field name="code"><![CDATA[
+pos_by_vendor = {}
+po_ids = set()
+po_lines_vals = []
+
+for wil in records:
+    # 1. Calculate delta and skip if no demand
+    if float_compare((delta := wil.x_demand - wil.x_consumed), 0, precision_digits=2) != 1:
+        continue
+        
+    product = wil.x_product_id
+    
+    # 2. Find the primary vendor for the product. 
+    # (If the product has no vendor configured under the 'Purchase' tab, we skip it)
+    vendor = product.seller_ids[0].partner_id if product.seller_ids else False
+    if not vendor:
+        continue
+        
+    vendor_id = vendor.id
+
+    # 1. Safely find the standard Receipt operation type for this specific company
+    so = wil.x_work_item_id.x_sale_order_line_id.order_id
+    receipt_picking_type = env['stock.picking.type'].search([
+        ('code', '=', 'incoming'),
+        ('company_id', '=', so.company_id.id)
+    ], limit=1)
+
+    if vendor_id not in pos_by_vendor:
+        # 2. Search for an open PO, making sure it is a STANDARD receipt, not a dropship
+        domain = [
+            ('partner_id', '=', vendor_id),
+            ('state', 'in', ['draft', 'sent'])
+        ]
+        if receipt_picking_type:
+            domain.append(('picking_type_id', '=', receipt_picking_type.id))
+            
+        existing_po = env['purchase.order'].search(domain, limit=1)
+        
+        if existing_po:
+            pos_by_vendor[vendor_id] = existing_po
+        else:
+            # 3. Create the new PO with the correct picking type
+            po_vals = {
+                'partner_id': vendor_id,
+            }
+            if receipt_picking_type:
+                po_vals['picking_type_id'] = receipt_picking_type.id
+                
+            pos_by_vendor[vendor_id] = env['purchase.order'].create(po_vals)
+            
+        po_ids.add(pos_by_vendor[vendor_id].id)
+        
+    # Link the PO back to the work item line if you created a field for it
+    pos_by_vendor[vendor_id]['x_work_item_line_ids'] = [Command.link(wil.id)]
+
+    # 4. Prepare the PO Line values
+    po_lines_vals.append({
+        'order_id': pos_by_vendor[vendor_id].id,
+        'product_id': product.id,
+        'product_qty': delta,
+        'product_uom_id': wil.x_unit_id.id,
+        'name': product.display_name, # The description is mandatory on PO lines
+    })
+
+# 5. Create all PO lines in bulk
+if po_lines_vals:
+    env['purchase.order.line'].create(po_lines_vals)
+
+# 6. Route the user
+if (po_list := list(po_ids)):
+    action = {
+        'type': 'ir.actions.act_window', 
+        'res_model': 'purchase.order', 
+        'name': 'Procurement Purchase Order(s)',
+        'view_mode': 'list,form' if len(po_list) > 1 else 'form',
+    } | ({'res_id': po_list[0]} if len(po_list) == 1 else {'domain': [('id', 'in', po_list)]})
+else:
+    # No POs created (delta was 0, or products had no vendors configured)
+    action = {
+        'type': 'ir.actions.client', 
+        'tag': 'display_notification', 
+        'params': {
+            'message': 'No Purchase Orders created. Check demand or ensure products have vendors configured.', 
+            'type': 'warning', 
+            'next': {'type': 'ir.actions.client', 'tag': 'soft_reload'}
+        }
+    }
+]]></field>
+    </record>
+    <record id="action_wil_create_dropshipping" model="ir.actions.server">
+        <field name="model_id" ref="x_work_item_line_model"/>
+        <field name="state">code</field>
+        <field name="name">Construction Developer: Create Dropshipping Order from Procurement</field>
+        <field name="code"><![CDATA[
+# Dictionary key will now be a tuple: (vendor_id, so_id)
+pos_by_group = {}
+po_ids = set()
+po_lines_vals = []
+
+# Fetch the standard Odoo Dropship operation type
+dropship_picking_type = env['stock.picking.type'].search([('code', '=', 'dropship')], limit=1)
+
+for wil in records:
+    if float_compare((delta := wil.x_demand - wil.x_consumed), 0, precision_digits=2) != 1:
+        continue
+        
+    product = wil.x_product_id
+    
+    vendor = product.seller_ids[0].partner_id if product.seller_ids else False
+    if not vendor:
+        continue
+        
+    so = wil.x_work_item_id.x_sale_order_line_id.order_id
+    group_key = (vendor.id, so.id)
+    
+    # Check for an open PO for this Vendor AND this specific Delivery Address
+    if group_key not in pos_by_group:
+        existing_po = env['purchase.order'].search([
+            ('partner_id', '=', vendor.id),
+            ('state', 'in', ['draft', 'sent']),
+            ('dest_address_id', '=', so.partner_shipping_id.id) # Crucial: Must match the destination!
+        ], limit=1)
+        
+        if existing_po:
+            pos_by_group[group_key] = existing_po
+        else:
+            po_vals = {
+                'partner_id': vendor.id,
+                'origin': so.name,
+                # Standard Odoo dropshipping maps the delivery to the Partner Address
+                'dest_address_id': so.partner_shipping_id.id, 
+            }
+            # Set Deliver To = "Dropship"
+            dropship_picking_type = env['stock.picking.type'].search([
+                ('code', '=', 'dropship'),
+                ('company_id', '=', so.company_id.id)
+            ], limit=1)
+            if dropship_picking_type:
+                po_vals['picking_type_id'] = dropship_picking_type.id
+
+            pos_by_group[group_key] = env['purchase.order'].create(po_vals)
+            
+        po_ids.add(pos_by_group[group_key].id)
+    
+    # Link the Work Item Line to the Dropship PO
+    pos_by_group[group_key]['x_work_item_line_ids'] = [Command.link(wil.id)]
+
+    po_lines_vals.append({
+        'order_id': pos_by_group[group_key].id,
+        'product_id': product.id,
+        'product_qty': delta,
+        'product_uom_id': wil.x_unit_id.id, 
+        'name': product.display_name,
+    })
+
+if po_lines_vals:
+    env['purchase.order.line'].create(po_lines_vals)
+
+if (po_list := list(po_ids)):
+    action = {
+        'type': 'ir.actions.act_window', 
+        'res_model': 'purchase.order', 
+        'name': 'Procurement Dropship PO(s)',
+        'view_mode': 'list,form' if len(po_list) > 1 else 'form',
+    } | ({'res_id': po_list[0]} if len(po_list) == 1 else {'domain': [('id', 'in', po_list)]})
+else:
+    action = {
+        'type': 'ir.actions.client', 
+        'tag': 'display_notification', 
+        'params': {
+            'message': 'No Purchase Orders created. Check demand or ensure products have vendors configured.', 
+            'type': 'warning', 
+            'next': {'type': 'ir.actions.client', 'tag': 'soft_reload'}
+        }
+    }
 ]]></field>
     </record>
 </odoo>

--- a/construction_developer/data/ir_actions_server.xml
+++ b/construction_developer/data/ir_actions_server.xml
@@ -402,82 +402,18 @@ for so in records.filtered(lambda so: (so.state != 'draft' or env.context.get('f
     so.partner_shipping_id['x_ws_location_id'] = action
 </field>
     </record>
-    <record id="action_wil_create_picking" model="ir.actions.server">
+    <record id="action_wil_procurement_shopping_list" model="ir.actions.server">
         <field name="model_id" ref="x_work_item_line_model"/>
         <field name="state">code</field>
-        <field name="name">Construction Developer: Create Picking from Procurement</field>
-        <field name="code">
-pickings_by_so = {}
-picking_ids = set()
-moves_vals = []
-
-internal_type = env.ref('stock.picking_type_internal')
-stock_loc = env.ref('stock.stock_location_stock')
-
-for wil in records:
-    # 1. Check demand
-    if float_compare((delta := wil.x_demand - wil.x_consumed), 0, precision_digits=2) != 1:
-        continue
-
-    so = wil.x_work_item_id.x_sale_order_line_id.order_id
-
-    # The SO's worksite is the picking destination
-    if not (worksite_loc := so.partner_shipping_id.x_ws_location_id):
-        worksite_loc = env.ref('construction_developer.action_create_delivery_location_on_sales_order_confirm') \
-                        .with_context(force_loc=True, active_model='sale.order', active_ids=[so.id]) \
-                        .run()
-
-    # Find an open picking for this SO or create a new one
-    # We need one picking per SO because the destination is the SO's worksite
-    if so.id not in pickings_by_so:
-        existing_picking = env['stock.picking'].search([
-            ('picking_type_id', '=', internal_type.id),
-            ('location_dest_id', '=', worksite_loc.id),
-            ('origin', '=', so.name), # Ensure it belongs to this specific SO
-            ('state', 'in', ['draft', 'waiting', 'confirmed']) # Do not add to 'assigned' (Ready) or 'done'/'cancelled'
-        ], limit=1)
-
-        pickings_by_so[so.id] = existing_picking or env['stock.picking'].create({
-            'picking_type_id': internal_type.id,
-            'location_id': stock_loc.id,
-            'location_dest_id': worksite_loc.id,
-            'origin': so.name,
-        })
-        pickings_by_so[so.id]['x_work_item_line_ids'] = [Command.link(wil.id)]
-    
-        picking_ids.add(pickings_by_so[so.id].id)
-
-    # 4. Prepare the Stock Move
-    moves_vals.append({
-        'product_id': wil.x_product_id.id,
-        'product_uom_qty': delta,
-        'product_uom': wil.x_unit_id.id,
-        'sale_line_id': wil.x_work_item_id.x_sale_order_line_id.id,
-        'picking_id': pickings_by_so[so.id].id,
-        'location_id': stock_loc.id,
-        'location_dest_id': worksite_loc.id,
-    })
-
-if moves_vals: env['stock.move'].create(moves_vals)
-
-if (picking_list := list(picking_ids)):
-    action = {'type': 'ir.actions.act_window', 'res_model': 'stock.picking', 'name': 'Procurement Internal Transfer(s)',
-              'view_mode': 'list,form' if len(picking_list) > 1 else 'form',
-             } | ({'res_id': picking_list[0]} if len(picking_list) == 1 else {'domain': [('id', 'in', picking_list)]})
-else:
-    action = {'type': 'ir.actions.client', 'tag': 'display_notification', 
-              'params': {'message': 'No transfers needed (demand already fulfilled).', 'type': 'warning', 'next': {'type': 'ir.actions.client', 'tag': 'soft_reload'}}}
-</field>
-    </record>
-    <record id="action_wil_create_purchase" model="ir.actions.server">
-        <field name="model_id" ref="x_work_item_line_model"/>
-        <field name="state">code</field>
-        <field name="name">Construction Developer: Create Purchase Order from Procurement</field>
+        <field name="name">Construction Developer: Procurement shopping list</field>
         <field name="code">
 dropship = env.context.get('dropship')
-pos_by_group = {}
-po_ids = set()
-po_lines_vals = []
+picking = env.context.get('picking')  # if not picking: dropship or PO
+pickings_or_po_by_group = {}
+pickings_or_po_ids = set()
+pickings_or_po_vals = []
+
+stock_loc = env.ref('stock.stock_location_stock')
 
 for wil in records:
     # Skip if no demand
@@ -485,70 +421,92 @@ for wil in records:
         continue
 
     product = wil.x_product_id
-
     vendor = product.seller_ids[0].partner_id if product.seller_ids else False
-    if not vendor:
+
+    if not picking and not vendor:  # can't process a PO without a vendor
         continue
 
     so = wil.x_work_item_id.x_sale_order_line_id.order_id
 
-    # If not dropship: picking type = 'Receipts'
-    picking_type = env['stock.picking.type'].search([
-        ('code', '=', 'dropship' if dropship else 'incoming'),
-        ('company_id', '=', so.company_id.id),
-    ], limit=1)
+    if picking:
+        picking_type = env.ref('stock.picking_type_internal')
+        group_key = so.id
 
-    # For dropshipping: grouped by Vendor + Specific Sale Order (for the unique address)
-    # For standard: grouped by Vendor + Company (to safely combine SOs in the same company)
-    group_key = (vendor.id, so.id) if dropship else (vendor.id, so.company_id.id)
+        # The SO's worksite is the picking destination
+        if not (worksite_loc := so.partner_shipping_id.x_ws_location_id):
+            worksite_loc = env.ref('construction_developer.action_create_delivery_location_on_sales_order_confirm') \
+                            .with_context(force_loc=True, active_model='sale.order', active_ids=[so.id]) \
+                            .run()
 
-    if group_key not in pos_by_group:
-        # Search for an open PO
-        domain = [('partner_id', '=', vendor.id), ('state', 'in', ['draft', 'sent'])]
-        if dropship:
-            # Check for an open PO for this Vendor AND this specific Delivery Address
-            domain += [('dest_address_id', '=', so.partner_shipping_id.id)]
+    else:
+        # If not dropship: picking type = 'Receipts'
+        picking_type = env['stock.picking.type'].search([
+            ('code', '=', 'dropship' if dropship else 'incoming'),
+            ('company_id', '=', so.company_id.id),
+        ], limit=1)
+        # For dropshipping: grouped by Vendor + Specific Sale Order (for the unique address)
+        # For standard: grouped by Vendor + Company (to safely combine SOs in the same company)
+        # Don't group different company products in the same PO
+        group_key = (vendor.id, so.id) if dropship else (vendor.id, so.company_id.id)
+
+    if group_key not in pickings_or_po_by_group:
+        domain = [('state', 'in', ['draft', 'waiting', 'confirmed'] if picking else ['draft', 'sent'])]
+        picking_or_po_vals = {'origin': so.name}
         if picking_type:
             domain += [('picking_type_id', '=', picking_type.id)]
-
-        existing_po = env['purchase.order'].search(domain, limit=1)
-
-        if not (po := existing_po):
-            po_vals = {'partner_id': vendor.id}
+            picking_or_po_vals |= {'picking_type_id': picking_type.id}
+        if picking:
+            domain += [('location_dest_id', '=', worksite_loc.id), ('origin', '=', so.name)]
+            picking_or_po_vals |= {
+                'location_id': stock_loc.id,
+                'location_dest_id': worksite_loc.id,
+            }
+        else:
+            domain += [('partner_id', '=', vendor.id)]
+            picking_or_po_vals |= {'partner_id': vendor.id}
             if dropship:
-                # Standard Odoo dropshipping maps the delivery to the Partner Address
-                po_vals |= {'origin': so.name, 'dest_address_id': so.partner_shipping_id.id}
-            if picking_type:
-                po_vals |= {'picking_type_id': picking_type.id}
-            po = env['purchase.order'].create(po_vals)
+                # Check for an open PO for this Vendor AND this specific Delivery Address
+                domain += [('dest_address_id', '=', so.partner_shipping_id.id)]
+                picking_or_po_vals |= {'dest_address_id': so.partner_shipping_id.id}
 
-        # Link existing or new PO
-        pos_by_group[group_key] = po
-        po_ids.add(po.id)
+        # Search for an open PO/picking
+        existing_picking_or_po = env['stock.picking' if picking else 'purchase.order'].search(domain, limit=1)
 
-    pos_by_group[group_key]['x_work_item_line_ids'] = [Command.link(wil.id)]
+        if not (picking_or_po := existing_picking_or_po):
+            picking_or_po = env['stock.picking' if picking else 'purchase.order'].create(picking_or_po_vals)
 
-    po_lines_vals.append({
-        'order_id': pos_by_group[group_key].id,
+        # Link existing or new PO/picking
+        pickings_or_po_by_group[group_key] = picking_or_po
+        pickings_or_po_ids.add(picking_or_po.id)
+
+    pickings_or_po_by_group[group_key]['x_work_item_line_ids'] = [Command.link(wil.id)]
+
+    pickings_or_po_vals.append({
         'product_id': product.id,
-        'product_qty': delta,
-        'product_uom_id': wil.x_unit_id.id,
+        'sale_line_id': wil.x_work_item_id.x_sale_order_line_id.id,
+        ('product_uom_qty' if picking else 'product_qty'): delta,
+        ('product_uom' if picking else 'product_uom_id'): wil.x_unit_id.id,
+        ('picking_id' if picking else 'order_id'): pickings_or_po_by_group[group_key].id,
+    } | ({
+        'location_id': stock_loc.id,
+        'location_dest_id': worksite_loc.id,
+    } if picking else {
         'name': product.display_name,
         'sale_order_id': so.id,
-        'sale_line_id': wil.x_work_item_id.x_sale_order_line_id.id,
-    })
+    }))
 
-if po_lines_vals:
-    env['purchase.order.line'].create(po_lines_vals)
+if pickings_or_po_vals: env['stock.move' if picking else 'purchase.order.line'].create(pickings_or_po_vals)
 
-if (po_list := list(po_ids)):
-    action = {'type': 'ir.actions.act_window', 'res_model': 'purchase.order', 'name': 'Procurement Order(s)',
-              'view_mode': 'list,form' if len(po_list) > 1 else 'form',
-             } | ({'domain': [('id', 'in', po_list)]} if len(po_list) > 1 else {'res_id': po_list[0]})
+if (pickings_or_po_list := list(pickings_or_po_ids)):
+    action = {'type': 'ir.actions.act_window', 'res_model': 'stock.picking' if picking else 'purchase.order', 'name': f'Procurement {'Internal Transfer' if picking else 'Order'}(s)',
+              'view_mode': 'list,form' if len(pickings_or_po_list) > 1 else 'form',
+             } | ({'domain': [('id', 'in', pickings_or_po_list)]} if len(pickings_or_po_list) > 1 else {'res_id': pickings_or_po_list[0]})
 else:
-    # No POs created (delta was 0, or products had no vendors configured)
-    action = {'type': 'ir.actions.client', 'tag': 'display_notification', 
-              'params': {'message': 'No Purchase Orders created. Check demand or ensure products have vendors configured.', 'type': 'warning', 'next': {'type': 'ir.actions.client', 'tag': 'soft_reload'}}}
+    po_message = "No Purchase Orders created. Check demand or ensure products have vendors configured."
+    picking_message = "No Purchase Orders created. Check demand or ensure products have vendors configured."
+    # Nothing created (delta was 0, or products had no vendors configured)
+    action = {'type': 'ir.actions.client', 'tag': 'display_notification',
+              'params': {'message': picking_message if picking else po_message, 'type': 'warning', 'next': {'type': 'ir.actions.client', 'tag': 'soft_reload'}}}
 </field>
     </record>
 </odoo>

--- a/construction_developer/data/ir_actions_server.xml
+++ b/construction_developer/data/ir_actions_server.xml
@@ -391,4 +391,64 @@ if so_ids != [0]:
     action['context']['active_ids'] = so_ids
 ]]></field>
     </record>
+    <record id="action_create_delivery_location_on_sales_order_confirm" model="ir.actions.server">
+        <field name="model_id" ref="sale.model_sale_order"/>
+        <field name="state">code</field>
+        <field name="name">Construction Developer: Create Delivery Location</field>
+        <field name="code"><![CDATA[
+for so in records.filtered(lambda so: so.state != 'draft' and not so.partner_shipping_id.x_ws_location_id):
+    wh = env['ir.model.data']._xmlid_to_res_id('construction_developer.stock_location_1')
+    so.partner_shipping_id['x_ws_location_id'] = env['stock.location'].create({'name': f"{so.name} - {so.partner_id.name}", 'usage': 'internal', 'company_id': env.company.id, 'location_id': wh})
+]]></field>
+    </record>
+    <record id="action_wil_create_picking" model="ir.actions.server">
+        <field name="model_id" ref="x_work_item_line_model"/>
+        <field name="state">code</field>
+        <field name="name">Construction Developer: Create Picking from Procurement</field>
+        <field name="code"><![CDATA[
+# For all selected work item lines: find the SO's address.
+# If the delivery address has a location, use it, otherwise create and link one
+pickings_per_so = {}
+created_pickings_per_so = {}
+
+for so in records.x_work_item_id.x_sale_order_line_id.order_id:
+    worksite_loc = so.partner_shipping_id.x_ws_location_id
+
+    pickings_per_so[so.id] = {
+        'picking_type_id': env.ref('stock.picking_type_internal').id,
+        'location_id': env.ref('stock.stock_location_stock').id,
+        'location_dest_id': worksite_loc.id,
+    }
+
+moves_vals = []
+for wil in records:
+    so_id = wil.x_work_item_id.x_sale_order_line_id.order_id.id
+    
+    picking_vals = pickings_per_so[so_id]
+    
+    if float_compare((delta := wil.x_demand - wil.x_consumed), 0, precision_digits=2) == 1:
+        # 3. Create the picking if we haven't yet for this SO
+        if so_id not in created_pickings_per_so:
+            created_pickings_per_so[so_id] = env['stock.picking'].create(picking_vals)
+            
+        created_pickings_per_so[so_id]['x_work_item_line_ids'] = [Command.link(wil.id)]
+        moves_vals.append({
+            'product_id': wil.x_product_id.id,
+            'product_uom_qty': delta,
+            'product_uom': wil.x_unit_id.id,
+            'picking_id': created_pickings_per_so[so_id].id,
+        })
+
+moves = env['stock.move'].create(moves_vals)
+
+if (pickings := [p.id for p in created_pickings_per_so.values()]):
+    action = {
+        'type': 'ir.actions.act_window', 'res_model': 'stock.picking', 'name': 'Created Internal Transfer(s)',
+        'view_mode': ('list,' * (len(pickings) > 1)) + 'form',
+    } | ({'res_id': pickings[0]} if len(pickings) == 1 else {'domain': [('id', 'in', pickings)]})
+else:
+    # no pickings created (delta was 0 for all lines)
+    action = {'type': 'ir.actions.client', 'tag': 'display_notification', 'params': {'message': 'No transfers needed (demand already fulfilled).', 'type': 'warning', 'next': {'type': 'ir.actions.client', 'tag': 'soft_reload'}}}
+]]></field>
+    </record>
 </odoo>

--- a/construction_developer/data/ir_actions_server.xml
+++ b/construction_developer/data/ir_actions_server.xml
@@ -50,26 +50,126 @@ record['x_quantity_increment'] = record.x_progress_increment * record.product_uo
         <field name="code"><![CDATA[
 lines = record.order_id.order_line.sorted(key=lambda sol: sol.sequence)
 i = [sol.sequence for sol in lines].index(record.sequence) + 1
+
 while (i < len(lines) and
       ((record.display_type == 'line_section' and lines[i].display_type != 'line_section')
       or (record.display_type == 'line_subsection' and (lines[i].display_type not in ['line_subsection', 'line_section'])))):
+
     if lines[i].x_is_deliverable:
         increment = min(lines[i].product_uom_qty - lines[i].qty_delivered, lines[i].product_uom_qty * record.x_progress_increment)  # ensures the total doesn't exceed lines[i].product_uom_qty
         percentage = increment / lines[i].product_uom_qty if lines[i].product_uom_qty else False
-        lines[i]['x_quantity_increment'], lines[i]['x_progress_increment'] = increment, percentage
+
+        lines[i].write({'x_quantity_increment': increment, 'x_progress_increment': percentage})
+
     i += 1
+
 record['x_progress_increment'] = 0
 action = {'type': 'ir.actions.client', 'tag': 'soft_reload'}
 ]]></field>
     </record>
     <record id="action_sol_update_qty_delivered" model="ir.actions.server">
-        <field name="code"><![CDATA[
-for sol in records: sol.write({'qty_delivered': sol.qty_delivered + sol.x_quantity_increment, 'x_quantity_increment': 0, 'x_progress_increment': 0})
-action = {'type': 'ir.actions.client', 'tag': 'display_notification', 'params': {'message': "Delivered quantities updated.", 'type': 'success', 'next': {'type': 'ir.actions.client', 'tag': 'soft_reload'}}}
-]]></field>
         <field name="model_id" ref="sale.model_sale_order_line"/>
         <field name="state">code</field>
         <field name="name">Construction Developer: Update Quantity Delivered</field>
+        <field name="code">
+# Only run the action if the setting is activated
+moves_action = env.ref('construction_developer.action_sol_create_procurement_moves')
+is_moves_active = env['ir.config_parameter'].sudo().get_param('construction.procurement_active') == 'True'
+returned_action = moves_action.run() if is_moves_active else False
+
+for sol in records: 
+    sol.write({
+        'qty_delivered': sol.qty_delivered + sol.x_quantity_increment, 
+        'x_quantity_increment': 0, 
+        'x_progress_increment': 0
+    })
+
+if returned_action:
+    action = returned_action
+else:
+    action = {'type': 'ir.actions.client', 'tag': 'display_notification', 'params': {'message': "Delivered quantities updated.", 'type': 'success', 'next': {'type': 'ir.actions.client', 'tag': 'soft_reload'}}}
+</field>
+    </record>
+
+    <record id="action_sol_create_procurement_moves" model="ir.actions.server">
+        <field name="model_id" ref="sale.model_sale_order_line"/>
+        <field name="state">code</field>
+        <field name="name">Construction Developer: Create Procurement Moves</field>
+        <field name="code">
+moves_vals = []
+pickings_by_so = {}
+
+out_type_id = env.ref('stock.picking_type_out').id
+dest_loc_id = env.ref('stock.stock_location_customers').id
+
+def add_moves_vals(moves_vals, line, increment, picking_id, source_loc_id, dest_loc_id, is_wil=False):
+    moves_vals.append({
+        'product_id':      (line.x_product_id if is_wil else line.product_id).id,
+        'product_uom_qty': (line.x_quantity if is_wil else 1) * increment,
+        'product_uom':     (line.x_unit_id if is_wil else line.product_uom).id,
+        'sale_line_id':    (line.x_work_item_id.x_sale_order_line_id if is_wil else line).id,
+        'picking_id': picking_id,
+        'location_id': source_loc_id,
+        'location_dest_id': dest_loc_id,
+    })
+
+# Pre-filter records to only those that actually need processing
+valid_sols = records.filtered(lambda sol: sol.x_quantity_increment > 0 and sol.order_id.partner_shipping_id.x_ws_location_id)
+
+# Map existing pickings to our SOs, or create them if missing
+if valid_sols:
+    valid_sos = valid_sols.order_id
+    source_loc_ids = valid_sos.mapped('partner_shipping_id.x_ws_location_id').ids
+    origins = [f"Progress Delivery: {so.name}" for so in valid_sos]
+
+    # ONE database query to find all draft pickings for these SOs
+    existing_pickings = env['stock.picking'].search([
+        ('picking_type_id', '=', out_type_id),
+        ('location_id', 'in', source_loc_ids),
+        ('location_dest_id', '=', dest_loc_id),
+        ('origin', 'in', origins),
+        ('state', '=', 'draft')
+    ])
+
+    draft_pickings_by_origin = {p.origin: p for p in existing_pickings}
+
+    for so in valid_sos:
+        origin = f"Progress Delivery: {so.name}"
+        if origin in draft_pickings_by_origin:
+            pickings_by_so[so.id] = draft_pickings_by_origin[origin]
+        else:
+            pickings_by_so[so.id] = env['stock.picking'].create({
+                'picking_type_id': out_type_id,
+                'location_id': so.partner_shipping_id.x_ws_location_id.id,
+                'location_dest_id': dest_loc_id,
+                'origin': origin,
+            })
+
+# Create the values for the moves
+for sol in records:
+    increment = sol.x_quantity_increment
+
+    if sol in valid_sols:
+        so = sol.order_id
+        picking = pickings_by_so[so.id]
+        source_loc_id = so.partner_shipping_id.x_ws_location_id.id
+
+        if sol.x_line_work_item_id:
+            for wil in sol.x_line_work_item_id.x_work_item_line_ids:
+                if wil.x_product_id and wil.x_product_id.is_storable:
+                    add_moves_vals(moves_vals, wil, increment, picking.id, source_loc_id, dest_loc_id, is_wil=True)
+        elif sol.product_id:
+            add_moves_vals(moves_vals, sol, increment, picking.id, source_loc_id, dest_loc_id, is_wil=False)
+
+moves = env['stock.move'].create(moves_vals) if moves_vals else False
+
+if moves and (pickings := moves.picking_id.ids):
+    action = {'type': 'ir.actions.act_window', 'res_model': 'stock.picking', 'name': "Transfers",
+              'view_mode': 'list,form' if len(pickings) > 1 else 'form',
+             } | ({'domain': [('id', 'in', pickings)]} if len(pickings) > 1 else {'res_id': pickings[0]})
+else:
+    action = False
+</field>
     </record>
     <!-- 
     server action and not compute because otherwise compute generates the same ID if
@@ -381,7 +481,7 @@ if so_ids != [0]:
 
             -- Individual Margin / Total Margin of all rows
             x_margin / NULLIF(SUM(x_margin) OVER (), 0) AS x_margin_share,
-            
+
             -- Individual Cost / Total Cost of all rows
             x_total_cost / NULLIF(SUM(x_total_cost) OVER (), 0) AS x_cost_share
 
@@ -391,6 +491,21 @@ if so_ids != [0]:
     action['context']['active_ids'] = so_ids
 ]]></field>
     </record>
+
+    <record id="action_check_stock_move_validity" model="ir.actions.server">
+        <field name="model_id" ref="stock.model_stock_move"/>
+        <field name="state">code</field>
+        <field name="name">Construction Developer: Check Stock Move Validity</field>
+        <field name="code">
+for move in records:
+    if (will := move.picking_id.move_ids.filtered(lambda m: m.x_work_item_line_ids and m.product_id == move.product_id and m.id != move.id)):
+        raise UserError(f"""There already exists lines for the product(s) you're trying to add.
+To avoid losing the Work Item Procurement information because of line merging, please update the existing lines instead.
+
+Product(s): {", ".join(will.product_id.mapped('display_name'))}""")
+</field>
+    </record>
+
     <record id="action_create_delivery_location_on_sales_order_confirm" model="ir.actions.server">
         <field name="model_id" ref="sale.model_sale_order"/>
         <field name="state">code</field>
@@ -398,115 +513,219 @@ if so_ids != [0]:
         <field name="code">
 for so in records.filtered(lambda so: (so.state != 'draft' or env.context.get('force_loc', False)) and not so.partner_shipping_id.x_ws_location_id):
     wh = env['ir.model.data']._xmlid_to_res_id('construction_developer.stock_location_1')
-    action = env['stock.location'].create({'name': f"{so.name} - {so.partner_id.name}", 'usage': 'internal', 'company_id': env.company.id, 'location_id': wh})
+    action = env['stock.location'].create({'name': f"{so.partner_shipping_id.name}", 'usage': 'internal', 'company_id': env.company.id, 'location_id': wh})
     so.partner_shipping_id['x_ws_location_id'] = action
 </field>
     </record>
-    <record id="action_wil_procurement_shopping_list" model="ir.actions.server">
+    <record id="action_wil_procurement_po" model="ir.actions.server">
         <field name="model_id" ref="x_work_item_line_model"/>
         <field name="state">code</field>
-        <field name="name">Construction Developer: Procurement shopping list</field>
+        <field name="name">Construction Developer: Procurement Purchase Orders</field>
         <field name="code">
 dropship = env.context.get('dropship')
-picking = env.context.get('picking')  # if not picking: dropship or PO
-pickings_or_po_by_group = {}
-pickings_or_po_ids = set()
-pickings_or_po_vals = []
+quantities = env.context.get('wi_quantities', {})
 
-stock_loc = env.ref('stock.stock_location_stock')
+pos_by_group = {}
+touched_po_ids = set()
+
+pols_by_key = {}
+existing_pols_by_key = {}
 
 for wil in records:
-    # Skip if no demand
-    if float_compare((delta := wil.x_demand - wil.x_consumed), 0, precision_digits=2) != 1:
+    delta = quantities.get(wil.x_work_item_id, wil.x_demand - wil.x_consumed)
+    if float_compare(delta, 0, precision_digits=2) != 1:
         continue
 
     product = wil.x_product_id
     vendor = product.seller_ids[0].partner_id if product.seller_ids else False
-
-    if not picking and not vendor:  # can't process a PO without a vendor
+    if not vendor:
         continue
 
     so = wil.x_work_item_id.x_sale_order_line_id.order_id
 
-    if picking:
-        picking_type = env.ref('stock.picking_type_internal')
-        group_key = so.id
+    # Resolve Analytic Account early for grouping
+    project = env['project.project'].search(['|', ('sale_order_id', '=', so.id), ('sale_line_id', 'in', so.order_line.ids), ('account_id', '!=', False)], limit=1)
+    account_id = project.account_id.id if project else False
 
-        # The SO's worksite is the picking destination
-        if not (worksite_loc := so.partner_shipping_id.x_ws_location_id):
-            worksite_loc = env.ref('construction_developer.action_create_delivery_location_on_sales_order_confirm') \
-                            .with_context(force_loc=True, active_model='sale.order', active_ids=[so.id]) \
-                            .run()
+    picking_type = env['stock.picking.type'].search([
+        ('code', '=', 'dropship' if dropship else 'incoming'),
+        ('company_id', '=', so.company_id.id),
+    ], limit=1)
 
-    else:
-        # If not dropship: picking type = 'Receipts'
-        picking_type = env['stock.picking.type'].search([
-            ('code', '=', 'dropship' if dropship else 'incoming'),
-            ('company_id', '=', so.company_id.id),
-        ], limit=1)
-        # For dropshipping: grouped by Vendor + Specific Sale Order (for the unique address)
-        # For standard: grouped by Vendor + Company (to safely combine SOs in the same company)
-        # Don't group different company products in the same PO
-        group_key = (vendor.id, so.id) if dropship else (vendor.id, so.company_id.id)
+    group_key = (vendor.id, so.id) if dropship else (vendor.id, so.company_id.id)
 
-    if group_key not in pickings_or_po_by_group:
-        domain = [('state', 'in', ['draft', 'waiting', 'confirmed'] if picking else ['draft', 'sent'])]
-        picking_or_po_vals = {'origin': so.name}
+    # Header Logic
+    if group_key not in pos_by_group:
+        domain = [('state', 'in', ['draft', 'sent']), ('partner_id', '=', vendor.id)]
+        po_vals = {'origin': so.name, 'partner_id': vendor.id}
+
         if picking_type:
             domain += [('picking_type_id', '=', picking_type.id)]
-            picking_or_po_vals |= {'picking_type_id': picking_type.id}
-        if picking:
-            domain += [('location_dest_id', '=', worksite_loc.id), ('origin', '=', so.name)]
-            picking_or_po_vals |= {
+            po_vals |= {'picking_type_id': picking_type.id}
+
+        if dropship:
+            domain += [('dest_address_id', '=', so.partner_shipping_id.id)]
+            po_vals |= {'dest_address_id': so.partner_shipping_id.id}
+
+        if not (po := env['purchase.order'].search(domain, limit=1)):
+            po = env['purchase.order'].create(po_vals)
+
+        pos_by_group[group_key] = po
+
+        # Map existing lines: JSON keys are strings, so we convert back to int safely
+        for pol in po.order_line:
+            dist = pol.analytic_distribution or {}
+            pol_account_id = int(list(dist.keys())[0]) if dist else False
+            existing_pols_by_key[(po.id, pol.product_id.id, pol_account_id)] = pol
+
+    po = pos_by_group[group_key]
+    line_key = (po.id, product.id, account_id)
+
+    # Line Logic
+    if line_key in existing_pols_by_key:
+        existing_pol = existing_pols_by_key[line_key]
+        existing_pol.write({
+            'product_qty': existing_pol.product_qty + delta,
+            'x_work_item_line_ids': [Command.link(wil.id)]
+        })
+        touched_po_ids.add(po.id)
+    else:
+        if line_key not in pols_by_key:
+            pols_by_key[line_key] = {
+                'order_id': po.id,
+                'name': product.display_name,
+                'product_id': product.id,
+                'product_qty': 0.0,
+                'product_uom_id': wil.x_unit_id.id,
+                'sale_order_id': so.id,
+                'sale_line_id': wil.x_work_item_id.x_sale_order_line_id.id,
+                'x_work_item_line_ids': [],
+                'analytic_distribution': {account_id: 100} if account_id else False
+            }
+        pols_by_key[line_key]['product_qty'] += delta
+        pols_by_key[line_key]['x_work_item_line_ids'].append(Command.link(wil.id))
+
+action = env.ref('construction_developer.action_display_form_or_list').with_context(
+    vals_list=list(pols_by_key.values()),
+    picking=False,
+    existing_header_ids=list(touched_po_ids)
+).run()
+</field>
+    </record>
+
+    <record id="action_wil_procurement_transfer" model="ir.actions.server">
+        <field name="model_id" ref="x_work_item_line_model"/>
+        <field name="state">code</field>
+        <field name="name">Construction Developer: Procurement Internal Transfers</field>
+        <field name="code">
+quantities = env.context.get('wi_quantities', {})
+pickings_by_so = {}
+touched_picking_ids = set()
+
+moves_by_product_key = {}
+existing_moves_by_key = {}
+
+stock_loc = env.ref('stock.stock_location_stock')
+picking_type = env.ref('stock.picking_type_internal')
+
+for wil in records:
+    delta = quantities.get(wil.x_work_item_id, wil.x_demand - wil.x_consumed)
+    if float_compare(delta, 0, precision_digits=2) != 1:
+        continue
+
+    product = wil.x_product_id
+    so = wil.x_work_item_id.x_sale_order_line_id.order_id
+
+    # Create if no location (SO not confirmed or other edge case)
+    if not (worksite_loc := so.partner_shipping_id.x_ws_location_id):
+        worksite_loc = env.ref('construction_developer.action_create_delivery_location_on_sales_order_confirm') \
+                        .with_context(force_loc=True, active_model='sale.order', active_ids=[so.id]) \
+                        .run()
+
+    # Find existing picking to add to if exists
+    if so.id not in pickings_by_so:
+        existing_picking = env['stock.picking'].search([
+            ('state', 'in', ['draft', 'waiting', 'confirmed']),
+            ('picking_type_id', '=', picking_type.id),
+            ('location_dest_id', '=', worksite_loc.id),
+            ('origin', '=', so.name)
+        ], limit=1)
+
+        if not (picking := existing_picking):
+            picking = env['stock.picking'].create({
+                'origin': so.name,
+                'picking_type_id': picking_type.id,
                 'location_id': stock_loc.id,
                 'location_dest_id': worksite_loc.id,
+            })
+
+        pickings_by_so[so.id] = picking
+
+        # Map existing lines to prevent duplicates
+        for move in picking.move_ids:
+            existing_moves_by_key[(picking.id, move.product_id.id)] = move
+
+
+    picking = pickings_by_so[so.id]
+    line_key = (picking.id, product.id)
+
+    # Aggregate lines if already exist
+    if line_key in existing_moves_by_key:
+        existing_moves_by_key[line_key].write({
+            'product_uom_qty': existing_moves_by_key[line_key].product_uom_qty + delta,
+            'x_work_item_line_ids': [Command.link(wil.id)]
+        })
+        touched_picking_ids.add(picking.id)
+    else:
+        if line_key not in moves_by_product_key:
+            moves_by_product_key[line_key] = {
+                'product_id': product.id,
+                'product_uom_qty': 0.0,
+                'product_uom': wil.x_unit_id.id,
+                'picking_id': picking.id,
+                'location_id': stock_loc.id,
+                'location_dest_id': worksite_loc.id,
+                'x_work_item_line_ids': [],
             }
-        else:
-            domain += [('partner_id', '=', vendor.id)]
-            picking_or_po_vals |= {'partner_id': vendor.id}
-            if dropship:
-                # Check for an open PO for this Vendor AND this specific Delivery Address
-                domain += [('dest_address_id', '=', so.partner_shipping_id.id)]
-                picking_or_po_vals |= {'dest_address_id': so.partner_shipping_id.id}
+        moves_by_product_key[line_key]['product_uom_qty'] += delta
+        moves_by_product_key[line_key]['x_work_item_line_ids'].append(Command.link(wil.id))
 
-        # Search for an open PO/picking
-        existing_picking_or_po = env['stock.picking' if picking else 'purchase.order'].search(domain, limit=1)
+action = env.ref('construction_developer.action_display_form_or_list').with_context(
+    vals_list=list(moves_by_product_key.values()),
+    picking=True,
+    existing_header_ids=list(touched_picking_ids)
+).run()
+</field>
+    </record>
 
-        if not (picking_or_po := existing_picking_or_po):
-            picking_or_po = env['stock.picking' if picking else 'purchase.order'].create(picking_or_po_vals)
+    <record id="action_display_form_or_list" model="ir.actions.server">
+        <field name="model_id" ref="base.model_ir_actions_server"/>
+        <field name="state">code</field>
+        <field name="name">Construction Developer: Procurement Routing Helper</field>
+        <field name="code">
+vals_list = env.context.get('vals_list', [])
+picking = env.context.get('picking')
+header_ids = set(env.context.get('existing_header_ids', []))
 
-        # Link existing or new PO/picking
-        pickings_or_po_by_group[group_key] = picking_or_po
-        pickings_or_po_ids.add(picking_or_po.id)
+# Create new lines if any, and extract their parent PO/Picking IDs
+if vals_list:
+    new_lines = env['stock.move' if picking else 'purchase.order.line'].create(vals_list)
+    header_ids.update(new_lines.mapped('picking_id' if picking else 'order_id').ids)
 
-    pickings_or_po_by_group[group_key]['x_work_item_line_ids'] = [Command.link(wil.id)]
+header_ids = list(header_ids)
 
-    pickings_or_po_vals.append({
-        'product_id': product.id,
-        'sale_line_id': wil.x_work_item_id.x_sale_order_line_id.id,
-        ('product_uom_qty' if picking else 'product_qty'): delta,
-        ('product_uom' if picking else 'product_uom_id'): wil.x_unit_id.id,
-        ('picking_id' if picking else 'order_id'): pickings_or_po_by_group[group_key].id,
-    } | ({
-        'location_id': stock_loc.id,
-        'location_dest_id': worksite_loc.id,
-    } if picking else {
-        'name': product.display_name,
-        'sale_order_id': so.id,
-    }))
+empty_message = 'No transfers needed (demand already fulfilled).' if picking else 'No Purchase Orders created. Check demand and ensure products have vendors configured.'
 
-if pickings_or_po_vals: env['stock.move' if picking else 'purchase.order.line'].create(pickings_or_po_vals)
-
-if (pickings_or_po_list := list(pickings_or_po_ids)):
-    action = {'type': 'ir.actions.act_window', 'res_model': 'stock.picking' if picking else 'purchase.order', 'name': f'Procurement {'Internal Transfer' if picking else 'Order'}(s)',
-              'view_mode': 'list,form' if len(pickings_or_po_list) > 1 else 'form',
-             } | ({'domain': [('id', 'in', pickings_or_po_list)]} if len(pickings_or_po_list) > 1 else {'res_id': pickings_or_po_list[0]})
+if header_ids:
+    action = {
+        'type': 'ir.actions.act_window',
+        'name': 'Procurement ' + ('Transfers' if picking else 'Orders'),
+        'res_model': 'stock.picking' if picking else 'purchase.order',
+        'view_mode': 'list,form' if len(header_ids) > 1 else 'form',
+    } | ({'domain': [('id', 'in', header_ids)]} if len(header_ids) > 1 else {'res_id': header_ids[0]})
 else:
-    po_message = "No Purchase Orders created. Check demand or ensure products have vendors configured."
-    picking_message = "No Purchase Orders created. Check demand or ensure products have vendors configured."
-    # Nothing created (delta was 0, or products had no vendors configured)
     action = {'type': 'ir.actions.client', 'tag': 'display_notification',
-              'params': {'message': picking_message if picking else po_message, 'type': 'warning', 'next': {'type': 'ir.actions.client', 'tag': 'soft_reload'}}}
+              'params': {'message': empty_message, 'type': 'warning', 'next': {'type': 'ir.actions.client', 'tag': 'soft_reload'}}}
 </field>
     </record>
 </odoo>

--- a/construction_developer/data/ir_actions_server.xml
+++ b/construction_developer/data/ir_actions_server.xml
@@ -164,6 +164,7 @@ for sol in records:
 moves = env['stock.move'].create(moves_vals) if moves_vals else False
 
 if moves and (pickings := moves.picking_id.ids):
+    moves.picking_id.button_validate()
     action = {'type': 'ir.actions.act_window', 'res_model': 'stock.picking', 'name': "Transfers",
               'view_mode': 'list,form' if len(pickings) > 1 else 'form',
              } | ({'domain': [('id', 'in', pickings)]} if len(pickings) > 1 else {'res_id': pickings[0]})

--- a/construction_developer/data/ir_actions_server.xml
+++ b/construction_developer/data/ir_actions_server.xml
@@ -492,17 +492,20 @@ if so_ids != [0]:
 ]]></field>
     </record>
 
-    <record id="action_check_stock_move_validity" model="ir.actions.server">
+<record id="action_check_stock_move_validity" model="ir.actions.server">
         <field name="model_id" ref="stock.model_stock_move"/>
         <field name="state">code</field>
         <field name="name">Construction Developer: Check Stock Move Validity</field>
         <field name="code">
-for move in records:
-    if (will := move.picking_id.move_ids.filtered(lambda m: m.x_work_item_line_ids and m.product_id == move.product_id and m.id != move.id)):
-        raise UserError(f"""There already exists lines for the product(s) you're trying to add.
+for move in records:        
+    will = move.picking_id.move_ids.filtered(lambda m: m.x_work_item_line_ids and m.product_id == move.product_id and m.id != move.id)
+
+    if will and not any(move.x_work_item_line_ids == w.x_work_item_line_ids for w in will):
+            raise UserError(f"""There already exist lines for the product you're trying to add.
 To avoid losing the Work Item Procurement information because of line merging, please update the existing lines instead.
 
-Product(s): {", ".join(will.product_id.mapped('display_name'))}""")
+Product: {will[0].product_id.display_name}
+""")
 </field>
     </record>
 
@@ -648,7 +651,7 @@ for wil in records:
             ('state', 'in', ['draft', 'waiting', 'confirmed']),
             ('picking_type_id', '=', picking_type.id),
             ('location_dest_id', '=', worksite_loc.id),
-            ('origin', '=', so.name)
+            ('sale_id', '=', so.id)
         ], limit=1)
 
         if not (picking := existing_picking):
@@ -657,6 +660,7 @@ for wil in records:
                 'picking_type_id': picking_type.id,
                 'location_id': stock_loc.id,
                 'location_dest_id': worksite_loc.id,
+                'sale_id': so.id,
             })
 
         pickings_by_so[so.id] = picking
@@ -686,6 +690,7 @@ for wil in records:
                 'location_id': stock_loc.id,
                 'location_dest_id': worksite_loc.id,
                 'x_work_item_line_ids': [],
+                'sale_line_id': wil.x_work_item_id.x_sale_order_line_id.id
             }
         moves_by_product_key[line_key]['product_uom_qty'] += delta
         moves_by_product_key[line_key]['x_work_item_line_ids'].append(Command.link(wil.id))

--- a/construction_developer/data/ir_actions_server.xml
+++ b/construction_developer/data/ir_actions_server.xml
@@ -520,6 +520,23 @@ for so in records.filtered(lambda so: (so.state != 'draft' or env.context.get('f
     so.partner_shipping_id['x_ws_location_id'] = action
 </field>
     </record>
+
+    <record id="action_link_orphan_po_account" model="ir.actions.server">
+        <field name="model_id" ref="sale.model_sale_order"/>
+        <field name="state">code</field>
+        <field name="name">Construction Developer: Link Orphan POL Account</field>
+        <field name="code">
+if (valid_sos := records.filtered(lambda so: so.state != 'draft' and so.project_account_id)):
+    orphan_pol = env['purchase.order.line'].search([
+        ('x_wil_so_ids', 'in', valid_sos.ids),
+        ('analytic_distribution', '=', False),
+    ])
+
+    for pol in orphan_pol:
+        pol['analytic_distribution'] = {pol.sale_line_id.order_id.project_account_id.id: 100}
+</field>
+    </record>
+
     <record id="action_wil_procurement_po" model="ir.actions.server">
         <field name="model_id" ref="x_work_item_line_model"/>
         <field name="state">code</field>
@@ -603,7 +620,7 @@ for wil in records:
                 'sale_order_id': so.id,
                 'sale_line_id': wil.x_work_item_id.x_sale_order_line_id.id,
                 'x_work_item_line_ids': [],
-                'analytic_distribution': {account_id: 100} if account_id else False
+                'analytic_distribution': {project.account_id.id: 100} if account_id else False
             }
         pols_by_key[line_key]['product_qty'] += delta
         pols_by_key[line_key]['x_work_item_line_ids'].append(Command.link(wil.id))

--- a/construction_developer/data/ir_model_fields.xml
+++ b/construction_developer/data/ir_model_fields.xml
@@ -420,6 +420,33 @@ for record in self:
         <field name="relation">x_work_item</field>
         <field name="store" eval="False"/>
     </record>
+    <record id="field_res_partner_x_ws_location_id" model="ir.model.fields">
+        <field name="model_id" ref="base.model_res_partner"/>
+        <field name="ttype">many2one</field>
+        <field name="relation">stock.location</field>
+        <field name="name">x_ws_location_id</field>
+        <field name="field_description">Worksite Location</field>
+    </record>
+
+    <record id="field_stock_picking_x_work_item_line_ids" model="ir.model.fields">
+        <field name="name">x_work_item_line_ids</field>
+        <field name="ttype">many2many</field>
+        <field name="field_description">Work Item Line</field>
+        <field name="model_id" ref="stock.model_stock_picking"/>
+        <field name="relation">x_work_item_line</field>
+        <field name="readonly" eval="True"/>
+        <field name="copied" eval="True"/>
+    </record>
+
+    <record id="field_x_work_item_line_x_picking_ids" model="ir.model.fields">
+        <field name="name">x_picking_ids</field>
+        <field name="ttype">many2many</field>
+        <field name="field_description">Stock Pickings</field>
+        <field name="model_id" ref="x_work_item_line_model"/>
+        <field name="readonly" eval="True"/>
+        <field name="relation">stock.picking</field>
+        <field name="relation_field">x_work_item_line_ids</field>
+    </record>
 
 <!-- 
     Remarks: New Models
@@ -844,10 +871,9 @@ for r in self: r['x_demand'] = (r.x_quantity * (line.product_uom_qty if (line :=
         <field name="field_description">Consumed</field>
         <field name="model_id" ref="x_work_item_line_model"/>
         <field name="readonly" eval="True"/>
-        <field name="store" eval="False"/>
         <field name="depends">x_demand,x_work_item_id,x_work_item_id.x_sale_order_line_id,x_work_item_id.x_sale_order_line_id.x_cost_nature,x_work_item_id.x_sale_order_line_id.x_delivered_progress</field>
         <field name="compute"><![CDATA[
-for r in self: r['x_consumed'] = r.x_demand if (r.x_work_item_id.x_sale_order_line_id.x_cost_nature == 'material' and r.x_work_item_id.x_sale_order_line_id.x_delivered_progress == 100) else 0
+for r in self: r['x_consumed'] = 0.01 * r.x_demand * r.x_work_item_id.x_sale_order_line_id.x_delivered_progress
 ]]></field>
     </record>
 

--- a/construction_developer/data/ir_model_fields.xml
+++ b/construction_developer/data/ir_model_fields.xml
@@ -448,6 +448,26 @@ for record in self:
         <field name="relation_field">x_work_item_line_ids</field>
     </record>
 
+    <record id="field_purchase_order_x_work_item_line_ids" model="ir.model.fields">
+        <field name="name">x_work_item_line_ids</field>
+        <field name="ttype">many2many</field>
+        <field name="field_description">Work Item Line</field>
+        <field name="model_id" ref="purchase.model_purchase_order"/>
+        <field name="relation">x_work_item_line</field>
+        <field name="readonly" eval="True"/>
+        <field name="copied" eval="True"/>
+    </record>
+
+    <record id="field_x_work_item_line_x_purchase_order_ids" model="ir.model.fields">
+        <field name="name">x_purchase_order_ids</field>
+        <field name="ttype">many2many</field>
+        <field name="field_description">Purchase Orders</field>
+        <field name="model_id" ref="x_work_item_line_model"/>
+        <field name="readonly" eval="True"/>
+        <field name="relation">purchase.order</field>
+        <field name="relation_field">x_work_item_line_ids</field>
+    </record>
+
 <!-- 
     Remarks: New Models
 -->

--- a/construction_developer/data/ir_model_fields.xml
+++ b/construction_developer/data/ir_model_fields.xml
@@ -84,7 +84,7 @@ for sol in self: sol['x_is_undeliverable'] = not sol.display_type and not (sol.i
         <field name="store" eval="False"/>
         <field name="model_id" ref="sale.model_sale_order_line"/>
         <field name="compute"><![CDATA[
-for sol in self: sol['x_is_deliverable'] = not sol.display_type and sol.is_service and sol.x_service_policy == 'delivered_manual'
+for sol in self: sol['x_is_deliverable'] = sol.product_id and not sol.display_type and sol.is_service and sol.x_service_policy == 'delivered_manual'
         ]]></field>
     </record>
     <record id="field_sale_order_line_x_display_button" model="ir.model.fields">
@@ -428,44 +428,81 @@ for record in self:
         <field name="field_description">Worksite Location</field>
     </record>
 
-    <record id="field_stock_picking_x_work_item_line_ids" model="ir.model.fields">
+    <record id="field_stock_move_x_work_item_line_ids" model="ir.model.fields">
         <field name="name">x_work_item_line_ids</field>
         <field name="ttype">many2many</field>
-        <field name="field_description">Work Item Line</field>
-        <field name="model_id" ref="stock.model_stock_picking"/>
+        <field name="field_description">Work Item Lines</field>
+        <field name="model_id" ref="stock.model_stock_move"/>
         <field name="relation">x_work_item_line</field>
         <field name="readonly" eval="True"/>
         <field name="copied" eval="True"/>
+    </record>
+
+    <record id="field_stock_move_x_wil_so_ids" model="ir.model.fields">
+        <field name="name">x_wil_so_ids</field>
+        <field name="ttype">many2many</field>
+        <field name="field_description">Work Items Sale Orders</field>
+        <field name="model_id" ref="stock.model_stock_move"/>
+        <field name="relation">sale.order</field>
+        <field name="readonly" eval="True"/>
+        <field name="store" eval="False"/>
+        <field name="compute">
+for rec in self: rec['x_wil_so_ids'] = rec.x_work_item_line_ids.x_sale_order_id.ids
+</field>
     </record>
 
     <record id="field_x_work_item_line_x_picking_ids" model="ir.model.fields">
         <field name="name">x_picking_ids</field>
         <field name="ttype">many2many</field>
-        <field name="field_description">Stock Pickings</field>
+        <field name="field_description">Transfers</field>
         <field name="model_id" ref="x_work_item_line_model"/>
         <field name="readonly" eval="True"/>
         <field name="relation">stock.picking</field>
-        <field name="relation_field">x_work_item_line_ids</field>
+        <field name="store" eval="False"/>
+        <field name="compute">
+for rec in self: 
+    res = self.env['stock.picking'].search([('move_ids.x_work_item_line_ids','in', rec.id)])
+    rec['x_picking_ids'] = res.ids if res else False
+</field>
     </record>
 
-    <record id="field_purchase_order_x_work_item_line_ids" model="ir.model.fields">
+    <record id="field_purchase_order_line_x_work_item_line_ids" model="ir.model.fields">
         <field name="name">x_work_item_line_ids</field>
         <field name="ttype">many2many</field>
         <field name="field_description">Work Item Line</field>
-        <field name="model_id" ref="purchase.model_purchase_order"/>
+        <field name="model_id" ref="purchase.model_purchase_order_line"/>
         <field name="relation">x_work_item_line</field>
         <field name="readonly" eval="True"/>
         <field name="copied" eval="True"/>
     </record>
 
+
+    <record id="field_purchase_order_line_x_wil_so_ids" model="ir.model.fields">
+        <field name="name">x_wil_so_ids</field>
+        <field name="ttype">many2many</field>
+        <field name="field_description">Work Items Sale Orders</field>
+        <field name="model_id" ref="purchase.model_purchase_order_line"/>
+        <field name="relation">sale.order</field>
+        <field name="readonly" eval="True"/>
+        <field name="store" eval="False"/>
+        <field name="compute">
+for rec in self: rec['x_wil_so_ids'] = rec.x_work_item_line_ids.x_sale_order_id.ids
+</field>
+    </record>
+
     <record id="field_x_work_item_line_x_purchase_order_ids" model="ir.model.fields">
         <field name="name">x_purchase_order_ids</field>
         <field name="ttype">many2many</field>
-        <field name="field_description">Purchase Orders</field>
+        <field name="field_description">Orders</field>
         <field name="model_id" ref="x_work_item_line_model"/>
         <field name="readonly" eval="True"/>
         <field name="relation">purchase.order</field>
-        <field name="relation_field">x_work_item_line_ids</field>
+        <field name="store" eval="False"/>
+        <field name="compute">
+for rec in self: 
+    res = self.env['purchase.order'].search([('order_line.x_work_item_line_ids','in', rec.id)])
+    rec['x_purchase_order_ids'] = res.ids if res else False
+</field>
     </record>
 
 <!-- 

--- a/construction_developer/data/ir_model_fields.xml
+++ b/construction_developer/data/ir_model_fields.xml
@@ -477,6 +477,17 @@ for rec in self:
     </record>
 
 
+    <record id="field_x_work_item_line_x_sale_order_id" model="ir.model.fields">
+        <field name="ttype">many2one</field>
+        <field name="related">x_work_item_id.x_sale_order_line_id.order_id</field>
+        <field name="relation">sale.order</field>
+        <field name="field_description">Sale Order</field>
+        <field name="model_id" ref="x_work_item_line_model"/>
+        <field name="name">x_sale_order_id</field>
+        <field name="readonly" eval="True"/>
+        <field name="store" eval="False"/>
+    </record>
+
     <record id="field_purchase_order_line_x_wil_so_ids" model="ir.model.fields">
         <field name="name">x_wil_so_ids</field>
         <field name="ttype">many2many</field>
@@ -484,7 +495,7 @@ for rec in self:
         <field name="model_id" ref="purchase.model_purchase_order_line"/>
         <field name="relation">sale.order</field>
         <field name="readonly" eval="True"/>
-        <field name="store" eval="False"/>
+        <field name="depends">x_work_item_line_ids,x_work_item_line_ids.x_sale_order_id</field>
         <field name="compute">
 for rec in self: rec['x_wil_so_ids'] = rec.x_work_item_line_ids.x_sale_order_id.ids
 </field>
@@ -940,17 +951,6 @@ for r in self: r['x_consumed'] = 0.01 * r.x_demand * r.x_work_item_id.x_sale_ord
         <field name="field_description">Line Reference</field>
         <field name="model_id" ref="x_work_item_line_model"/>
         <field name="name">x_line_reference</field>
-        <field name="readonly" eval="True"/>
-        <field name="store" eval="False"/>
-    </record>
-
-    <record id="field_x_work_item_line_x_sale_order_id" model="ir.model.fields">
-        <field name="ttype">many2one</field>
-        <field name="related">x_work_item_id.x_sale_order_line_id.order_id</field>
-        <field name="relation">sale.order</field>
-        <field name="field_description">Sale Order</field>
-        <field name="model_id" ref="x_work_item_line_model"/>
-        <field name="name">x_sale_order_id</field>
         <field name="readonly" eval="True"/>
         <field name="store" eval="False"/>
     </record>

--- a/construction_developer/data/ir_ui_view.xml
+++ b/construction_developer/data/ir_ui_view.xml
@@ -201,7 +201,9 @@
         <field name="arch" type="xml">
             <list open_form_view="false" create="0">
                 <header>
-                    <button class="btn btn-primary" name="%(action_wil_create_picking)d" type="action" string="Create Move"/>
+                    <button class="btn btn-primary" name="%(action_wil_create_picking)d" type="action" string="Create Picking"/>
+                    <button class="btn btn-primary" name="%(action_wil_create_purchase)d" type="action" string="Purchase"/>
+                    <button class="btn btn-primary" name="%(action_wil_create_dropshipping)d" type="action" string="Dropship"/>
                 </header>
                 <field name="x_sale_order_id" widget="many2one" optional="show"/>
                 <field name="x_line_reference" optional="show"/>
@@ -210,6 +212,7 @@
                 <field name="x_unit_id" widget="many2one" optional="show"/>
                 <field name="x_demand" optional="show"/>
                 <field name="x_picking_ids" widget="many2many_tags" optional="show"/>
+                <field name="x_purchase_order_ids" widget="many2many_tags" optional="show"/>
                 <field name="x_consumed" optional="show"/>
             </list>
         </field>

--- a/construction_developer/data/ir_ui_view.xml
+++ b/construction_developer/data/ir_ui_view.xml
@@ -200,12 +200,16 @@
         <field name="active" eval="True"/>
         <field name="arch" type="xml">
             <list open_form_view="false" create="0">
+                <header>
+                    <button class="btn btn-primary" name="%(action_wil_create_picking)d" type="action" string="Create Move"/>
+                </header>
                 <field name="x_sale_order_id" widget="many2one" optional="show"/>
                 <field name="x_line_reference" optional="show"/>
                 <field name="x_product_id" widget="many2one" optional="show"/>
                 <field name="x_work_item_id" widget="many2one" optional="show"/>
                 <field name="x_unit_id" widget="many2one" optional="show"/>
                 <field name="x_demand" optional="show"/>
+                <field name="x_picking_ids" widget="many2many_tags" optional="show"/>
                 <field name="x_consumed" optional="show"/>
             </list>
         </field>

--- a/construction_developer/data/ir_ui_view.xml
+++ b/construction_developer/data/ir_ui_view.xml
@@ -201,9 +201,9 @@
         <field name="arch" type="xml">
             <list open_form_view="false" create="0">
                 <header>
-                    <button string="Create Picking" name="%(action_wil_procurement_shopping_list)d" type="action" class="btn btn-primary" context="{'picking': True}"/>
-                    <button string="Purchase" name="%(action_wil_procurement_shopping_list)d" type="action" class="btn btn-primary"/>
-                    <button string="Dropship" name="%(action_wil_procurement_shopping_list)d" type="action" class="btn btn-primary" context="{'dropship': True}"/>
+                    <button string="Purchase" name="%(action_wil_procurement_po)d" type="action" class="btn btn-primary"/>
+                    <button string="Dropship" name="%(action_wil_procurement_po)d" type="action" class="btn btn-primary" context="{'dropship': True}"/>
+                    <button string="Transfer" name="%(action_wil_procurement_transfer)d" type="action" class="btn btn-primary" context="{'picking': True}" groups="construction_developer.group_procurement_move"/>
                 </header>
                 <field name="x_sale_order_id" widget="many2one" optional="show"/>
                 <field name="x_line_reference" optional="show"/>
@@ -211,8 +211,8 @@
                 <field name="x_work_item_id" widget="many2one" optional="show"/>
                 <field name="x_unit_id" widget="many2one" optional="show"/>
                 <field name="x_demand" optional="show"/>
-                <field name="x_picking_ids" widget="many2many_tags" optional="show"/>
                 <field name="x_purchase_order_ids" widget="many2many_tags" optional="show"/>
+                <field name="x_picking_ids" widget="many2many_tags" optional="show" groups="construction_developer.group_procurement_move"/>
                 <field name="x_consumed" optional="show"/>
             </list>
         </field>
@@ -399,6 +399,35 @@
         <field name="priority">1600</field>
         <field name="type">form</field>
         <field name="active" eval="True"/>
+    </record>
+
+    <record id="stock_picking_form_view_inherit" model="ir.ui.view">
+        <field name="inherit_id" ref="stock.view_picking_form"/>
+        <field name="mode">extension</field>
+        <field name="model">stock.picking</field>
+        <field name="name">stock.picking.form.inherit.construction_developer</field>
+        <field name="priority">1600</field>
+        <field name="type">form</field>
+        <field name="active" eval="True"/>
+        <field name="arch" type="xml">
+            <xpath expr="//notebook/page[@name='operations']/field[@name='move_ids']/list/button[@name='action_show_details']" position="before">
+                <field name="x_wil_so_ids" widget="many2many_tags" optional="hide"/>
+            </xpath>
+        </field>
+    </record>
+    <record id="purchase_order_form_view_inherit" model="ir.ui.view">
+        <field name="inherit_id" ref="purchase.purchase_order_form"/>
+        <field name="mode">extension</field>
+        <field name="model">purchase.order</field>
+        <field name="name">purchase.order.form.inherit.construction_developer</field>
+        <field name="priority">1600</field>
+        <field name="type">form</field>
+        <field name="active" eval="True"/>
+        <field name="arch" type="xml">
+            <xpath expr="//notebook/page[@name='products']/field[@name='order_line']/list/field[@name='price_subtotal']" position="after">
+                <field name="x_wil_so_ids" widget="many2many_tags" optional="hide"/>
+            </xpath>
+        </field>
     </record>
 
 <!-- remark -->

--- a/construction_developer/data/ir_ui_view.xml
+++ b/construction_developer/data/ir_ui_view.xml
@@ -201,9 +201,9 @@
         <field name="arch" type="xml">
             <list open_form_view="false" create="0">
                 <header>
-                    <button class="btn btn-primary" name="%(action_wil_create_picking)d" type="action" string="Create Picking"/>
-                    <button class="btn btn-primary" name="%(action_wil_create_purchase)d" type="action" string="Purchase"/>
-                    <button class="btn btn-primary" name="%(action_wil_create_dropshipping)d" type="action" string="Dropship"/>
+                    <button string="Create Picking" name="%(action_wil_create_picking)d" type="action" class="btn btn-primary"/>
+                    <button string="Purchase" name="%(action_wil_create_purchase)d" type="action" class="btn btn-primary"/>
+                    <button string="Dropship" name="%(action_wil_create_purchase)d" type="action" class="btn btn-primary" context="{'dropship': True}"/>
                 </header>
                 <field name="x_sale_order_id" widget="many2one" optional="show"/>
                 <field name="x_line_reference" optional="show"/>

--- a/construction_developer/data/ir_ui_view.xml
+++ b/construction_developer/data/ir_ui_view.xml
@@ -201,9 +201,9 @@
         <field name="arch" type="xml">
             <list open_form_view="false" create="0">
                 <header>
-                    <button string="Create Picking" name="%(action_wil_create_picking)d" type="action" class="btn btn-primary"/>
-                    <button string="Purchase" name="%(action_wil_create_purchase)d" type="action" class="btn btn-primary"/>
-                    <button string="Dropship" name="%(action_wil_create_purchase)d" type="action" class="btn btn-primary" context="{'dropship': True}"/>
+                    <button string="Create Picking" name="%(action_wil_procurement_shopping_list)d" type="action" class="btn btn-primary" context="{'picking': True}"/>
+                    <button string="Purchase" name="%(action_wil_procurement_shopping_list)d" type="action" class="btn btn-primary"/>
+                    <button string="Dropship" name="%(action_wil_procurement_shopping_list)d" type="action" class="btn btn-primary" context="{'dropship': True}"/>
                 </header>
                 <field name="x_sale_order_id" widget="many2one" optional="show"/>
                 <field name="x_line_reference" optional="show"/>

--- a/construction_developer/data/product_template.xml
+++ b/construction_developer/data/product_template.xml
@@ -72,6 +72,7 @@
         <field name="default_code">06.4.30.010</field>
         <field name="service_type">manual</field>
         <field name="categ_id" ref="construction.product_category_46"/>
+        <field name="is_storable" eval="True"/>
     </record>
     <record id="product_template_65" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Compacted sand</field>
@@ -81,6 +82,7 @@
         <field name="service_type">manual</field>
         <field name="invoice_policy">order</field>
         <field name="categ_id" ref="construction.product_category_47"/>
+        <field name="is_storable" eval="True"/>
     </record>
     <record id="product_template_80" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Concrete</field>
@@ -89,6 +91,7 @@
         <field name="default_code">04.1.10.030</field>
         <field name="service_type">manual</field>
         <field name="categ_id" ref="construction.product_category_45"/>
+        <field name="is_storable" eval="True"/>
     </record>
     <record id="product_template_79" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Connection pipe</field>
@@ -97,6 +100,7 @@
         <field name="default_code">02.4.30.025</field>
         <field name="service_type">manual</field>
         <field name="categ_id" ref="construction.product_category_48"/>
+        <field name="is_storable" eval="True"/>
     </record>
     <record id="product_template_73" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Corrugated metal sheet</field>
@@ -105,6 +109,7 @@
         <field name="default_code">08.3.15.005</field>
         <field name="service_type">manual</field>
         <field name="categ_id" ref="construction.product_category_42"/>
+        <field name="is_storable" eval="True"/>
     </record>
     <record id="product_template_72" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Downspout accessory</field>
@@ -112,6 +117,7 @@
         <field name="default_code">08.6.25.030</field>
         <field name="service_type">manual</field>
         <field name="categ_id" ref="construction.product_category_43"/>
+        <field name="is_storable" eval="True"/>
     </record>
     <record id="product_template_78" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Drain channel with grid</field>
@@ -120,6 +126,7 @@
         <field name="default_code">02.5.10.015</field>
         <field name="service_type">manual</field>
         <field name="categ_id" ref="construction.product_category_48"/>
+        <field name="is_storable" eval="True"/>
     </record>
     <record id="product_template_63" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Geotextile fabric</field>
@@ -129,6 +136,7 @@
         <field name="service_type">manual</field>
         <field name="invoice_policy">order</field>
         <field name="categ_id" ref="construction.product_category_47"/>
+        <field name="is_storable" eval="True"/>
     </record>
     <record id="product_template_64" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Gravel 0.25</field>
@@ -138,6 +146,7 @@
         <field name="service_type">manual</field>
         <field name="invoice_policy">order</field>
         <field name="categ_id" ref="construction.product_category_47"/>
+        <field name="is_storable" eval="True"/>
     </record>
     <record id="product_template_71" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">PVC gutter</field>
@@ -146,6 +155,7 @@
         <field name="default_code">08.6.20.010</field>
         <field name="service_type">manual</field>
         <field name="categ_id" ref="construction.product_category_43"/>
+        <field name="is_storable" eval="True"/>
     </record>
     <record id="product_template_74" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Roofing fixation screws</field>
@@ -153,6 +163,7 @@
         <field name="default_code">08.9.10.015</field>
         <field name="service_type">manual</field>
         <field name="categ_id" ref="construction.product_category_42"/>
+        <field name="is_storable" eval="True"/>
     </record>
     <record id="product_template_76" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Steel beam (matching profile)</field>
@@ -160,6 +171,7 @@
         <field name="default_code">05.2.20.045</field>
         <field name="service_type">manual</field>
         <field name="categ_id" ref="construction.product_category_46"/>
+        <field name="is_storable" eval="True"/>
     </record>
     <record id="product_template_75" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Steel post (galvanized, coated)</field>
@@ -167,6 +179,7 @@
         <field name="default_code">05.2.10.020</field>
         <field name="service_type">manual</field>
         <field name="categ_id" ref="construction.product_category_46"/>
+        <field name="is_storable" eval="True"/>
     </record>
     <record id="product_template_81" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Steel reinforcement mesh</field>
@@ -175,5 +188,6 @@
         <field name="default_code">04.2.20.010</field>
         <field name="service_type">manual</field>
         <field name="categ_id" ref="construction.product_category_45"/>
+        <field name="is_storable" eval="True"/>
     </record>
 </odoo>

--- a/construction_developer/data/res_config_settings.xml
+++ b/construction_developer/data/res_config_settings.xml
@@ -2,6 +2,7 @@
 <odoo noupdate="1">
     <record id="construction_developer_res_config_settings_enable" model="res.config.settings" >
         <field name="group_product_variant" eval="True"/>
+        <field name="group_stock_multi_locations" eval="True"/>
     </record>
 
     <function model="res.config.settings" name="execute">

--- a/construction_developer/data/res_config_settings.xml
+++ b/construction_developer/data/res_config_settings.xml
@@ -3,6 +3,7 @@
     <record id="construction_developer_res_config_settings_enable" model="res.config.settings" >
         <field name="group_product_variant" eval="True"/>
         <field name="group_stock_multi_locations" eval="True"/>
+        <field name="module_stock_dropshipping" eval="True"/>
     </record>
 
     <function model="res.config.settings" name="execute">

--- a/construction_developer/data/res_config_settings.xml
+++ b/construction_developer/data/res_config_settings.xml
@@ -2,8 +2,6 @@
 <odoo noupdate="1">
     <record id="construction_developer_res_config_settings_enable" model="res.config.settings" >
         <field name="group_product_variant" eval="True"/>
-        <field name="group_stock_multi_locations" eval="True"/>
-        <field name="module_stock_dropshipping" eval="True"/>
     </record>
 
     <function model="res.config.settings" name="execute">

--- a/construction_developer/data/res_config_settings_post.xml
+++ b/construction_developer/data/res_config_settings_post.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo>
     <!-- procurement move setting -->
     <record id="x_setting_field_procurement_move" model="ir.model.fields">
         <field name="ttype">boolean</field>
@@ -26,12 +26,12 @@ env['ir.config_parameter'].sudo().set_param('construction.procurement_active', s
 group_user = env.ref('base.group_user')
 procurement_group = env.ref('construction_developer.group_procurement_move')
 
+record['group_stock_multi_locations'] = is_active
+
 if is_active:
     group_user._apply_group(procurement_group)
-    record['group_stock_multi_locations'] = True
 else:
     group_user._remove_group(procurement_group)
-    record['group_stock_multi_locations'] = False
 
 
 records_to_toggle = [

--- a/construction_developer/data/res_config_settings_post.xml
+++ b/construction_developer/data/res_config_settings_post.xml
@@ -1,0 +1,101 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<odoo noupdate="1">
+    <!-- procurement move setting -->
+    <record id="x_setting_field_procurement_move" model="ir.model.fields">
+        <field name="ttype">boolean</field>
+        <field name="field_description">Procurement Move</field>
+        <field name="model_id" ref="base_setup.model_res_config_settings"/>
+        <field name="name">x_module_procurement_move</field>
+        <field name="store" eval="True"/>
+        <field name="compute"><![CDATA[
+self['x_module_procurement_move'] = self.env.user.has_group('construction_developer.group_procurement_move')
+]]></field>
+    </record>
+
+    <record id="x_action_toggle_procurement_move" model="ir.actions.server">
+        <field name="model_id" ref="base_setup.model_res_config_settings"/>
+        <field name="state">code</field>
+        <field name="name">Toggle Procurement Move Features</field>
+        <field name="code">
+# 'record' represents the current res.config.settings instance being saved
+is_active = record.x_module_procurement_move
+# Save the state permanently to check in server action
+env['ir.config_parameter'].sudo().set_param('construction.procurement_active', str(is_active))
+
+# (De)activate Setting + Multi locations
+group_user = env.ref('base.group_user')
+procurement_group = env.ref('construction_developer.group_procurement_move')
+
+if is_active:
+    group_user._apply_group(procurement_group)
+    record['group_stock_multi_locations'] = True
+else:
+    group_user._remove_group(procurement_group)
+    record['group_stock_multi_locations'] = False
+
+
+records_to_toggle = [
+    'automation_on_stock_move_create_or_write',
+    'stock_picking_form_view_inherit',
+]
+
+for xml_id in records_to_toggle:
+    if (rec := env.ref(f'construction_developer.{xml_id}', raise_if_not_found=False)):
+        rec['active'] = is_active
+
+
+
+cloc_entries = [
+    'action_wil_procurement_transfer',
+    'action_check_stock_move_validity',
+    'action_sol_create_procurement_moves',
+]
+
+for cloc_entry in cloc_entries:
+    cloc_exclude_id = f'construction_developer_{cloc_entry}'
+    entry_model = 'ir.actions.server' if cloc_entry.startswith('server_action') else 'ir.model.fields'
+    pairs = lambda cloc_entry_id: [
+        ('name', cloc_exclude_id),
+        ('model', entry_model),
+        ('module', '__cloc_exclude__'),
+        ('res_id', cloc_entry_id.id),
+    ]
+
+    if is_active:
+        # Unlink/Remove from cloc exclusion when feature is turned ON
+        if (cloc_entry_id := env.ref(f'__cloc_exclude__.{cloc_exclude_id}', raise_if_not_found=False)):
+            env['ir.model.data'].search([(key, '=', value) for key, value in pairs(cloc_entry_id)], limit=1).unlink()
+    else:
+        # Create cloc exclusion when feature is turned OFF
+        if (cloc_entry_id := env.ref(f'construction_developer.{cloc_entry}', raise_if_not_found=False)) and not env.ref(f'__cloc_exclude__.{cloc_exclude_id}', raise_if_not_found=False):
+            env['ir.model.data'].create({key: val for key, val in pairs(cloc_entry_id)})
+</field>
+    </record>
+
+    <record id="base_automation_on_procurement_move_setting_changed" model="base.automation">
+        <field name="name">On Change: Procurement Move Setting</field>
+        <field name="model_id" ref="base_setup.model_res_config_settings"/>
+        <field name="trigger">on_create_or_write</field>
+        <field name="on_change_field_ids" eval="[(6, 0, [ref('x_setting_field_procurement_move')])]"/>
+        <field name="action_server_ids" eval="[(6, 0, [ref('x_action_toggle_procurement_move')])]"/>
+    </record>
+
+    <record id="res_config_settings_form_view_inherited" model="ir.ui.view">
+        <field name="name">res.config.settings.form.view.inherited.construction_developer</field>
+        <field name="model">res.config.settings</field>
+        <field name="priority" eval="40"/>
+        <field name="active" eval="True"/>
+        <field name="inherit_id" ref="base.res_config_settings_view_form" />
+        <field name="arch" type="xml">
+            <xpath expr="//form" position="inside">
+                <app string="Construction Developer" name="construction_developer">
+                    <block title="Transfers" name="transfers_block">
+                        <setting id="construction_developer_procurement_move_setting" help="Create client worksite locations and create transfers to them.">
+                            <field name="x_module_procurement_move"/>
+                        </setting>
+                    </block>
+                </app>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/construction_developer/data/res_groups.xml
+++ b/construction_developer/data/res_groups.xml
@@ -1,0 +1,6 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<odoo noupdate="1">
+    <record id="group_procurement_move" model="res.groups">
+        <field name="name">Procurement Move</field>
+    </record>
+</odoo>

--- a/construction_developer/data/stock_location.xml
+++ b/construction_developer/data/stock_location.xml
@@ -1,0 +1,6 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<odoo noupdate="1">
+  <record id="stock_location_1" model="stock.location">
+    <field name="name">Worksites</field>
+  </record>
+</odoo>

--- a/construction_developer/demo/product_supplierinfo.xml
+++ b/construction_developer/demo/product_supplierinfo.xml
@@ -119,73 +119,73 @@
   </record>
   <record id="product_supplierinfo_40" model="product.supplierinfo">
     <field name="partner_id" ref="base_industry_data.res_partner_35"/>
-    <field name="product_tmpl_id" ref="construction_developer.product_template_74"/>
+    <field name="product_tmpl_id" ref="product_template_74"/>
     <field name="product_uom_id" ref="uom.product_uom_unit"/>
     <field name="price">0.05</field>
   </record>
   <record id="product_supplierinfo_29" model="product.supplierinfo">
     <field name="partner_id" ref="base_industry_data.res_partner_31"/>
-    <field name="product_tmpl_id" ref="construction_developer.product_template_63"/>
+    <field name="product_tmpl_id" ref="product_template_63"/>
     <field name="product_uom_id" ref="uom.product_uom_square_meter"/>
     <field name="price">0.5</field>
   </record>
   <record id="product_supplierinfo_32" model="product.supplierinfo">
     <field name="partner_id" ref="base_industry_data.res_partner_35"/>
-    <field name="product_tmpl_id" ref="construction_developer.product_template_79"/>
+    <field name="product_tmpl_id" ref="product_template_79"/>
     <field name="product_uom_id" ref="uom.product_uom_meter"/>
     <field name="price">2.0</field>
   </record>
   <record id="product_supplierinfo_39" model="product.supplierinfo">
     <field name="partner_id" ref="base_industry_data.res_partner_31"/>
-    <field name="product_tmpl_id" ref="construction_developer.product_template_72"/>
+    <field name="product_tmpl_id" ref="product_template_72"/>
     <field name="product_uom_id" ref="uom.product_uom_unit"/>
     <field name="price">3.0</field>
   </record>
   <record id="product_supplierinfo_38" model="product.supplierinfo">
     <field name="partner_id" ref="base_industry_data.res_partner_35"/>
-    <field name="product_tmpl_id" ref="construction_developer.product_template_71"/>
+    <field name="product_tmpl_id" ref="product_template_71"/>
     <field name="product_uom_id" ref="uom.product_uom_meter"/>
     <field name="price">8.0</field>
   </record>
   <record id="product_supplierinfo_36" model="product.supplierinfo">
     <field name="partner_id" ref="base_industry_data.res_partner_35"/>
-    <field name="product_tmpl_id" ref="construction_developer.product_template_77"/>
+    <field name="product_tmpl_id" ref="product_template_77"/>
     <field name="product_uom_id" ref="uom.product_uom_litre"/>
     <field name="price">10.0</field>
   </record>
   <record id="product_supplierinfo_37" model="product.supplierinfo">
     <field name="partner_id" ref="base_industry_data.res_partner_31"/>
-    <field name="product_tmpl_id" ref="construction_developer.product_template_73"/>
+    <field name="product_tmpl_id" ref="product_template_73"/>
     <field name="product_uom_id" ref="uom.product_uom_square_meter"/>
     <field name="price">12.5</field>
   </record>
   <record id="product_supplierinfo_31" model="product.supplierinfo">
     <field name="partner_id" ref="base_industry_data.res_partner_31"/>
-    <field name="product_tmpl_id" ref="construction_developer.product_template_65"/>
+    <field name="product_tmpl_id" ref="product_template_65"/>
     <field name="product_uom_id" ref="uom.product_uom_ton"/>
     <field name="price">20.0</field>
   </record>
   <record id="product_supplierinfo_30" model="product.supplierinfo">
     <field name="partner_id" ref="base_industry_data.res_partner_35"/>
-    <field name="product_tmpl_id" ref="construction_developer.product_template_64"/>
+    <field name="product_tmpl_id" ref="product_template_64"/>
     <field name="product_uom_id" ref="uom.product_uom_ton"/>
     <field name="price">25.0</field>
   </record>
   <record id="product_supplierinfo_34" model="product.supplierinfo">
     <field name="partner_id" ref="base_industry_data.res_partner_35"/>
-    <field name="product_tmpl_id" ref="construction_developer.product_template_75"/>
+    <field name="product_tmpl_id" ref="product_template_75"/>
     <field name="product_uom_id" ref="uom.product_uom_unit"/>
     <field name="price">60.0</field>
   </record>
   <record id="product_supplierinfo_33" model="product.supplierinfo">
     <field name="partner_id" ref="base_industry_data.res_partner_31"/>
-    <field name="product_tmpl_id" ref="construction_developer.product_template_80"/>
+    <field name="product_tmpl_id" ref="product_template_80"/>
     <field name="product_uom_id" ref="uom.product_uom_ton"/>
     <field name="price">80.0</field>
   </record>
   <record id="product_supplierinfo_35" model="product.supplierinfo">
     <field name="partner_id" ref="base_industry_data.res_partner_31"/>
-    <field name="product_tmpl_id" ref="construction_developer.product_template_76"/>
+    <field name="product_tmpl_id" ref="product_template_76"/>
     <field name="product_uom_id" ref="uom.product_uom_unit"/>
     <field name="price">100.0</field>
   </record>

--- a/construction_developer/demo/product_supplierinfo.xml
+++ b/construction_developer/demo/product_supplierinfo.xml
@@ -117,4 +117,76 @@
     <field name="price">7000.0</field>
     <field name="delay" eval="False"/>
   </record>
+  <record id="product_supplierinfo_40" model="product.supplierinfo">
+    <field name="partner_id" ref="base_industry_data.res_partner_35"/>
+    <field name="product_tmpl_id" ref="construction_developer.product_template_74"/>
+    <field name="product_uom_id" ref="uom.product_uom_unit"/>
+    <field name="price">0.05</field>
+  </record>
+  <record id="product_supplierinfo_29" model="product.supplierinfo">
+    <field name="partner_id" ref="base_industry_data.res_partner_31"/>
+    <field name="product_tmpl_id" ref="construction_developer.product_template_63"/>
+    <field name="product_uom_id" ref="uom.product_uom_square_meter"/>
+    <field name="price">0.5</field>
+  </record>
+  <record id="product_supplierinfo_32" model="product.supplierinfo">
+    <field name="partner_id" ref="base_industry_data.res_partner_35"/>
+    <field name="product_tmpl_id" ref="construction_developer.product_template_79"/>
+    <field name="product_uom_id" ref="uom.product_uom_meter"/>
+    <field name="price">2.0</field>
+  </record>
+  <record id="product_supplierinfo_39" model="product.supplierinfo">
+    <field name="partner_id" ref="base_industry_data.res_partner_31"/>
+    <field name="product_tmpl_id" ref="construction_developer.product_template_72"/>
+    <field name="product_uom_id" ref="uom.product_uom_unit"/>
+    <field name="price">3.0</field>
+  </record>
+  <record id="product_supplierinfo_38" model="product.supplierinfo">
+    <field name="partner_id" ref="base_industry_data.res_partner_35"/>
+    <field name="product_tmpl_id" ref="construction_developer.product_template_71"/>
+    <field name="product_uom_id" ref="uom.product_uom_meter"/>
+    <field name="price">8.0</field>
+  </record>
+  <record id="product_supplierinfo_36" model="product.supplierinfo">
+    <field name="partner_id" ref="base_industry_data.res_partner_35"/>
+    <field name="product_tmpl_id" ref="construction_developer.product_template_77"/>
+    <field name="product_uom_id" ref="uom.product_uom_litre"/>
+    <field name="price">10.0</field>
+  </record>
+  <record id="product_supplierinfo_37" model="product.supplierinfo">
+    <field name="partner_id" ref="base_industry_data.res_partner_31"/>
+    <field name="product_tmpl_id" ref="construction_developer.product_template_73"/>
+    <field name="product_uom_id" ref="uom.product_uom_square_meter"/>
+    <field name="price">12.5</field>
+  </record>
+  <record id="product_supplierinfo_31" model="product.supplierinfo">
+    <field name="partner_id" ref="base_industry_data.res_partner_31"/>
+    <field name="product_tmpl_id" ref="construction_developer.product_template_65"/>
+    <field name="product_uom_id" ref="uom.product_uom_ton"/>
+    <field name="price">20.0</field>
+  </record>
+  <record id="product_supplierinfo_30" model="product.supplierinfo">
+    <field name="partner_id" ref="base_industry_data.res_partner_35"/>
+    <field name="product_tmpl_id" ref="construction_developer.product_template_64"/>
+    <field name="product_uom_id" ref="uom.product_uom_ton"/>
+    <field name="price">25.0</field>
+  </record>
+  <record id="product_supplierinfo_34" model="product.supplierinfo">
+    <field name="partner_id" ref="base_industry_data.res_partner_35"/>
+    <field name="product_tmpl_id" ref="construction_developer.product_template_75"/>
+    <field name="product_uom_id" ref="uom.product_uom_unit"/>
+    <field name="price">60.0</field>
+  </record>
+  <record id="product_supplierinfo_33" model="product.supplierinfo">
+    <field name="partner_id" ref="base_industry_data.res_partner_31"/>
+    <field name="product_tmpl_id" ref="construction_developer.product_template_80"/>
+    <field name="product_uom_id" ref="uom.product_uom_ton"/>
+    <field name="price">80.0</field>
+  </record>
+  <record id="product_supplierinfo_35" model="product.supplierinfo">
+    <field name="partner_id" ref="base_industry_data.res_partner_31"/>
+    <field name="product_tmpl_id" ref="construction_developer.product_template_76"/>
+    <field name="product_uom_id" ref="uom.product_uom_unit"/>
+    <field name="price">100.0</field>
+  </record>
 </odoo>

--- a/construction_developer/demo/purchase_order.xml
+++ b/construction_developer/demo/purchase_order.xml
@@ -1,18 +1,22 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1">
+<odoo>
     <record id="create_purchase_orders_for_all_WILs_of_project_S00003" model="ir.actions.server">
         <field name="name">Industry HR demo data: Conditionally create admin user</field>
         <field name="model_id" ref="base.model_ir_actions_server"/>
         <field name="state">code</field>
-        <field name="code"><![CDATA[
-# because can't use search in context="" for a function record
+        <field name="code">
+demo_so = env.ref('construction_developer.sale_order_41', raise_if_not_found=False)
 
-action = env.ref('construction_developer.action_wil_procurement_po')
-active_ids = env['x_work_item_line'].search([
-    ('x_work_item_id.x_sale_order_line_id.order_id', '=', env.ref('construction_developer.sale_order_41').id)
-]).ids
-action.with_context(active_ids=active_ids, active_model='x_work_item_line').run()
-]]></field>
+# Only run if no Purchase Order Lines exist for this specific Demo SO
+if demo_so and not env['purchase.order.line'].search_count([('sale_order_id', '=', demo_so.id)]):
+    action = env.ref('construction_developer.action_wil_procurement_po')
+    active_ids = env['x_work_item_line'].search([
+        ('x_work_item_id.x_sale_order_line_id.order_id', '=', demo_so.id)
+    ]).ids
+    
+    if active_ids:
+        action.with_context(active_ids=active_ids, active_model='x_work_item_line').run()
+</field>
     </record>
     <function name="run" model="ir.actions.server" eval="[ref('create_purchase_orders_for_all_WILs_of_project_S00003')]"/>
     <function model="ir.actions.server" name="unlink">

--- a/construction_developer/demo/purchase_order.xml
+++ b/construction_developer/demo/purchase_order.xml
@@ -1,0 +1,21 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<odoo noupdate="1">
+    <record id="create_purchase_orders_for_all_WILs_of_project_S00003" model="ir.actions.server">
+        <field name="name">Industry HR demo data: Conditionally create admin user</field>
+        <field name="model_id" ref="base.model_ir_actions_server"/>
+        <field name="state">code</field>
+        <field name="code"><![CDATA[
+# because can't use search in context="" for a function record
+
+action = env.ref('construction_developer.action_wil_procurement_po')
+active_ids = env['x_work_item_line'].search([
+    ('x_work_item_id.x_sale_order_line_id.order_id', '=', env.ref('construction_developer.sale_order_41').id)
+]).ids
+action.with_context(active_ids=active_ids, active_model='x_work_item_line').run()
+]]></field>
+    </record>
+    <function name="run" model="ir.actions.server" eval="[ref('create_purchase_orders_for_all_WILs_of_project_S00003')]"/>
+    <function model="ir.actions.server" name="unlink">
+        <value model="ir.actions.server" eval="ref('create_purchase_orders_for_all_WILs_of_project_S00003')"/>
+    </function>
+</odoo>

--- a/construction_developer/static/description/index.html
+++ b/construction_developer/static/description/index.html
@@ -57,6 +57,9 @@
         <strong>Materials Need Management</strong> - Manage the sale order shopping list deciding for reservation, purchase and drop shipping.
     </li>
     <li>
+        <strong>Work item component procurement</strong> - Reach material needs and easily purchase or plan on site drop shipping as you please.
+    </li>
+    <li>
         <strong>Progress management</strong> - Handle service delivery increments from projects for subsequent invoicing.
     </li>
     <li>

--- a/tests/test_construction_developer/static/src/js/tours/industry_construction_developer_cost_nature_tour.js
+++ b/tests/test_construction_developer/static/src/js/tours/industry_construction_developer_cost_nature_tour.js
@@ -12,6 +12,10 @@ registry.category("web_tour.tours").add("industry_construction_developer_cost_na
         "run": "click",
     },
     {
+        "trigger": ".o_button_more",
+        "run": "click",
+    },
+    {
         "trigger": ".oe_stat_button:contains('Cost Nature')",
         "run": "click",
     },


### PR DESCRIPTION
This commit adds a new button to be able to create grouped stock pickings for products that are not fully consumed from the procurement view. This commit also changes the way x_consumed is computed from the delivery progress for this purpose. In order to create the moves, we need to create locations to represent the clients' worksites, so the multi locations setting is now activated.

task-6123696, task-6123161