### PR TITLE
[FIX] booking_engine: prevent traceback when sending invites

### DIFF
--- a/booking_engine/__manifest__.py
+++ b/booking_engine/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Booking Engine',
-    'version': '1.12',
+    'version': '1.13',
     'category': 'Hidden/Tools',
     'author': 'Odoo S.A.',
     'depends': [

--- a/booking_engine/data/ir_actions_server.xml
+++ b/booking_engine/data/ir_actions_server.xml
@@ -569,7 +569,8 @@ if survey:
         } for order in orders_to_survey]
 
         invites = env['survey.invite'].create(vals_list)
-        invites.action_invite()
+        for invite in invites:
+            invite.action_invite()
         orders_to_survey.write({'x_is_survey_sent': True})]]></field>
     </record>
 </odoo>


### PR DESCRIPTION
When the cron ``Booking Engine: Send Customer Satisfaction Survey`` runs,
it creates multiple ``survey.invite`` records and calls ``action_invite()`` on the whole recordset.

However, ``action_invite()`` expects a singleton record and raises a
traceback when multiple invites are processed at once.

Steps to reproduce the error:
- Install ``hotel`` module
- Go to Surveys > Open the Customer Satisfaction survey > In the Options Tab >
  Set Email Delay to 0
- Go to Rental > Create and confirm two rental orders with a Deluxe
  Room product and a rental period end date set before today
- Run the ``Booking Engine: Send Customer Satisfaction Survey`` cron

Traceback:
```py
ValueError('Expected singleton: survey.invite(2, 3, 4)')
```

https://github.com/odoo/industry/blob/622e5d9825cccf1d0e4164fc720411d9b6193f0d/booking_engine/data/ir_actions_server.xml#L571-L572
The issue comes from calling ``action_invite()`` on multiple records.

sentry-7470595476