### PR TITLE
[FIX] *: prevent an error while opening POS session

### DIFF
--- a/bowling/__manifest__.py
+++ b/bowling/__manifest__.py
@@ -1,5 +1,6 @@
 {
     'name': 'Bowling Alley',
+    'version': '1.1',
     'category': 'Hospitality',
     'depends': [
         'base_industry_data',

--- a/bowling/data/restaurant_table.xml
+++ b/bowling/data/restaurant_table.xml
@@ -3,133 +3,133 @@
   <record id="restaurant_table_1" model="restaurant.table">
     <field name="floor_id" ref="restaurant_floor_1"/>
     <field name="table_number">1</field>
-    <field name="floor_plan_layout">{'top': 70.0, 'left': 170.0, 'width': 70.0, 'height': 350.0, 'shape': 'square', 'color': 'orange'}</field>
+    <field name="floor_plan_layout" eval="{ 'top': 70.0, 'left': 170.0, 'width': 70.0, 'height': 350.0, 'shape': 'square', 'color': 'orange' }"/>
     <field name="seats">6</field>
   </record>
   <record id="restaurant_table_2" model="restaurant.table">
     <field name="floor_id" ref="restaurant_floor_1"/>
     <field name="table_number">2</field>
-    <field name="floor_plan_layout">{'top': 70.0, 'left': 280.0, 'width': 70.0, 'height': 350.0, 'shape': 'square', 'color': 'orange'}</field>
+    <field name="floor_plan_layout" eval="{ 'top': 70.0, 'left': 280.0, 'width': 70.0, 'height': 350.0, 'shape': 'square', 'color': 'orange' }"/>
     <field name="seats">6</field>
   </record>
   <record id="restaurant_table_3" model="restaurant.table">
     <field name="floor_id" ref="restaurant_floor_1"/>
     <field name="table_number">3</field>
-    <field name="floor_plan_layout">{'top': 70.0, 'left': 390.0, 'width': 70.0, 'height': 350.0, 'shape': 'square', 'color': 'orange'}</field>
+    <field name="floor_plan_layout" eval="{ 'top': 70.0, 'left': 390.0, 'width': 70.0, 'height': 350.0, 'shape': 'square', 'color': 'orange' }"/>
     <field name="seats">6</field>
   </record>
   <record id="restaurant_table_4" model="restaurant.table">
     <field name="floor_id" ref="restaurant_floor_1"/>
     <field name="table_number">4</field>
-    <field name="floor_plan_layout">{'top': 70.0, 'left': 500.0, 'width': 70.0, 'height': 350.0, 'shape': 'square', 'color': 'orange'}</field>
+    <field name="floor_plan_layout" eval="{ 'top': 70.0, 'left': 500.0, 'width': 70.0, 'height': 350.0, 'shape': 'square', 'color': 'orange' }"/>
     <field name="seats">6</field>
   </record>
   <record id="restaurant_table_5" model="restaurant.table">
     <field name="floor_id" ref="restaurant_floor_1"/>
     <field name="table_number">5</field>
-    <field name="floor_plan_layout">{'top': 70.0, 'left': 610.0, 'width': 70.0, 'height': 350.0, 'shape': 'square', 'color': 'orange'}</field>
+    <field name="floor_plan_layout" eval="{ 'top': 70.0, 'left': 610.0, 'width': 70.0, 'height': 350.0, 'shape': 'square', 'color': 'orange' }"/>
     <field name="seats">6</field>
   </record>
   <record id="restaurant_table_6" model="restaurant.table">
     <field name="floor_id" ref="restaurant_floor_1"/>
     <field name="table_number">6</field>
-    <field name="floor_plan_layout">{'top': 70.0, 'left': 720.0, 'width': 70.0, 'height': 350.0, 'shape': 'square', 'color': 'orange'}</field>
+    <field name="floor_plan_layout" eval="{ 'top': 70.0, 'left': 720.0, 'width': 70.0, 'height': 350.0, 'shape': 'square', 'color': 'orange' }"/>
     <field name="seats">6</field>
   </record>
   <record id="restaurant_table_7" model="restaurant.table">
     <field name="floor_id" ref="restaurant_floor_1"/>
     <field name="table_number">7</field>
-    <field name="floor_plan_layout">{'top': 70.0, 'left': 830.0, 'width': 70.0, 'height': 350.0, 'shape': 'square', 'color': 'orange'}</field>
+    <field name="floor_plan_layout" eval="{ 'top': 70.0, 'left': 830.0, 'width': 70.0, 'height': 350.0, 'shape': 'square', 'color': 'orange' }"/>
     <field name="seats">6</field>
   </record>
   <record id="restaurant_table_8" model="restaurant.table">
     <field name="floor_id" ref="restaurant_floor_1"/>
     <field name="table_number">8</field>
-    <field name="floor_plan_layout">{'top': 70.0, 'left': 940.0, 'width': 70.0, 'height': 350.0, 'shape': 'square', 'color': 'orange'}</field>
+    <field name="floor_plan_layout" eval="{ 'top': 70.0, 'left': 940.0, 'width': 70.0, 'height': 350.0, 'shape': 'square', 'color': 'orange' }"/>
     <field name="seats">6</field>
   </record>
   <record id="restaurant_table_9" model="restaurant.table">
     <field name="floor_id" ref="restaurant_floor_1"/>
     <field name="table_number">9</field>
-    <field name="floor_plan_layout">{'top': 70.0, 'left': 1050.0, 'width': 70.0, 'height': 350.0, 'shape': 'square', 'color': 'orange'}</field>
+    <field name="floor_plan_layout" eval="{ 'top': 70.0, 'left': 1050.0, 'width': 70.0, 'height': 350.0, 'shape': 'square', 'color': 'orange' }"/>
     <field name="seats">6</field>
   </record>
   <record id="restaurant_table_10" model="restaurant.table">
     <field name="floor_id" ref="restaurant_floor_1"/>
     <field name="table_number">10</field>
-    <field name="floor_plan_layout">{'top': 70.0, 'left': 1160.0, 'width': 70.0, 'height': 350.0, 'shape': 'square', 'color': 'orange'}</field>
+    <field name="floor_plan_layout" eval="{ 'top': 70.0, 'left': 1160.0, 'width': 70.0, 'height': 350.0, 'shape': 'square', 'color': 'orange' }"/>
     <field name="seats">6</field>
   </record>
   <record id="restaurant_table_11" model="restaurant.table">
     <field name="floor_id" ref="restaurant_floor_1"/>
     <field name="table_number">11</field>
-    <field name="floor_plan_layout">{'top': 70.0, 'left': 1270.0, 'width': 70.0, 'height': 350.0, 'shape': 'square', 'color': 'orange'}</field>
+    <field name="floor_plan_layout" eval="{ 'top': 70.0, 'left': 1270.0, 'width': 70.0, 'height': 350.0, 'shape': 'square', 'color': 'orange' }"/>
     <field name="seats">6</field>
   </record>
   <record id="restaurant_table_12" model="restaurant.table">
     <field name="floor_id" ref="restaurant_floor_1"/>
     <field name="table_number">12</field>
-    <field name="floor_plan_layout">{'top': 70.0, 'left': 1380.0, 'width': 70.0, 'height': 350.0, 'shape': 'square', 'color': 'orange'}</field>
+    <field name="floor_plan_layout" eval="{ 'top': 70.0, 'left': 1380.0, 'width': 70.0, 'height': 350.0, 'shape': 'square', 'color': 'orange' }"/>
     <field name="seats">6</field>
   </record>
   <record id="restaurant_table_13" model="restaurant.table">
     <field name="floor_id" ref="restaurant_floor_1"/>
     <field name="table_number">13</field>
-    <field name="floor_plan_layout">{'top': 70.0, 'left': 1490.0, 'width': 70.0, 'height': 350.0, 'shape': 'square', 'color': 'orange'}</field>
+    <field name="floor_plan_layout" eval="{ 'top': 70.0, 'left': 1490.0, 'width': 70.0, 'height': 350.0, 'shape': 'square', 'color': 'orange' }"/>
     <field name="seats">6</field>
   </record>
   <record id="restaurant_table_14" model="restaurant.table">
     <field name="floor_id" ref="restaurant_floor_1"/>
     <field name="table_number">14</field>
-    <field name="floor_plan_layout">{'top': 70.0, 'left': 1600.0, 'width': 70.0, 'height': 350.0, 'shape': 'square', 'color': 'orange'}</field>
+    <field name="floor_plan_layout" eval="{ 'top': 70.0, 'left': 1600.0, 'width': 70.0, 'height': 350.0, 'shape': 'square', 'color': 'orange' }"/>
     <field name="seats">6</field>
   </record>
   <record id="restaurant_table_15" model="restaurant.table">
     <field name="floor_id" ref="restaurant_floor_2"/>
     <field name="table_number">1</field>
-    <field name="floor_plan_layout">{'top': 120.0, 'left': 170.0, 'width': 130.0, 'height': 130.0, 'shape': 'square', 'color': 'green'}</field>
+    <field name="floor_plan_layout" eval="{ 'top': 120.0, 'left': 170.0, 'width': 130.0, 'height': 130.0, 'shape': 'square', 'color': 'green' }"/>
     <field name="seats">6</field>
   </record>
   <record id="restaurant_table_16" model="restaurant.table">
     <field name="floor_id" ref="restaurant_floor_2"/>
     <field name="table_number">2</field>
-    <field name="floor_plan_layout">{'top': 120.0, 'left': 340.0, 'width': 130.0, 'height': 130.0, 'shape': 'square', 'color': 'green'}</field>
+    <field name="floor_plan_layout" eval="{ 'top': 120.0, 'left': 340.0, 'width': 130.0, 'height': 130.0, 'shape': 'square', 'color': 'green' }"/>
     <field name="seats">6</field>
   </record>
   <record id="restaurant_table_17" model="restaurant.table">
     <field name="floor_id" ref="restaurant_floor_2"/>
     <field name="table_number">3</field>
-    <field name="floor_plan_layout">{'top': 120.0, 'left': 510.0, 'width': 130.0, 'height': 130.0, 'shape': 'square', 'color': 'green'}</field>
+    <field name="floor_plan_layout" eval="{ 'top': 120.0, 'left': 510.0, 'width': 130.0, 'height': 130.0, 'shape': 'square', 'color': 'green' }"/>
     <field name="seats">6</field>
   </record>
   <record id="restaurant_table_18" model="restaurant.table">
     <field name="floor_id" ref="restaurant_floor_2"/>
     <field name="table_number">4</field>
-    <field name="floor_plan_layout">{'top': 120.0, 'left': 680.0, 'width': 130.0, 'height': 130.0, 'shape': 'square', 'color': 'green'}</field>
+    <field name="floor_plan_layout" eval="{ 'top': 120.0, 'left': 680.0, 'width': 130.0, 'height': 130.0, 'shape': 'square', 'color': 'green' }"/>
     <field name="seats">6</field>
   </record>
   <record id="restaurant_table_19" model="restaurant.table">
     <field name="floor_id" ref="restaurant_floor_2"/>
     <field name="table_number">5</field>
-    <field name="floor_plan_layout">{'top': 120.0, 'left': 850.0, 'width': 130.0, 'height': 130.0, 'shape': 'square', 'color': 'green'}</field>
+    <field name="floor_plan_layout" eval="{ 'top': 120.0, 'left': 850.0, 'width': 130.0, 'height': 130.0, 'shape': 'square', 'color': 'green' }"/>
     <field name="seats">6</field>
   </record>
   <record id="restaurant_table_20" model="restaurant.table">
     <field name="floor_id" ref="restaurant_floor_2"/>
     <field name="table_number">6</field>
-    <field name="floor_plan_layout">{'top': 120.0, 'left': 1020.0, 'width': 130.0, 'height': 130.0, 'shape': 'square', 'color': 'green'}</field>
+    <field name="floor_plan_layout" eval="{ 'top': 120.0, 'left': 1020.0, 'width': 130.0, 'height': 130.0, 'shape': 'square', 'color': 'green' }"/>
     <field name="seats">6</field>
   </record>
   <record id="restaurant_table_21" model="restaurant.table">
     <field name="floor_id" ref="restaurant_floor_2"/>
     <field name="table_number">7</field>
-    <field name="floor_plan_layout">{'top': 120.0, 'left': 1190.0, 'width': 130.0, 'height': 130.0, 'shape': 'square', 'color': 'green'}</field>
+    <field name="floor_plan_layout" eval="{ 'top': 120.0, 'left': 1190.0, 'width': 130.0, 'height': 130.0, 'shape': 'square', 'color': 'green' }"/>
     <field name="seats">6</field>
   </record>
   <record id="restaurant_table_23" model="restaurant.table">
     <field name="floor_id" ref="restaurant_floor_2"/>
     <field name="table_number">8</field>
-    <field name="floor_plan_layout">{'top': 120.0, 'left': 1360.0, 'width': 130.0, 'height': 130.0, 'shape': 'square', 'color': 'green'}</field>
+    <field name="floor_plan_layout" eval="{ 'top': 120.0, 'left': 1360.0, 'width': 130.0, 'height': 130.0, 'shape': 'square', 'color': 'green' }"/>
     <field name="seats">6</field>
   </record>
 </odoo>

--- a/food_trucks/__manifest__.py
+++ b/food_trucks/__manifest__.py
@@ -1,5 +1,6 @@
 {
     'name': 'Food Trucks',
+    'version': '1.1',
     'category': 'Hospitality',
     'author': 'Odoo S.A.',
     'depends': [

--- a/food_trucks/data/restaurant_table.xml
+++ b/food_trucks/data/restaurant_table.xml
@@ -2,6 +2,6 @@
 <odoo noupdate="1">
   <record id="restaurant_table_1" model="restaurant.table">
     <field name="table_number">101</field>
-    <field name="floor_plan_layout">{'top': 100.0, 'left': 100.0, 'width': 130.0, 'height': 130.0, 'shape': 'square'}</field>
+    <field name="floor_plan_layout" eval="{'top': 100.0, 'left': 100.0, 'width': 130.0, 'height': 130.0, 'shape': 'square'}" />
   </record>
 </odoo>

--- a/micro_brewery/__manifest__.py
+++ b/micro_brewery/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Microbrewery',
-    'version': '2.4',
+    'version': '2.5',
     'category': 'Supply Chain',
     'depends': [
         'account',

--- a/micro_brewery/data/restaurant_table.xml
+++ b/micro_brewery/data/restaurant_table.xml
@@ -4,139 +4,139 @@
         <field name="floor_id" ref="restaurant_floor_1"/>
         <field name="table_number">1</field>
         <field name="seats">2</field>
-        <field name="floor_plan_layout">{'top': 100.0, 'left': 48.82, 'width': 130.0, 'height': 130.0, 'shape': 'square'}</field>
+        <field name="floor_plan_layout" eval="{'top': 100.0, 'left': 48.82, 'width': 130.0, 'height': 130.0, 'shape': 'square'}" />
     </record>
     <record id="restaurant_table_2" model="restaurant.table">
         <field name="floor_id" ref="restaurant_floor_1"/>
         <field name="table_number">2</field>
         <field name="seats">2</field>
-        <field name="floor_plan_layout">{'top': 100.0, 'left': 203.23, 'width': 130.0, 'height': 130.0, 'shape': 'square'}</field>
+        <field name="floor_plan_layout" eval="{'top': 100.0, 'left': 203.23, 'width': 130.0, 'height': 130.0, 'shape': 'square'}" />
     </record>
     <record id="restaurant_table_3" model="restaurant.table">
         <field name="floor_id" ref="restaurant_floor_1"/>
         <field name="table_number">3</field>
         <field name="seats">2</field>
-        <field name="floor_plan_layout">{'top': 100.0, 'left': 357.63, 'width': 130.0, 'height': 130.0, 'shape': 'square'}</field>
+        <field name="floor_plan_layout" eval="{'top': 100.0, 'left': 357.63, 'width': 130.0, 'height': 130.0, 'shape': 'square'}" />
     </record>
     <record id="restaurant_table_4" model="restaurant.table">
         <field name="floor_id" ref="restaurant_floor_1"/>
         <field name="table_number">4</field>
         <field name="seats">2</field>
-        <field name="floor_plan_layout">{'top': 100.0, 'left': 512.03, 'width': 130.0, 'height': 130.0, 'shape': 'square'}</field>
+        <field name="floor_plan_layout" eval="{'top': 100.0, 'left': 512.03, 'width': 130.0, 'height': 130.0, 'shape': 'square'}" />
     </record>
     <record id="restaurant_table_5" model="restaurant.table">
         <field name="floor_id" ref="restaurant_floor_1"/>
         <field name="table_number">5</field>
         <field name="seats">2</field>
-        <field name="floor_plan_layout">{'top': 100.0, 'left': 693.44, 'width': 130.0, 'height': 130.0, 'shape': 'square'}</field>
+        <field name="floor_plan_layout" eval="{'top': 100.0, 'left': 693.44, 'width': 130.0, 'height': 130.0, 'shape': 'square'}" />
     </record>
 
     <record id="restaurant_table_6" model="restaurant.table">
         <field name="floor_id" ref="restaurant_floor_1"/>
         <field name="table_number">6</field>
         <field name="seats">4</field>
-        <field name="floor_plan_layout">{'top': 350.0, 'left': 50, 'width': 300.0, 'height': 193.0, 'shape': 'square'}</field>
+        <field name="floor_plan_layout" eval="{'top': 350.0, 'left': 50, 'width': 300.0, 'height': 193.0, 'shape': 'square'}" />
     </record>
     <record id="restaurant_table_7" model="restaurant.table">
         <field name="floor_id" ref="restaurant_floor_1"/>
         <field name="table_number">7</field>
         <field name="seats">4</field>
-        <field name="floor_plan_layout">{'top': 350.0, 'left': 459.63, 'width': 293.0, 'height': 190.0, 'shape': 'square'}</field>
+        <field name="floor_plan_layout" eval="{'top': 350.0, 'left': 459.63, 'width': 293.0, 'height': 190.0, 'shape': 'square'}" />
     </record>
     <record id="restaurant_table_8" model="restaurant.table">
         <field name="floor_id" ref="restaurant_floor_1"/>
         <field name="table_number">8</field>
         <field name="seats">4</field>
-        <field name="floor_plan_layout">{'top': 72.0, 'left': 844.63, 'width': 296.0, 'height': 188.0, 'shape': 'square'}</field>
+        <field name="floor_plan_layout" eval="{'top': 72.0, 'left': 844.63, 'width': 296.0, 'height': 188.0, 'shape': 'square'}" />
     </record>
     <record id="restaurant_table_9" model="restaurant.table">
         <field name="floor_id" ref="restaurant_floor_1"/>
         <field name="table_number">9</field>
         <field name="seats">4</field>
-        <field name="floor_plan_layout">{'top': 350.0, 'left': 841.63, 'width': 297.0, 'height': 193.0, 'shape': 'square'}</field>
+        <field name="floor_plan_layout" eval="{'top': 350.0, 'left': 841.63, 'width': 297.0, 'height': 193.0, 'shape': 'square'}" />
     </record>
     <record id="restaurant_table_10" model="restaurant.table">
         <field name="floor_id" ref="restaurant_floor_1"/>
         <field name="table_number">10</field>
         <field name="seats">4</field>
-        <field name="floor_plan_layout">{'top': 72.0, 'left': 1224.63, 'width': 287.0, 'height': 185.0, 'shape': 'square'}</field>
+        <field name="floor_plan_layout" eval="{'top': 72.0, 'left': 1224.63, 'width': 287.0, 'height': 185.0, 'shape': 'square'}" />
     </record>
     <record id="restaurant_table_11" model="restaurant.table">
         <field name="floor_id" ref="restaurant_floor_1"/>
         <field name="table_number">11</field>
         <field name="seats">4</field>
-        <field name="floor_plan_layout">{'top': 350.0, 'left': 1224.63, 'width': 283.0, 'height': 183.0, 'shape': 'square'}</field>
+        <field name="floor_plan_layout" eval="{'top': 350.0, 'left': 1224.63, 'width': 283.0, 'height': 183.0, 'shape': 'square'}" />
     </record>
     <record id="restaurant_table_12" model="restaurant.table">
         <field name="floor_id" ref="restaurant_floor_2"/>
         <field name="table_number">12</field>
         <field name="seats">6</field>
-        <field name="floor_plan_layout">{'top': 64.0, 'left': 93.82, 'width': 261.0, 'height': 144.0, 'shape': 'square'}</field>
+        <field name="floor_plan_layout" eval="{'top': 64.0, 'left': 93.82, 'width': 261.0, 'height': 144.0, 'shape': 'square'}" />
     </record>
     <record id="restaurant_table_13" model="restaurant.table">
         <field name="floor_id" ref="restaurant_floor_2"/>
         <field name="table_number">13</field>
         <field name="seats">6</field>
-        <field name="floor_plan_layout">{'top': 299.0, 'left': 89.23, 'width': 269.0, 'height': 151.0, 'shape': 'square'}</field>
+        <field name="floor_plan_layout" eval="{'top': 299.0, 'left': 89.23, 'width': 269.0, 'height': 151.0, 'shape': 'square'}" />
     </record>
     <record id="restaurant_table_14" model="restaurant.table">
         <field name="floor_id" ref="restaurant_floor_2"/>
         <field name="table_number">14</field>
         <field name="seats">6</field>
-        <field name="floor_plan_layout">{'top': 559.0, 'left': 90.63, 'width': 264.0, 'height': 147.0, 'shape': 'square'}</field>
+        <field name="floor_plan_layout" eval="{'top': 559.0, 'left': 90.63, 'width': 264.0, 'height': 147.0, 'shape': 'square'}" />
     </record>
     <record id="restaurant_table_15" model="restaurant.table">
         <field name="floor_id" ref="restaurant_floor_2"/>
         <field name="table_number">15</field>
         <field name="seats">6</field>
-        <field name="floor_plan_layout">{'top': 67.0, 'left': 478.03, 'width': 253.0, 'height': 140.0, 'shape': 'square'}</field>
+        <field name="floor_plan_layout" eval="{'top': 67.0, 'left': 478.03, 'width': 253.0, 'height': 140.0, 'shape': 'square'}" />
     </record>
     <record id="restaurant_table_16" model="restaurant.table">
         <field name="floor_id" ref="restaurant_floor_2"/>
         <field name="table_number">16</field>
         <field name="seats">6</field>
-        <field name="floor_plan_layout">{'top': 302.0, 'left': 479.45, 'width': 246.0, 'height': 143.0, 'shape': 'square'}</field>
+        <field name="floor_plan_layout" eval="{'top': 302.0, 'left': 479.45, 'width': 246.0, 'height': 143.0, 'shape': 'square'}" />
     </record>
     <record id="restaurant_table_17" model="restaurant.table">
         <field name="floor_id" ref="restaurant_floor_2"/>
         <field name="table_number">17</field>
         <field name="seats">4</field>
-        <field name="floor_plan_layout">{'top': 70.0, 'left': 827.85, 'width': 130.0, 'height': 130.0, 'shape': 'round'}</field>
+        <field name="floor_plan_layout" eval="{'top': 70.0, 'left': 827.85, 'width': 130.0, 'height': 130.0, 'shape': 'round'}" />
     </record>
     <record id="restaurant_table_18" model="restaurant.table">
         <field name="floor_id" ref="restaurant_floor_2"/>
         <field name="table_number">18</field>
         <field name="seats">4</field>
-        <field name="floor_plan_layout">{'top': 310.0, 'left': 1081.23, 'width': 130.0, 'height': 130.0, 'shape': 'round'}</field>
+        <field name="floor_plan_layout" eval="{'top': 310.0, 'left': 1081.23, 'width': 130.0, 'height': 130.0, 'shape': 'round'}" />
     </record>
     <record id="restaurant_table_19" model="restaurant.table">
         <field name="floor_id" ref="restaurant_floor_2"/>
         <field name="table_number">19</field>
         <field name="seats">6</field>
-        <field name="floor_plan_layout">{'top': 563.0, 'left': 481.23, 'width': 234.0, 'height': 131.0, 'shape': 'square'}</field>
+        <field name="floor_plan_layout" eval="{'top': 563.0, 'left': 481.23, 'width': 234.0, 'height': 131.0, 'shape': 'square'}" />
     </record>
     <record id="restaurant_table_20" model="restaurant.table">
         <field name="floor_id" ref="restaurant_floor_2"/>
         <field name="table_number">20</field>
         <field name="seats">4</field>
-        <field name="floor_plan_layout">{'top': 512.0, 'left': 1091.22, 'width': 130.0, 'height': 130.0, 'shape': 'round'}</field>
+        <field name="floor_plan_layout" eval="{'top': 512.0, 'left': 1091.22, 'width': 130.0, 'height': 130.0, 'shape': 'round'}" />
     </record>
     <record id="restaurant_table_22" model="restaurant.table">
         <field name="floor_id" ref="restaurant_floor_2"/>
         <field name="table_number">22</field>
         <field name="seats">4</field>
-        <field name="floor_plan_layout">{'top': 57.0, 'left': 1236.45, 'width': 130.0, 'height': 130.0, 'shape': 'round'}</field>
+        <field name="floor_plan_layout" eval="{'top': 57.0, 'left': 1236.45, 'width': 130.0, 'height': 130.0, 'shape': 'round'}" />
     </record>
     <record id="restaurant_table_23" model="restaurant.table">
         <field name="floor_id" ref="restaurant_floor_2"/>
         <field name="table_number">23</field>
         <field name="seats">4</field>
-        <field name="floor_plan_layout">{'top': 309.0, 'left': 1243.44, 'width': 130.0, 'height': 130.0, 'shape': 'round'}</field>
+        <field name="floor_plan_layout" eval="{'top': 309.0, 'left': 1243.44, 'width': 130.0, 'height': 130.0, 'shape': 'round'}" />
     </record>
     <record id="restaurant_table_24" model="restaurant.table">
         <field name="floor_id" ref="restaurant_floor_2"/>
         <field name="table_number">24</field>
         <field name="seats">4</field>
-        <field name="floor_plan_layout">{'top': 554.0, 'left': 1252.44, 'width': 130.0, 'height': 130.0, 'shape': 'round'}</field>
+        <field name="floor_plan_layout" eval="{'top': 554.0, 'left': 1252.44, 'width': 130.0, 'height': 130.0, 'shape': 'round'}" />
     </record>
 </odoo>

--- a/sports_club/__manifest__.py
+++ b/sports_club/__manifest__.py
@@ -1,5 +1,6 @@
 {
     'name': 'Sports Club',
+    'version': '1.1',
     'category': 'Health and Fitness',
     'depends': [
         'appointment_crm',

--- a/sports_club/data/restaurant_table.xml
+++ b/sports_club/data/restaurant_table.xml
@@ -4,54 +4,54 @@
         <field name="floor_id" ref="restaurant_floor_1"/>
         <field name="table_number">1</field>
         <field name="seats">4</field>
-        <field name="floor_plan_layout">{'top': 103.0, 'left': 610.8, 'width': 141.0, 'height': 139.0, 'color': '#6C6DEC', 'shape': 'square'}</field>
+        <field name="floor_plan_layout" eval="{'top': 103.0, 'left': 610.8, 'width': 141.0, 'height': 139.0, 'color': '#6C6DEC', 'shape': 'square'}" />
     </record>
     <record id="restaurant_table_2" model="restaurant.table">
         <field name="floor_id" ref="restaurant_floor_1"/>
         <field name="table_number">2</field>
         <field name="seats">6</field>
-        <field name="floor_plan_layout">{'top': 104.0, 'left': 835.8, 'width': 246.0, 'height': 141.0, 'color': '#6C6DEC', 'shape': 'square'}</field>
+        <field name="floor_plan_layout" eval="{'top': 104.0, 'left': 835.8, 'width': 246.0, 'height': 141.0, 'color': '#6C6DEC', 'shape': 'square'}" />
     </record>
     <record id="restaurant_table_3" model="restaurant.table">
         <field name="floor_id" ref="restaurant_floor_1"/>
         <field name="table_number">3</field>
         <field name="seats">4</field>
-        <field name="floor_plan_layout">{'top': 313.0, 'left': 949.8, 'width': 130.0, 'height': 130.0, 'color': '#6C6DEC', 'shape': 'square'}</field>
+        <field name="floor_plan_layout" eval="{'top': 313.0, 'left': 949.8, 'width': 130.0, 'height': 130.0, 'color': '#6C6DEC', 'shape': 'square'}" />
     </record>
     <record id="restaurant_table_4" model="restaurant.table">
         <field name="floor_id" ref="restaurant_floor_1"/>
         <field name="table_number">4</field>
         <field name="seats">4</field>
-        <field name="floor_plan_layout">{'top': 312.0, 'left': 600.8, 'width': 311.0, 'height': 132.0, 'color': '#6C6DEC', 'shape': 'square'}</field>
+        <field name="floor_plan_layout" eval="{'top': 312.0, 'left': 600.8, 'width': 311.0, 'height': 132.0, 'color': '#6C6DEC', 'shape': 'square'}" />
     </record>
     <record id="restaurant_table_5" model="restaurant.table">
         <field name="floor_id" ref="restaurant_floor_1"/>
         <field name="table_number">5</field>
-        <field name="floor_plan_layout">{'top': 479.0, 'left': 601.0, 'width': 60.0, 'height': 60.0, 'color': 'rgb(53, 211, 116)', 'shape': 'square'}</field>
+        <field name="floor_plan_layout" eval="{'top': 479.0, 'left': 601.0, 'width': 60.0, 'height': 60.0, 'color': 'rgb(53, 211, 116)', 'shape': 'square'}" />
     </record>
     <record id="restaurant_table_6" model="restaurant.table">
         <field name="floor_id" ref="restaurant_floor_1"/>
         <field name="table_number">6</field>
-        <field name="floor_plan_layout">{'top': 481.0, 'left': 681.8, 'width': 60.0, 'height': 60.0, 'color': 'rgb(53, 211, 116)', 'shape': 'square'}</field>
+        <field name="floor_plan_layout" eval="{'top': 481.0, 'left': 681.8, 'width': 60.0, 'height': 60.0, 'color': 'rgb(53, 211, 116)', 'shape': 'square'}" />
     </record>
     <record id="restaurant_table_7" model="restaurant.table">
         <field name="floor_id" ref="restaurant_floor_1"/>
         <field name="table_number">7</field>
-        <field name="floor_plan_layout">{'top': 482.0, 'left': 761.8, 'width': 60.0, 'height': 60.0, 'color': 'rgb(53, 211, 116)', 'shape': 'square'}</field>
+        <field name="floor_plan_layout" eval="{'top': 482.0, 'left': 761.8, 'width': 60.0, 'height': 60.0, 'color': 'rgb(53, 211, 116)', 'shape': 'square'}" />
     </record>
     <record id="restaurant_table_8" model="restaurant.table">
         <field name="floor_id" ref="restaurant_floor_1"/>
         <field name="table_number">8</field>
-        <field name="floor_plan_layout">{'top': 482.0, 'left': 844.8, 'width': 60.0, 'height': 60.0, 'color': 'rgb(53, 211, 116)', 'shape': 'square'}</field>
+        <field name="floor_plan_layout" eval="{'top': 482.0, 'left': 844.8, 'width': 60.0, 'height': 60.0, 'color': 'rgb(53, 211, 116)', 'shape': 'square'}" />
     </record>
     <record id="restaurant_table_9" model="restaurant.table">
         <field name="floor_id" ref="restaurant_floor_1"/>
         <field name="table_number">9</field>
-        <field name="floor_plan_layout">{'top': 484.0, 'left': 928.2, 'width': 60.0, 'height': 60.0, 'color': 'rgb(53, 211, 116)', 'shape': 'square'}</field>
+        <field name="floor_plan_layout" eval="{'top': 484.0, 'left': 928.2, 'width': 60.0, 'height': 60.0, 'color': 'rgb(53, 211, 116)', 'shape': 'square'}" />
     </record>
     <record id="restaurant_table_10" model="restaurant.table">
         <field name="floor_id" ref="restaurant_floor_1"/>
         <field name="table_number">10</field>
-        <field name="floor_plan_layout">{'top': 484.0, 'left': 1016.6, 'width': 60.0, 'height': 60.0, 'color': 'rgb(53, 211, 116)', 'shape': 'square'}</field>
+        <field name="floor_plan_layout" eval="{'top': 484.0, 'left': 1016.6, 'width': 60.0, 'height': 60.0, 'color': 'rgb(53, 211, 116)', 'shape': 'square'}" />
     </record>
 </odoo>


### PR DESCRIPTION
 *= ['bowling', 'food_trucks', 'micro_brewery', 'sports_club']

Currently, an error occurs while opening the restaurant session.

Step to reproduce:
- Install the bowling module.
- Open the Restaurant POS session.

`TypeError: 'str' object is not a mapping`

The issue occurs because floor_plan_layout values are defined as strings in XML
data. During floor plan computation, the value is later unpacked as a
dictionary [1], which causes the traceback 

link [1]: https://github.com/odoo/odoo/blob/76e179f24807612f2d864f14f1a0a1a5661585b0/addons/pos_restaurant/models/pos_config.py#L186

To fix this issue, define floor_plan_layout values using eval="{}" in the XML
data, so they are stored as dictionaries instead of strings.

The same issue also exists in food_trucks, micro_brewery, and sports_club, but
no traceback occurs because module_pos_restaurant(Is a Bar/Restaurant) is
disabled (False), which skips the restaurant floor plan computation. If
that is enabled (True), the same error will occur.

Task ID-6193639