### PR TITLE
[FIX] beverage_distributor, micro_brewery: Automated BoM

### DIFF
--- a/beverage_distributor/data/ir_actions_server.xml
+++ b/beverage_distributor/data/ir_actions_server.xml
@@ -27,6 +27,17 @@ if record.x_unit_sale_product:
     else:
         bom_vals['product_tmpl_id'] = record.x_unit_sale_product.id
         env['mrp.bom'].create(bom_vals)
+
+    target_company_id = record.company_id.id or env.company.id
+    
+    warehouse = env['stock.warehouse'].search([('company_id', '=', target_company_id)], limit=1)
+    if not warehouse:
+        raise UserError("Cannot generate Reordering Rule: No warehouse configured for this product's company.")
+    
+    manufacture_route_id = warehouse.manufacture_pull_id.route_id.id
+    if not manufacture_route_id:
+        raise UserError("Cannot generate Reordering Rule: No manufacture route for this company's warehouse.")
+
     if not reordering_rule:
         env['stock.warehouse.orderpoint'].create({
             'product_id': record.x_unit_sale_product.product_variant_id.id,
@@ -34,8 +45,8 @@ if record.x_unit_sale_product:
             'product_min_qty': 0,
             'product_max_qty': 0,
             'qty_multiple': record.x_quantity_by_deposit_product or 1,
-            'route_id': env.ref('mrp.route_warehouse0_manufacture').id,
-            'location_id': env.ref('stock.stock_location_stock').id,
+            'route_id': manufacture_route_id,
+            'location_id': warehouse.lot_stock_id.id,
         })
 else:
     existing_bom = env['mrp.bom'].search([('x_parent_product', '=',record.id)], limit=1)

--- a/micro_brewery/data/ir_actions_server.xml
+++ b/micro_brewery/data/ir_actions_server.xml
@@ -27,6 +27,17 @@ if record.x_unit_sale_product:
     else:
         bom_vals['product_tmpl_id'] = record.x_unit_sale_product.id
         env['mrp.bom'].create(bom_vals)
+
+    target_company_id = record.company_id.id or env.company.id
+    
+    warehouse = env['stock.warehouse'].search([('company_id', '=', target_company_id)], limit=1)
+    if not warehouse:
+        raise UserError("Cannot generate Reordering Rule: No warehouse configured for this product's company.")
+    
+    manufacture_route_id = warehouse.manufacture_pull_id.route_id.id
+    if not manufacture_route_id:
+        raise UserError("Cannot generate Reordering Rule: No manufacture route for this company's warehouse.")
+
     if not reordering_rule:
         env['stock.warehouse.orderpoint'].create({
             'product_id': record.x_unit_sale_product.product_variant_id.id,
@@ -34,8 +45,8 @@ if record.x_unit_sale_product:
             'product_min_qty': 0,
             'product_max_qty': 0,
             'qty_multiple': record.x_quantity_by_deposit_product or 1,
-            'route_id': env.ref('mrp.route_warehouse0_manufacture').id,
-            'location_id': env.ref('stock.stock_location_stock').id,
+            'route_id': manufacture_route_id,
+            'location_id':warehouse.lot_stock_id.id,
         })
 else:
     existing_bom = env['mrp.bom'].search([('x_parent_product', '=',record.id)], limit=1)


### PR DESCRIPTION
Currently, the automation rule "Automated BoM" created with beverage_distributor and micro_brewery causes an error in a multi-company database.

The causing lines in the automaton rule are:
```
'route_id': env.ref('mrp.route_warehouse0_manufacture').id,
'location_id': env.ref('stock.stock_location_stock').id,
```

These two external identifiers are created for the first company in the database. If this automation were to run while not in the first database, or for products specifically not in company 1, this will cause an error.

The solution is to dynamically find the route and location depending on the current company.

Steps to reproduce:

1. Install beverage_distributor or micro_brewery
2. Create and select a new company
3. Create Product A
4. Create Product B
5. Set Product B to contain 10 Product As
6. Save > Error `Incompatible companies on records`



opw-6095558
closes #2150