### PR TITLE
[ADD] .*: improve rental booking and housekeeping management

### DIFF
--- a/booking_engine/data/ir_actions_act_window.xml
+++ b/booking_engine/data/ir_actions_act_window.xml
@@ -9,7 +9,7 @@
   </record>
   <record id="booking_engine_rooms_order_action" model="ir.actions.act_window">
     <field name="domain">[("x_order_involves_room", "=", True)]</field>
-    <field name="context">{'search_default_filter_today': 1, 'in_rental_app': 1, 'search_default_from_rental': 1, 'group_by': ['rental_status']}</field>
+    <field name="context">{'in_rental_app': 1, 'search_default_from_rental': 1, 'group_by': ['rental_status']}</field>
     <field name="name">Orders</field>
     <field name="res_model">sale.order</field>
     <field name="view_mode">kanban,list,form</field>
@@ -49,7 +49,7 @@
         <field name="name">Board</field>
         <field name="res_model">resource.resource</field>
         <field name="view_mode">kanban,form</field>
-        <field name="context" eval="{'default_resource_type': 'material', 'create': False}"/>
+        <field name="context" eval="{'default_resource_type': 'material', 'create': False, 'search_default_stage': 1}"/>
     </record>
     <record id="act_window_house_keeping_project_tasks" model="ir.actions.act_window">
         <field name="domain">[('project_id.x_is_house_keeping_project', '=', True)]</field>

--- a/booking_engine/data/ir_model_fields.xml
+++ b/booking_engine/data/ir_model_fields.xml
@@ -789,4 +789,52 @@ Note that saving a new survey with this set will archive previous survey with th
       <field name="model_id" ref="sale.model_sale_order"/>
       <field name="ttype">boolean</field>
   </record>
+  <record id="x_booking_color_field" model="ir.model.fields">
+    <field name="name">x_booking_color</field>
+    <field name="field_description">Booking Color</field>
+    <field name="model_id" ref="planning.model_planning_slot"/>
+    <field name="ttype">integer</field>
+    <field name="store" eval="False"/>
+    <field name="depends">sale_order_id.rental_status,sale_order_id.rental_start_date,sale_order_id.rental_return_date,sale_order_id.is_late</field>
+    <field name="compute"><![CDATA[
+today_start = datetime.datetime.combine(datetime.date.today(), datetime.time.min)
+today_end = datetime.datetime.combine(datetime.date.today(), datetime.time.max)
+
+for slot in self:
+    order = slot.sale_order_id
+    if not order:
+        slot['x_booking_color'] = 5   # purple - internal
+    elif order.rental_status == 'pickup' and order.rental_start_date and today_start <= order.rental_start_date <= today_end:
+        slot['x_booking_color'] = 3   # yellow - check in due
+    elif order.rental_status == 'return' and order.rental_return_date and order.rental_return_date > today_end:
+        slot['x_booking_color'] = 10  # green - ongoing
+    elif order.rental_status == 'return' and order.rental_return_date and today_start <= order.rental_return_date <= today_end:
+        slot['x_booking_color'] = 4   # blue - check out due
+    elif (order.rental_status == 'pickup' and order.is_late) or (order.rental_status == 'return' and order.is_late):
+        slot['x_booking_color'] = 1   # red - attention
+    else:
+        slot['x_booking_color'] = False # grey - no focus
+      ]]></field>
+  </record>
+  <record id="x_rental_status_field" model="ir.model.fields">
+    <field name="ttype">selection</field>
+    <field name="field_description">Rental Status</field>
+    <field name="model_id" ref="planning.model_planning_slot"/>
+    <field name="name">x_rental_status</field>
+    <field name="related">sale_order_id.rental_status</field>
+    <field name="store">False</field>
+    <field name="readonly" eval="True"/>
+  </record>
+  <record id="x_has_room_offer_role_field" model="ir.model.fields">
+      <field name="name">x_has_room_offer_role</field>
+      <field name="field_description">Has Room Offer Role</field>
+      <field name="model_id" ref="resource.model_resource_resource"/>
+      <field name="ttype">boolean</field>
+      <field name="store" eval="False"/>
+      <field name="depends">role_ids.x_is_a_room_offer</field>
+      <field name="compute"><![CDATA[
+for record in self:
+    record['x_has_room_offer_role'] = any(role.x_is_a_room_offer for role in record.role_ids)
+  ]]></field>
+  </record>
 </odoo>

--- a/booking_engine/data/ir_ui_view.xml
+++ b/booking_engine/data/ir_ui_view.xml
@@ -54,14 +54,14 @@
           <attribute name="string">Check Out</attribute>
         </xpath>
         <xpath expr="//field[@name='is_rental_order']" position="after">
-          <button string="City Tax" type="action" name="%(open_x_city_tax_action)d" context="{'search_default_x_sale_order_id': id, 'default_x_sale_order_id': id}"/>
+          <button string="City Tax" type="action" name="%(open_x_city_tax_action)d" context="{'search_default_x_sale_order_id': id, 'default_x_sale_order_id': id}" invisible="not x_order_involves_room"/>
         </xpath>
         <xpath expr="//form[1]/sheet[1]/notebook[1]" position="inside">
-          <page string="Guests">
+          <page string="Guests" invisible="not x_order_involves_room">
             <field name="x_guest_line_ids">
               <list default_order="x_sequence asc,id desc" editable="bottom">
                 <field name="x_sequence" widget="handle"/>
-                <field optional="show" name="x_guest_partner_id" widget="res_partner_many2one" required="1"/>
+                <field optional="show" name="x_guest_partner_id" widget="many2one_avatar" required="1"/>
                 <field optional="show" name="x_guest_identity_check" widget="badge" readonly="True" decoration-success="x_guest_identity_check == 'ok'" decoration-warning="x_guest_identity_check == 'na'" decoration-danger="x_guest_identity_check == 'invalid'"/>
                 <field optional="show" name="x_room_resource_id" domain="[('default_role_id.x_is_a_room_offer', '!=', False), ('id', 'in', x_sol_resource_ids)]" options="{'no_create': True, 'no_create_edit': True}"/>
               </list>
@@ -252,14 +252,18 @@
     <field name="type">form</field>
     <field name="active" eval="True"/>
   </record>
-  <record id="planning_kanban_view" model="ir.ui.view">
+  <record id="booking_engine_planning_kanban_view" model="ir.ui.view">
     <field name="arch" type="xml">
-        <xpath expr="//field[@name='sale_line_id']" position="replace">
-          <field name="sale_order_id" display="full" widget="many2one" class="d-block" context="{'form_view_ref': 'booking_engine.rental_order_view', 'in_rental_app': 1}"/>
-        </xpath>
+      <xpath expr="//kanban" position="attributes">
+          <attribute name="default_group_by">x_rental_status</attribute>
+      </xpath>
+      <xpath expr="//field[@name='sale_line_id']" position="replace"/>
+      <xpath expr="//footer/div" position="before">
+        <field name="sale_order_id" widget="many2one" context="{'form_view_ref': 'booking_engine.rental_order_view', 'in_rental_app': 1}"/>
+      </xpath>
     </field>
     <field name="inherit_id" ref="planning.planning_view_kanban"/>
-    <field name="mode">extension</field>
+    <field name="mode">primary</field>
     <field name="model">planning.slot</field>
     <field name="name">planning.slot.kanban.inherit.booking_engine</field>
     <field name="priority">200</field>
@@ -500,7 +504,7 @@
         <xpath expr="/gantt" position="attributes">
           <attribute name="form_view_id">%(booking_engine_schedule_form)d</attribute>
           <attribute name="multi_create_view"/>
-          <attribute name="color">sale_order_id</attribute>
+          <attribute name="color">x_booking_color</attribute>
         </xpath>
     </field>
     <field name="inherit_id" ref="planning.planning_view_gantt"/>
@@ -538,7 +542,7 @@
           <attribute name="invisible">context.get('has_product')</attribute>
         </xpath>
         <xpath expr="//field[@name='tz']" position="after">
-          <field name="x_occupant_ids" widget="many2many_tags" invisible="context.get('has_product')"/>
+          <field name="x_occupant_ids" widget="many2many_tags" invisible="context.get('has_product') or not x_occupant_ids"/>
         </xpath>
         <xpath expr="//field[@name='calendar_id']" position="attributes">
           <attribute name="domain">[('company_id', 'in', (False, company_id))]</attribute>
@@ -606,7 +610,7 @@
       (0, 0, {'view_mode': 'gantt', 'view_id': ref('booking_engine_planning_gantt_view')}),
       (0, 0, {'view_mode': 'form', 'view_id': ref('booking_engine_schedule_form')}),
       (0, 0, {'view_mode': 'list', 'view_id': ref('booking_engine_planning_list_view')}),
-      
+      (0, 0, {'view_mode': 'kanban', 'view_id': ref('booking_engine_planning_kanban_view')}),
     ]"/>
   </record>
   <record id="booking_engine_rooms_order_action" model="ir.actions.act_window">
@@ -649,7 +653,7 @@
         <field name="arch" type="xml">
             <xpath expr="/form/sheet/group" position="after">
                 <group>
-                    <group string="House Keeping" groups="booking_engine.group_house_keeping">
+                    <group string="House Keeping" groups="booking_engine.group_house_keeping" invisible="not x_has_room_offer_role">
                         <field name="x_occupancy" options="{}"/>
                         <field name="x_house_keeping_stage_id" domain="[('project_ids.x_is_house_keeping_project', '!=', False)]"/>
                         <field name="x_ongoing_task_id" context="{'form_view_ref': 'booking_engine.project_task_form_view_primary'}"/>
@@ -671,7 +675,7 @@
     </record>
     <record id="resource_resource_kanban_view_primary" model="ir.ui.view">
         <field name="arch" type="xml">
-            <kanban sample="1" highlight_color="x_task_stage_color">
+            <kanban sample="1" highlight_color="x_task_stage_color" default_group_by="x_house_keeping_stage_id">
                 <templates>
                     <t t-name="card">
                         <div class="d-flex flex-column">
@@ -1039,5 +1043,19 @@
               </div>
           </xpath>
       </field>
+  </record>
+  <record id="planning_search_view_inherit_booking_engine" model="ir.ui.view">
+    <field name="name">planning.slot.search.inherit.booking_engine</field>
+    <field name="model">planning.slot</field>
+    <field name="inherit_id" ref="planning.planning_view_search_base"/>
+    <field name="mode">extension</field>
+    <field name="active" eval="True"/>
+    <field name="arch" type="xml">
+        <xpath expr="//filter[@name='conflict_shifts']" position="before">
+          <filter string="Today's Check In" name="filter_checkin_today" domain="[('sale_order_id.rental_status', '=', 'pickup'), ('sale_order_id.rental_start_date', '&gt;=', 'today'), ('sale_order_id.rental_start_date', '&lt;', 'today +1d')]"/>
+          <filter string="Today's Check Out" name="filter_checkout_today" domain="[('sale_order_id.rental_status', '=', 'return'), ('sale_order_id.rental_return_date', '&gt;=', 'today'), ('sale_order_id.rental_return_date', '&lt;', 'today +1d')]"/>
+          <separator/>
+        </xpath>
+    </field>
   </record>
 </odoo>

--- a/campsite/demo/sale_order_post.xml
+++ b/campsite/demo/sale_order_post.xml
@@ -47,12 +47,40 @@
         <field name="status">pickup</field>
     </record>
 
+    <record id="pickup_wizard_6" model="rental.order.wizard">
+        <field name="order_id" ref="sale_order_6"/>
+        <field name="rental_wizard_line_ids" eval="[(0, 0, {'order_line_id': ref('sale_order_line_6'), 'product_id': ref('product_product_22'), 'qty_delivered': 1})]"/>
+        <field name="status">pickup</field>
+    </record>
+
+    <record id="pickup_wizard_11" model="rental.order.wizard">
+        <field name="order_id" ref="sale_order_11"/>
+        <field name="rental_wizard_line_ids" eval="[(0, 0, {'order_line_id': ref('sale_order_line_11a'), 'product_id': ref('product_product_14'), 'qty_delivered': 1}), (0, 0, {'order_line_id': ref('sale_order_line_11b'), 'product_id': ref('product_product_12'), 'qty_delivered': 1})]"/>
+        <field name="status">pickup</field>
+    </record>
+
+    <record id="pickup_wizard_14" model="rental.order.wizard">
+        <field name="order_id" ref="sale_order_14"/>
+        <field name="rental_wizard_line_ids" eval="[(0, 0, {'order_line_id': ref('sale_order_line_14'), 'product_id': ref('product_product_14'), 'qty_delivered': 1})]"/>
+        <field name="status">pickup</field>
+    </record>
+
+    <record id="pickup_wizard_16" model="rental.order.wizard">
+        <field name="order_id" ref="sale_order_16"/>
+        <field name="rental_wizard_line_ids" eval="[(0, 0, {'order_line_id': ref('sale_order_line_16'), 'product_id': ref('product_product_12'), 'qty_delivered': 1})]"/>
+        <field name="status">pickup</field>
+    </record>
+
     <function name="apply" model="rental.order.wizard">
         <value eval="[
             ref('pickup_wizard_1'),
             ref('return_wizard_1'),
             ref('pickup_wizard_2'),
             ref('pickup_wizard_3'),
+            ref('pickup_wizard_6'),
+            ref('pickup_wizard_11'),
+            ref('pickup_wizard_14'),
+            ref('pickup_wizard_16'),
         ]"/>
     </function>
     <function name="write" model="sale.order.line">

--- a/guest_house/demo/sale_order_post.xml
+++ b/guest_house/demo/sale_order_post.xml
@@ -27,12 +27,24 @@
         <field name="rental_wizard_line_ids" eval="[(0, 0, {'order_line_id': ref('sale_order_line_3'), 'product_id': ref('product_product_19'), 'qty_delivered': 1})]"/>
         <field name="status">pickup</field>
     </record>
+    <record id="pickup_wizard_7" model="rental.order.wizard">
+        <field name="order_id" ref="sale_order_7"/>
+        <field name="rental_wizard_line_ids" eval="[(0, 0, {'order_line_id': ref('sale_order_line_7a'), 'product_id': ref('product_product_17'), 'qty_delivered': 1}), (0, 0, {'order_line_id': ref('sale_order_line_7b'), 'product_id': ref('product_product_16'), 'qty_delivered': 1})]"/>
+        <field name="status">pickup</field>
+    </record>
+    <record id="pickup_wizard_14" model="rental.order.wizard">
+        <field name="order_id" ref="sale_order_14"/>
+        <field name="rental_wizard_line_ids" eval="[(0, 0, {'order_line_id': ref('sale_order_line_14'), 'product_id': ref('product_product_15'), 'qty_delivered': 1})]"/>
+        <field name="status">pickup</field>
+    </record>
     <function name="apply" model="rental.order.wizard">
         <value eval="[
             ref('pickup_wizard_1'),
             ref('return_wizard_1'),
             ref('pickup_wizard_2'),
             ref('pickup_wizard_3'),
+            ref('pickup_wizard_7'),
+            ref('pickup_wizard_14'),
         ]"/>
     </function>
     <function name="action_confirm" model="sale.order">

--- a/holiday_house/demo/sale_order_post.xml
+++ b/holiday_house/demo/sale_order_post.xml
@@ -47,12 +47,19 @@
         <field name="status">pickup</field>
     </record>
 
+    <record id="pickup_wizard_6" model="rental.order.wizard">
+        <field name="order_id" ref="sale_order_6"/>
+        <field name="rental_wizard_line_ids" eval="[(0, 0, {'order_line_id': ref('sale_order_line_6'), 'product_id': ref('product_product_13'), 'qty_delivered': 1})]"/>
+        <field name="status">pickup</field>
+    </record>
+
     <function name="apply" model="rental.order.wizard">
         <value eval="[
             ref('pickup_wizard_1'),
             ref('return_wizard_1'),
             ref('pickup_wizard_2'),
             ref('pickup_wizard_3'),
+            ref('pickup_wizard_6'),
         ]"/>
     </function>
     <function name="write" model="sale.order.line">

--- a/hotel/demo/sale_order_post.xml
+++ b/hotel/demo/sale_order_post.xml
@@ -47,12 +47,40 @@
         <field name="status">pickup</field>
     </record>
 
+    <record id="pickup_wizard_6" model="rental.order.wizard">
+        <field name="order_id" ref="sale_order_6"/>
+        <field name="rental_wizard_line_ids" eval="[(0, 0, {'order_line_id': ref('sale_order_line_6a'), 'product_id': ref('standard_room_1p_breakfast'), 'qty_delivered': 1}), (0, 0, {'order_line_id': ref('sale_order_line_6b'), 'product_id': ref('standard_room_1p_breakfast'), 'qty_delivered': 1})]"/>
+        <field name="status">pickup</field>
+    </record>
+
+    <record id="pickup_wizard_9" model="rental.order.wizard">
+        <field name="order_id" ref="sale_order_9"/>
+        <field name="rental_wizard_line_ids" eval="[(0, 0, {'order_line_id': ref('sale_order_line_9'), 'product_id': ref('product_template_8'), 'qty_delivered': 1})]"/>
+        <field name="status">pickup</field>
+    </record>
+
+    <record id="pickup_wizard_11" model="rental.order.wizard">
+        <field name="order_id" ref="sale_order_11"/>
+        <field name="rental_wizard_line_ids" eval="[(0, 0, {'order_line_id': ref('sale_order_line_11'), 'product_id': ref('product_template_8'), 'qty_delivered': 1})]"/>
+        <field name="status">pickup</field>
+    </record>
+
+    <record id="pickup_wizard_17" model="rental.order.wizard">
+        <field name="order_id" ref="sale_order_17"/>
+        <field name="rental_wizard_line_ids" eval="[(0, 0, {'order_line_id': ref('sale_order_line_17'), 'product_id': ref('deluxe_room_1p_breakfast'), 'qty_delivered': 1})]"/>
+        <field name="status">pickup</field>
+    </record>
+
     <function name="apply" model="rental.order.wizard">
         <value eval="[
             ref('pickup_wizard_1'),
             ref('return_wizard_1'),
             ref('pickup_wizard_2'),
             ref('pickup_wizard_3'),
+            ref('pickup_wizard_6'),
+            ref('pickup_wizard_9'),
+            ref('pickup_wizard_11'),
+            ref('pickup_wizard_17'),
         ]"/>
     </function>
     <function name="write" model="sale.order.line">


### PR DESCRIPTION
- add rental status indicators to quickly identify bookings for today's check-in, ongoing stays, and today's check-out directly from the view
- remove the default today filter
- add "Today's Check-In" and "Today's Check-Out" filters in the gantt view
- add default group by stage on the housekeeping board
- hide Guests tab and Tax button when no stay offer products are present in the SOL
- add many2one_avatar widget on x_guest_partner_id field
- hide the housekeeping section when the resource role is not linked to a stay offer product
- update demo data so orders with a start date before today and an end date after today are automatically checked in
- update demo data so orders with an end date before today are automatically checked out

Task-6144429