### PR TITLE
[IMP] headhunter: configurable mail templates

### DIFF
--- a/headhunter/__manifest__.py
+++ b/headhunter/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Talent Acquisition',
-    'version': '1.3',
+    'version': '1.4',
     'category': 'Services',
     'depends': [
         'account',

--- a/headhunter/data/ir_actions_act_window.xml
+++ b/headhunter/data/ir_actions_act_window.xml
@@ -65,4 +65,12 @@
         <field name="view_mode">list,form</field>
         <field name="context">{'group_by': 'job_id'}</field>
     </record>
+    <record id="email_template_window_action" model="ir.actions.act_window">
+        <field name="name">Email Templates</field>
+        <field name="res_model">mail.template</field>
+        <field name="view_mode">form,list</field>
+        <field name="view_id" ref="mail.email_template_tree" />
+        <field name="search_view_id" ref="mail.view_email_template_search"/>
+        <field name="context">{'search_default_filter_applicant': 1}</field>
+    </record>
 </odoo>

--- a/headhunter/data/ir_actions_server.xml
+++ b/headhunter/data/ir_actions_server.xml
@@ -53,11 +53,12 @@ action = env['portal.wizard'].with_context(default_partner_ids=record.x_hiring_t
   <!-- mail pop up server action -->
     <record id="ir_actions_server_for_email_pop_up" model="ir.actions.server">
         <field name="code"><![CDATA[
+template = env['mail.template'].search([('x_is_template_to_send_cv', '=', True)], limit=1)
 action = env.ref('headhunter.open_mail_compose_message_act_window').read()[0]
 action['context'] =  {
     'default_model': 'hr.applicant',
     'default_res_ids': [record.id],
-    'default_template_id': (env.ref('headhunter.mail_template_60', raise_if_not_found=False) or env['mail.compose.message']).id,
+    'default_template_id': template.id if template else False,
     'default_composition_mode': 'comment',
     'default_attachment_ids': [(6, 0, record.x_shared_cv_ids.ids)],
     'force_email': True,

--- a/headhunter/data/ir_model_fields.xml
+++ b/headhunter/data/ir_model_fields.xml
@@ -176,6 +176,13 @@ for job in self:
         <field name="ttype">boolean</field>
         <field name="copied" eval="False"/>
     </record>
+    <record id="x_is_template_to_send_cv_field" model="ir.model.fields">
+        <field name="name">x_is_template_to_send_cv</field>
+        <field name="field_description">Use for Send CV button</field>
+        <field name="model_id" ref="mail.model_mail_template" />
+        <field name="ttype">boolean</field>
+        <field name="help">If this toggle is enabled on multiple email templates, the template that appears first in the list will be used for the 'Send CV' button.</field>
+    </record>
     <!-- cv sent model fields -->
     <record id="x_applicant_id_field" model="ir.model.fields">
         <field name="name">x_applicant_id</field>

--- a/headhunter/data/ir_ui_menu.xml
+++ b/headhunter/data/ir_ui_menu.xml
@@ -1,6 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo>
     <menuitem id="CV_sent_menu" name="CV Sent Report" action="cv_sent_report_act_window" parent="hr_recruitment.report_hr_recruitment"/>
+    <menuitem id="email_templates_menu" name="Email Templates" action="email_template_window_action" parent="hr_recruitment.menu_hr_recruitment_config_activities" sequence="30"/>
     <record id="hr_recruitment.menu_hr_recruitment_root" model="ir.ui.menu" forcecreate="0">
         <field name="sequence">1</field>
     </record>

--- a/headhunter/data/ir_ui_view.xml
+++ b/headhunter/data/ir_ui_view.xml
@@ -281,4 +281,26 @@
             </xpath>
         </field>
     </record>
+    <record id="view_email_template_search_inherit" model="ir.ui.view">
+        <field name="name">mail.template.search.inherit.view</field>
+        <field name="model">mail.template</field>
+        <field name="inherit_id" ref="mail.view_email_template_search"/>
+        <field name="active" eval="True"/>
+        <field name="arch" type="xml">
+            <xpath expr="//filter[@name='base_templates']" position="after">
+                <filter string="Applicant Templates" name="filter_applicant" domain="[('model', '=', 'hr.applicant')]"/>
+            </xpath>
+        </field>
+    </record>
+    <record id="email_template_form_inherit_view" model="ir.ui.view">
+        <field name="name">mail.template.form.inherit.view</field>
+        <field name="model">mail.template</field>
+        <field name="inherit_id" ref="mail.email_template_form"/>
+        <field name="active" eval="True"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='attachment_ids']" position="after">
+                <field name="x_is_template_to_send_cv" widget="boolean_toggle"/>
+            </xpath>
+        </field>
+    </record>
 </odoo>

--- a/headhunter/data/mail_template.xml
+++ b/headhunter/data/mail_template.xml
@@ -135,6 +135,8 @@
     <record id="mail_template_60" model="mail.template">
         <field name="name">Recruitment: Send CV</field>
         <field name="model_id" ref="hr_recruitment.model_hr_applicant"/>
+        <field name="description">Email sent via the 'Send CV' button for talent and applicants</field>
+        <field name="x_is_template_to_send_cv" eval="True"/>
         <field name="subject">Potential Applicant for {{ (object.job_id.name + ' ') if object.job_id else '' }}</field>
         <field name="body_html"><![CDATA[
                 <div>Hi,</div>


### PR DESCRIPTION
Before this PR, the CV sending flow relied on a static mail template. As a result, users could not use a different template without modifying the server action manually.

With this commit, a boolean field has been added on mail templates to allow users to define which template should be used for sending CVs, making the flow more flexible and configurable.

**Task - 6213718**