### PR TITLE
[FIX] .*: fix error while validating the payment

### DIFF
--- a/gallery/data/pos_payment_method.xml
+++ b/gallery/data/pos_payment_method.xml
@@ -2,12 +2,18 @@
 <odoo noupdate="1" auto_sequence="1">
   <record id="pos_payment_method_2" model="pos.payment.method">
     <field name="name">Card</field>
+    <field name="journal_id" ref="account.1_bank"/>
   </record>
   <record id="pos_payment_method_3" model="pos.payment.method">
     <field name="name">Customer Account</field>
     <field name="split_transactions" eval="True"/>
   </record>
+  <record id="cash" model="account.journal">
+    <field name="name">Cash (gallery)</field>
+    <field name="type">cash</field>
+  </record>
   <record id="pos_payment_method_1" model="pos.payment.method">
     <field name="name">Cash</field>
+    <field name="journal_id" ref="cash"/>
   </record>
 </odoo>

--- a/student_organization/data/pos_payment_method.xml
+++ b/student_organization/data/pos_payment_method.xml
@@ -1,10 +1,16 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo auto_sequence="1" noupdate="1">
+  <record id="cash" model="account.journal">
+    <field name="name">Cash (student organization)</field>
+    <field name="type">cash</field>
+  </record>
   <record id="pos_payment_method_1" model="pos.payment.method">
     <field name="name">Cash</field>
+    <field name="journal_id" ref="cash"/>
   </record>
   <record id="pos_payment_method_2" model="pos.payment.method">
     <field name="name">Card</field>
+    <field name="journal_id" ref="account.1_bank"/>
   </record>
   <record id="pos_payment_method_3" model="pos.payment.method">
     <field name="name">Customer Account</field>


### PR DESCRIPTION
Before this commit, validating a payment could raise an error because the payment methods did not have a `journal_id` configured. As a result, the payment `type` was automatically set to `"pay_later"`, which requires a partner to be set on the payment. Since the partner was missing, the validation failed.

This commit links the cash and card payment methods to their respective journals to ensure the payment is created correctly and can be validated without errors.

Task-6208101