### PR TITLE
[IMP] booking_engine: add Daily Lines on SO and Manager Dashboard

### DIFF
--- a/booking_engine/__manifest__.py
+++ b/booking_engine/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Booking',
-    'version': '1.20',
+    'version': '1.21',
     'category': 'Hospitality',
     'author': 'Odoo S.A.',
     'depends': [

--- a/booking_engine/__manifest__.py
+++ b/booking_engine/__manifest__.py
@@ -44,6 +44,7 @@
         'data/survey_survey.xml',
         'data/survey_question.xml',
         'data/survey_question_answer.xml',
+        'data/spreadsheet_dashboard.xml',
     ],
     'demo': [
         'demo/website_menu.xml',

--- a/booking_engine/data/base_automation.xml
+++ b/booking_engine/data/base_automation.xml
@@ -158,4 +158,53 @@
         <field name="trigger_field_ids" eval="[(6, 0, [ref('x_is_customer_satisfaction_survey_field')])]"/>
         <field name="action_server_ids" eval="[(6, 0, [ref('server_action_to_archive_surveys')])]"/>
     </record>
+
+    <!-- Daily Lines -->
+    <record id="automation_daily_lines_on_so_create" model="base.automation">
+        <field name="model_id" ref="sale.model_sale_order"/>
+        <field name="action_server_ids" eval="[(6, 0, [ref('server_action_create_daily_lines_from_so')])]"/>
+        <field name="trigger">on_create_or_write</field>
+        <field name="filter_domain">[('rental_status', '=', 'pickup'), ('rental_start_date', '!=', False), ('rental_return_date', '!=', False)]</field>
+        <field name="filter_pre_domain">[('rental_status', 'in', ['draft', 'sent'])]</field>
+        <field name="name">Daily Lines: On SO confirmation</field>
+        <field name="trigger_field_ids" eval="[(6, 0, [ref('sale_renting.field_sale_order__rental_status')])]"/>
+    </record>
+    <record id="automation_daily_lines_on_so_cancel" model="base.automation">
+        <field name="model_id" ref="sale.model_sale_order"/>
+        <field name="action_server_ids" eval="[(6, 0, [ref('server_action_unlink_daily_lines_from_so')])]"/>
+        <field name="trigger">on_create_or_write</field>
+        <field name="filter_domain">[('x_daily_lines_ids', '!=', False), ('state', '=', 'cancel')]</field>
+        <field name="name">Daily Lines: On SO cancelled</field>
+        <field name="trigger_field_ids" eval="[(6, 0, [ref('sale.field_sale_order__state')])]"/>
+    </record>
+    <record id="automation_daily_lines_on_so_delete" model="base.automation">
+        <field name="model_id" ref="sale.model_sale_order"/>
+        <field name="action_server_ids" eval="[(6, 0, [ref('server_action_unlink_daily_lines_from_so_2')])]"/>
+        <field name="trigger">on_unlink</field>
+        <field name="filter_domain">[('x_daily_lines_ids', '!=', False)]</field>
+        <field name="name">Daily Lines: On SO delete</field>
+    </record>
+    <record id="automation_daily_lines_on_sol_create" model="base.automation">
+        <field name="model_id" ref="sale.model_sale_order_line"/>
+        <field name="action_server_ids" eval="[(6, 0, [ref('server_action_create_daily_lines_from_sol')])]"/>
+        <field name="trigger">on_create</field>
+        <field name="filter_domain">[('product_id.product_tmpl_id.x_is_a_room_offer', '=', True), ('order_id.rental_status', 'in', ['pickup', 'return', 'returned']), ('order_id.rental_start_date', '!=', False), ('order_id.rental_return_date', '!=', False)]</field>
+        <field name="name">Daily Lines: On SOL creation in confirmed order</field>
+    </record>
+    <record id="automation_daily_lines_on_sol_write" model="base.automation">
+        <field name="model_id" ref="sale.model_sale_order_line"/>
+        <field name="action_server_ids" eval="[(6, 0, [ref('server_action_modify_daily_lines_from_sol')])]"/>
+        <field name="trigger">on_write</field>
+        <field name="filter_domain">[('x_daily_line_ids', '!=', False)]</field>
+        <field name="name">Daily Lines: On SOL with daily lines write</field>
+    </record>
+    <record id="automation_daily_lines_on_so_rental_date_changed" model="base.automation">
+        <field name="model_id" ref="sale.model_sale_order"/>
+        <field name="action_server_ids" eval="[(6, 0, [ref('server_action_modify_daily_lines_from_so_date_change')])]"/>
+        <field name="trigger">on_write</field>
+        <field name="filter_domain">[('rental_status', 'in', ['pickup', 'return']), ('rental_start_date', '!=', False), ('rental_return_date', '!=', False)]</field>
+        <field name="filter_pre_domain">[('rental_status', 'in', ['pickup', 'return'])]</field>
+        <field name="name">Daily Lines: On SO rental date changed</field>
+        <field name="trigger_field_ids" eval="[(6, 0, [ref('sale_renting.field_sale_order__rental_start_date'), ref('sale_renting.field_sale_order__rental_return_date')])]"/>
+    </record>
 </odoo>

--- a/booking_engine/data/ir_actions_server.xml
+++ b/booking_engine/data/ir_actions_server.xml
@@ -528,4 +528,104 @@ if survey:
             invite.action_invite()
         orders_to_survey.write({'x_is_survey_sent': True})]]></field>
     </record>
+
+    <!-- Daily Lines -->
+    <record id="server_action_create_daily_lines_from_so" model="ir.actions.server">
+        <field name="code"><![CDATA[
+dates_covered = []
+current_date = record.rental_start_date
+while current_date < record.rental_return_date:
+    dates_covered.append(current_date.date())
+    current_date += datetime.timedelta(days=1)
+env.ref('booking_engine.server_action_method_create_daily_lines').with_context(
+    active_model='sale.order.line', active_ids=records.order_line.filtered(lambda l: l.product_id.product_tmpl_id.x_is_a_room_offer).ids, dates=dates_covered
+).run()
+]]></field>
+        <field name="model_id" ref="sale.model_sale_order"/>
+        <field name="state">code</field>
+        <field name="name">Dashboard: Create daily lines from so</field>
+    </record>
+    <record id="server_action_unlink_daily_lines_from_so" model="ir.actions.server">
+        <field name="code"><![CDATA[
+records.x_daily_lines_ids.unlink()
+]]></field>
+        <field name="model_id" ref="sale.model_sale_order"/>
+        <field name="state">code</field>
+        <field name="name">Dashboard: Delete daily lines from so</field>
+    </record>
+    <record id="server_action_unlink_daily_lines_from_so_2" model="ir.actions.server">
+        <field name="code"><![CDATA[
+records.x_daily_lines_ids.unlink()
+]]></field>
+        <field name="model_id" ref="sale.model_sale_order"/>
+        <field name="state">code</field>
+        <field name="name">Dashboard: Delete daily lines from so 2</field>
+    </record>
+    <record id="server_action_create_daily_lines_from_sol" model="ir.actions.server">
+        <field name="code"><![CDATA[
+dates_covered = []
+current_date = record.order_id.rental_start_date
+while current_date < record.order_id.rental_return_date:
+    dates_covered.append(current_date.date())
+    current_date += datetime.timedelta(days=1)
+env.ref('booking_engine.server_action_method_create_daily_lines').with_context(
+    active_model='sale.order.line', active_ids=records.ids, dates=dates_covered
+).run()
+]]></field>
+        <field name="model_id" ref="sale.model_sale_order_line"/>
+        <field name="state">code</field>
+        <field name="name">Dashboard: Create daily lines from sol</field>
+    </record>
+    <record id="server_action_method_create_daily_lines" model="ir.actions.server">
+        <field name="code"><![CDATA[
+dates_covered = env.context.get('dates') or []
+daily_lines_values = []
+for record in (records or []):
+    for current_date in dates_covered:
+        daily_lines_values.append({
+            'x_sale_order_id': record.order_id.id,
+            'x_sale_order_line_id': record.id,
+            'x_date': current_date,
+            'x_price': record.order_id.pricelist_id._get_product_price(record.product_id, 1.0, date=current_date),
+            'x_state': 'planned',
+        })
+env['x_so_daily_line'].create(daily_lines_values)
+]]></field>
+        <field name="model_id" ref="sale.model_sale_order_line"/>
+        <field name="state">code</field>
+        <field name="name">Dashboard: Create daily lines, Method</field>
+    </record>
+    <record id="server_action_modify_daily_lines_from_sol" model="ir.actions.server">
+        <field name="code"><![CDATA[
+for record in records:
+    for daily_line in record.x_daily_line_ids:
+        daily_line.write({
+            'x_price': record.order_id.pricelist_id._get_product_price(record.product_id, 1.0, date=daily_line.x_date),
+        })
+]]></field>
+        <field name="model_id" ref="sale.model_sale_order_line"/>
+        <field name="state">code</field>
+        <field name="name">Dashboard: Modify daily lines from sol</field>
+    </record>
+    <record id="server_action_modify_daily_lines_from_so_date_change" model="ir.actions.server">
+        <field name="code"><![CDATA[
+for record in records:
+    for daily_line in record.x_daily_lines_ids:
+        if daily_line.x_date < record.rental_start_date.date() or daily_line.x_date >= record.rental_return_date.date():
+            daily_line.unlink()
+    represented_dates = record.x_daily_lines_ids.mapped('x_date')
+    to_cover_dates = []
+    current_date = record.rental_start_date
+    while current_date < record.rental_return_date:
+        if current_date.date() not in represented_dates:
+            to_cover_dates.append(current_date.date())
+        current_date += datetime.timedelta(days=1)
+    record.env.ref('booking_engine.server_action_method_create_daily_lines').with_context(
+        active_model='sale.order.line', active_ids=record.order_line.filtered(lambda l: l.product_id.product_tmpl_id.x_is_a_room_offer).ids, dates=to_cover_dates
+    ).run()
+]]></field>
+        <field name="model_id" ref="sale.model_sale_order"/>
+        <field name="state">code</field>
+        <field name="name">Dashboard: Modify daily lines from so rental dates change</field>
+    </record>
 </odoo>

--- a/booking_engine/data/ir_model.xml
+++ b/booking_engine/data/ir_model.xml
@@ -13,4 +13,8 @@
     <field name="model">x_availability</field>
     <field name="name">Availability</field>
   </record>
+    <record id="x_model_so_daily_line" model="ir.model">
+        <field name="model">x_so_daily_line</field>
+        <field name="name">Sale Order Daily Line</field>
+    </record>
 </odoo>

--- a/booking_engine/data/ir_model_access.xml
+++ b/booking_engine/data/ir_model_access.xml
@@ -27,4 +27,13 @@
         <field name="perm_write" eval="False"/>
         <field name="perm_unlink" eval="False"/>
     </record>
+    <record id="x_model_daily_line_access" model="ir.model.access">
+        <field name="group_id" ref="base.group_user"/>
+        <field name="model_id" ref="x_model_so_daily_line"/>
+        <field name="name">x_model_daily_line_group_user_access</field>
+        <field name="perm_create" eval="False"/>
+        <field name="perm_read" eval="True"/>
+        <field name="perm_write" eval="False"/>
+        <field name="perm_unlink" eval="False"/>
+    </record>
 </odoo>

--- a/booking_engine/data/ir_model_fields.xml
+++ b/booking_engine/data/ir_model_fields.xml
@@ -833,4 +833,104 @@ for record in self:
     record['x_has_room_offer_role'] = any(role.x_is_a_room_offer for role in record.role_ids)
   ]]></field>
   </record>
+
+    <!-- Daily Lines -->
+    <record id="x_sale_order_id_field_daily_line" model="ir.model.fields">
+        <field name="ttype">many2one</field>
+        <field name="copied" eval="True"/>
+        <field name="field_description">Sale Order</field>
+        <field name="model_id" ref="x_model_so_daily_line"/>
+        <field name="name">x_sale_order_id</field>
+        <field name="relation">sale.order</field>
+    </record>
+    <record id="x_sale_order_line_id_field_daily_line" model="ir.model.fields">
+        <field name="ttype">many2one</field>
+        <field name="copied" eval="True"/>
+        <field name="field_description">Sale Order Line</field>
+        <field name="model_id" ref="x_model_so_daily_line"/>
+        <field name="name">x_sale_order_line_id</field>
+        <field name="relation">sale.order.line</field>
+    </record>
+    <record id="x_date_field_daily_line" model="ir.model.fields">
+        <field name="ttype">date</field>
+        <field name="copied" eval="True"/>
+        <field name="field_description">Date</field>
+        <field name="model_id" ref="x_model_so_daily_line"/>
+        <field name="name">x_date</field>
+    </record>
+    <record id="x_currency_id_field_daily_line" model="ir.model.fields">
+        <field name="ttype">many2one</field>
+        <field name="field_description">Currency</field>
+        <field name="model_id" ref="x_model_so_daily_line"/>
+        <field name="name">x_currency_id</field>
+        <field name="relation">res.currency</field>
+        <field name="related">x_sale_order_id.currency_id</field>
+    </record>
+    <record id="x_price_field_daily_line" model="ir.model.fields">
+        <field name="ttype">monetary</field>
+        <field name="copied" eval="True"/>
+        <field name="field_description">Price</field>
+        <field name="model_id" ref="x_model_so_daily_line"/>
+        <field name="name">x_price</field>
+        <field name="currency_field">x_currency_id</field>
+    </record>
+    <record id="x_state_field_daily_line" model="ir.model.fields">
+        <field name="ttype">selection</field>
+        <field name="copied" eval="True"/>
+        <field name="field_description">State</field>
+        <field name="model_id" ref="x_model_so_daily_line"/>
+        <field name="name">x_state</field>
+    </record>
+    <record id="x_state_field_daily_line_selection_planned" model="ir.model.fields.selection">
+        <field name="name">Planned</field>
+        <field name="field_id" ref="x_state_field_daily_line" />
+        <field name="value">planned</field>
+    </record>
+    <record id="x_state_field_daily_line_selection_done" model="ir.model.fields.selection">
+        <field name="name">Done</field>
+        <field name="field_id" ref="x_state_field_daily_line" />
+        <field name="value">done</field>
+    </record>
+    <record id="x_state_field_daily_line_selection_cancel" model="ir.model.fields.selection">
+        <field name="name">Cancel</field>
+        <field name="field_id" ref="x_state_field_daily_line" />
+        <field name="value">cancel</field>
+    </record>
+    <record id="x_quantity_field_daily_line" model="ir.model.fields">
+        <field name="ttype">float</field>
+        <field name="related">x_sale_order_line_id.product_uom_qty</field>
+        <field name="field_description">Quantity</field>
+        <field name="model_id" ref="x_model_so_daily_line"/>
+        <field name="name">x_quantity</field>
+        <field name="readonly" eval="True"/>
+    </record>
+    <record id="x_amount_field_daily_line" model="ir.model.fields">
+        <field name="compute"><![CDATA[
+for record in self:
+    record['x_amount'] = record.x_price * record.x_quantity  * (1 - record.x_sale_order_line_id.discount/100)]]></field>
+        <field name="ttype">monetary</field>
+        <field name="depends">x_price, x_quantity, x_sale_order_line_id.discount</field>
+        <field name="field_description">Amount</field>
+        <field name="model_id" ref="x_model_so_daily_line"/>
+        <field name="name">x_amount</field>
+        <field name="readonly" eval="True"/>
+        <field name="currency_field">x_currency_id</field>
+    </record>
+
+    <record id="x_daily_lines_ids_field_sale_order" model="ir.model.fields">
+        <field name="ttype">one2many</field>
+        <field name="field_description">Daily Lines</field>
+        <field name="model_id" ref="sale.model_sale_order"/>
+        <field name="name">x_daily_lines_ids</field>
+        <field name="relation">x_so_daily_line</field>
+        <field name="relation_field">x_sale_order_id</field>
+    </record>
+    <record id="x_daily_line_ids_field_sale_order_line" model="ir.model.fields">
+        <field name="ttype">one2many</field>
+        <field name="field_description">Daily Line</field>
+        <field name="model_id" ref="sale.model_sale_order_line"/>
+        <field name="name">x_daily_line_ids</field>
+        <field name="relation">x_so_daily_line</field>
+        <field name="relation_field">x_sale_order_line_id</field>
+    </record>
 </odoo>

--- a/booking_engine/data/ir_ui_menu.xml
+++ b/booking_engine/data/ir_ui_menu.xml
@@ -7,7 +7,7 @@
       <menuitem id="menu_board_house_keeping" name="Board" action="act_window_board"/>
       <menuitem id="menu_tasks_house_keeping" name="Tasks" action="act_window_house_keeping_project_tasks"/>
     </menuitem>
-    <menuitem id="menu_availability_steering" name="Steering">
+    <menuitem id="menu_availability_steering" name="Steering" groups="group_steering">
       <menuitem id="menu_availability_occupancy" name="Occupancy" action="action_window_availability_occupancy"/>
       <menuitem id="menu_availability_availability" name="Availability" action="action_window_availability_availability"/>
     </menuitem>

--- a/booking_engine/data/res_config_settings.xml
+++ b/booking_engine/data/res_config_settings.xml
@@ -149,6 +149,111 @@ self['x_setting_approvers'] = self.env['ir.config_parameter'].get_bool('booking_
         <field name="name">x_setting_related_approver_users_ids</field>
     </record>
 
+    <!-- Steering Settings-->
+    <record id="x_setting_field_steering" model="ir.model.fields">
+        <field name="ttype">boolean</field>
+        <field name="field_description">Steering</field>
+        <field name="model_id" ref="base_setup.model_res_config_settings"/>
+        <field name="name">x_setting_steering</field>
+        <field name="store" eval="True"/>
+        <field name="compute"><![CDATA[
+self['x_setting_steering'] = self.env['ir.config_parameter'].get_bool('booking_engine.x_steering_setting', False)
+]]></field>
+    </record>
+    <record id="server_action_set_x_setting_steering" model="ir.actions.server">
+        <field name="name">Set Steering setting</field>
+        <field name="code"><![CDATA[
+records_archive = [
+    'ir_cron_create_500_days_availability',
+    'ir_cron_send_survey',
+    'automation_on_planning_slot_change',
+    'automation_on_planning_slot_delete',
+    'automation_on_resource_calendar_leaves_change',
+    'automation_on_resource_calendar_leaves_delete',
+    'automation_on_resource_resource_change',
+    'automation_on_resource_resource_delete',
+    'automation_on_product_template_change',
+    'automation_on_product_template_delete',
+    'automation_to_archive_existing_surveys',
+    'automation_daily_lines_on_so_create',
+    'automation_daily_lines_on_so_cancel',
+    'automation_daily_lines_on_so_delete',
+    'automation_daily_lines_on_sol_create',
+    'automation_daily_lines_on_sol_write',
+    'automation_daily_lines_on_so_rental_date_changed',
+]
+cloc_entries = [
+    'x_availability_color_field_x_availability',
+    'x_available_field_x_availability',
+    'x_availability_field_x_availability',
+    'x_occupancy_field_x_availability',
+    'x_occupancy_color_field_x_availability',
+    'x_availability_color_field_x_availability',
+    'x_amount_field_daily_line',
+    'server_action_update_availabilities',
+    'server_action_create_500_days_availability',
+    'server_action_helper_compute_new_avails_to_recompute',
+    'server_action_update_availability_for_planning_slot_delete',
+    'server_action_update_availability_for_resource_calendar_leaves_delete',
+    'server_action_update_availability_for_resource_resource_delete',
+    'server_action_update_availability_for_product_template_delete',
+    'server_action_update_availability_for_planning_slot',
+    'server_action_update_availability_for_resource_calendar_leaves',
+    'server_action_update_availability_for_resource_resource',
+    'server_action_update_availability_for_product_template',
+    'server_action_to_archive_surveys',
+    'ir_actions_server_send_survey',
+    'server_action_create_daily_lines_from_so',
+    'server_action_unlink_daily_lines_from_so',
+    'server_action_unlink_daily_lines_from_so_2',
+    'server_action_create_daily_lines_from_sol',
+    'server_action_method_create_daily_lines',
+    'server_action_modify_daily_lines_from_sol',
+    'server_action_modify_daily_lines_from_so_date_change',
+]
+env['ir.config_parameter'].set_bool('booking_engine.x_steering_setting', record.x_setting_steering)
+if record.x_setting_steering:
+    env.ref('base.group_user')._apply_group(env.ref('booking_engine.group_steering'))
+    for to_unarchive in records_archive:
+        env.ref(f'booking_engine.{to_unarchive}')['active'] = True
+    for cloc_entry in cloc_entries:
+        if (cloc_entry_id := env.ref(f'__cloc_exclude__.booking_engine_{cloc_entry}', raise_if_not_found=False)):
+            entry_model = 'ir.actions.server' if cloc_entry.startswith('server_action') else 'ir.model.fields'
+            env['ir.model.data'].search([
+                ('name', '=', f'booking_engine_{cloc_entry}'),
+                ('model', '=', entry_model),
+                ('module', '=', '__cloc_exclude__'),
+                ('res_id', '=', cloc_entry_id.id),
+            ], limit=1).unlink()
+    env.ref('booking_engine.spreadsheet_dashboard_1')['is_published'] = True
+else:
+    env.ref('base.group_user')._remove_group(env.ref('booking_engine.group_steering'))
+    for to_archive in records_archive:
+        env.ref(f'booking_engine.{to_archive}')['active'] = False
+    for cloc_entry in cloc_entries:
+        cloc_exclude_id = f'booking_engine_{cloc_entry}'
+        entry_model = 'ir.actions.server' if cloc_entry.startswith('server_action') else 'ir.model.fields'
+        if (cloc_entry_id := env.ref(f'booking_engine.{cloc_entry}', raise_if_not_found=False)) and not env.ref(f'__cloc_exclude__.{cloc_exclude_id}', raise_if_not_found=False):
+            env['ir.model.data'].create({
+                'name': cloc_exclude_id,
+                'model': entry_model,
+                'module': '__cloc_exclude__',
+                'res_id': cloc_entry_id.id,
+            })
+    env.ref('booking_engine.spreadsheet_dashboard_1')['is_published'] = False
+]]></field>
+        <field name="model_id" ref="base_setup.model_res_config_settings"/>
+        <field name="state">code</field>
+    </record>
+    <record id="automation_on_x_setting_steering_set" model="base.automation">
+        <field name="name">On Steering setting set</field>
+        <field name="model_id" ref="base_setup.model_res_config_settings"/>
+        <field name="action_server_ids" eval="[(6, 0, [ref('server_action_set_x_setting_steering')])]"/>
+        <field name="trigger">on_create_or_write</field>
+        <field name="trigger_field_ids" eval="[(6, 0, [ref('x_setting_field_steering')])]"/>
+    </record>
+
+
     <record id="server_action_set_x_setting_approvers" model="ir.actions.server">
         <field name="name">HouseKeeping: Set approvers setting</field>
         <field name="code"><![CDATA[
@@ -174,7 +279,7 @@ env['ir.config_parameter'].set_bool('booking_engine.x_approvers_setting', (True 
         <field name="arch" type="xml">
             <xpath expr="//form" position="inside">
                 <app string="Accomodation" name="accomodation">
-                    <block title="House Keeping" name="house_keeping_config_block">
+                    <block title="Operations" name="booking_operations_config_block">
                         <setting id="booking_engine_house_keeping_setting" help="Access cleanness state and manage tasks.">
                             <field name="x_module_house_keeping"/>
                             <div class="row mt-2" invisible="not x_module_house_keeping">
@@ -190,12 +295,13 @@ env['ir.config_parameter'].set_bool('booking_engine.x_approvers_setting', (True 
                             </div>
                         </setting>
                     </block>
+                    <block title="Management" name="booking_management_config_block">
+                        <setting id="booking_engine_steering_setting" help="Monitor availability, occupancy, average daily rate, revenue per available unit and pick-ups.">
+                            <field name="x_setting_steering"/>
+                        </setting>
+                    </block>
                 </app>
             </xpath>
         </field>
     </record>
-
-    <function name="run" model="ir.actions.server" context="{'active_model': 'res.config.settings', 'active_id': ref('res_config_settings_enable')}">
-        <value eval="[ref('x_action_activate_house_keeping')]"/>
-    </function>
 </odoo>

--- a/booking_engine/data/res_groups.xml
+++ b/booking_engine/data/res_groups.xml
@@ -3,4 +3,7 @@
     <record id="group_house_keeping" model="res.groups">
         <field name="name">House Keeping</field>
     </record>
+    <record id="group_steering" model="res.groups">
+        <field name="name">Steering</field>
+    </record>
 </odoo>

--- a/booking_engine/data/spreadsheet_dashboard.xml
+++ b/booking_engine/data/spreadsheet_dashboard.xml
@@ -1,0 +1,13 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<odoo noupdate="1">
+    <record id="spreadsheet_dashboard_group_accomodation" model="spreadsheet.dashboard.group">
+        <field name="name">Accomodation</field>
+        <field name="sequence">0</field>
+    </record>
+    <record id="spreadsheet_dashboard_1" model="spreadsheet.dashboard">
+        <field name="spreadsheet_snapshot" type="base64" file="booking_engine/static/src/binary/spreadsheet_dashboard/PerformanceDashboard.osheet.json"/>
+        <field name="name">Performance</field>
+        <field name="dashboard_group_id" ref="spreadsheet_dashboard_group_accomodation"/>
+        <field name="group_ids" eval="[(6, 0, [ref('base.group_system')])]"/>
+    </record>
+</odoo>

--- a/booking_engine/static/src/binary/spreadsheet_dashboard/PerformanceDashboard.osheet.json
+++ b/booking_engine/static/src/binary/spreadsheet_dashboard/PerformanceDashboard.osheet.json
@@ -1,0 +1,569 @@
+{
+    "version": "19.1.2",
+    "sheets": [{
+        "id": "sheet1",
+        "name": "Dashboard",
+        "colNumber": 13,
+        "rowNumber": 39,
+        "rows": {},
+        "cols": {
+            "5": {
+                "size": 56
+            },
+            "6": {
+                "size": 24
+            },
+            "12": {
+                "size": 55
+            }
+        },
+        "merges": [],
+        "cells": {
+            "A8": "[Average Daily Rate (ADR)](odoo://view/{\"viewType\":\"graph\",\"action\":{\"domain\":[[\"state\",\"not in\",[\"draft\",\"cancel\",\"sent\"]]],\"context\":{\"group_by\":[\"date:month\"],\"graph_measure\":\"price_subtotal\",\"graph_mode\":\"line\",\"graph_groupbys\":[\"date:month\"]},\"modelName\":\"sale.report\",\"views\":[[false,\"graph\"],[false,\"pivot\"],[false,\"search\"]]},\"threshold\":0,\"name\":\"Sales Analysis\"})",
+            "A24": "Occupancy",
+            "H8": "Revenue Per Available Rooms (RevPAR)",
+            "H24": "Pick-ups"
+        },
+        "styles": {
+            "A6:M6": 1,
+            "A8:M8": 2,
+            "A24:M24": 2
+        },
+        "formats": {},
+        "borders": {
+            "A8:F8": 1,
+            "A24:F24": 1,
+            "H8:M8": 1,
+            "H24:M24": 1
+        },
+        "conditionalFormats": [],
+        "dataValidationRules": [],
+        "figures": [{
+            "id": "3388eef8-4cb3",
+            "col": 0,
+            "row": 24,
+            "offset": {
+                "x": 0,
+                "y": 1.22216796875
+            },
+            "width": 536,
+            "height": 335,
+            "tag": "chart",
+            "data": {
+                "type": "line",
+                "dataSetsHaveTitle": false,
+                "dataSets": [{
+                    "dataRange": "Computations!D:D",
+                    "backgroundColor": "#F6B26B",
+                    "label": "Occupancy"
+                }],
+                "legendPosition": "none",
+                "labelRange": "Computations!A:A",
+                "title": {},
+                "labelsAsText": false,
+                "stacked": false,
+                "aggregated": false,
+                "cumulative": false,
+                "fillArea": true,
+                "humanize": true,
+                "chartId": "9c340420-b831"
+            }
+        }, {
+            "id": "0112f659-bb3f",
+            "col": 0,
+            "row": 8,
+            "offset": {
+                "x": 0,
+                "y": 1.32379150390625
+            },
+            "width": 536,
+            "height": 335,
+            "tag": "chart",
+            "data": {
+                "type": "line",
+                "dataSetsHaveTitle": false,
+                "dataSets": [{
+                    "dataRange": "Computations!E:E",
+                    "label": "ADR"
+                }],
+                "legendPosition": "none",
+                "labelRange": "Computations!A:A",
+                "title": {},
+                "labelsAsText": false,
+                "stacked": false,
+                "aggregated": false,
+                "cumulative": false,
+                "fillArea": true,
+                "humanize": true,
+                "chartId": "c4a06801-7e42"
+            }
+        }, {
+            "id": "da269ffe-4916",
+            "col": 7,
+            "row": 8,
+            "offset": {
+                "x": 0,
+                "y": 1.32379150390625
+            },
+            "width": 536,
+            "height": 335,
+            "tag": "chart",
+            "data": {
+                "type": "line",
+                "dataSetsHaveTitle": false,
+                "dataSets": [{
+                    "dataRange": "Computations!F:F",
+                    "backgroundColor": "#93C47D",
+                    "label": "RevPAR"
+                }],
+                "legendPosition": "none",
+                "labelRange": "Computations!A:A",
+                "title": {},
+                "labelsAsText": false,
+                "stacked": false,
+                "aggregated": false,
+                "cumulative": false,
+                "fillArea": true,
+                "humanize": true,
+                "chartId": "3fb5d88f-b7ad"
+            }
+        }, {
+            "id": "ff62eb91-4e28",
+            "col": 7,
+            "row": 24,
+            "offset": {
+                "x": 0,
+                "y": 1.22216796875
+            },
+            "width": 536,
+            "height": 335,
+            "tag": "chart",
+            "data": {
+                "type": "line",
+                "dataSetsHaveTitle": false,
+                "dataSets": [{
+                    "dataRange": "Computations!G:G",
+                    "backgroundColor": "#8E7CC3",
+                    "label": "Pick-ups"
+                }],
+                "legendPosition": "none",
+                "labelRange": "Computations!A:A",
+                "title": {},
+                "labelsAsText": false,
+                "stacked": false,
+                "aggregated": false,
+                "cumulative": false,
+                "fillArea": true,
+                "humanize": true,
+                "chartId": "b235909f-e931"
+            }
+        }, {
+            "id": "89c8c72a-b85a",
+            "col": 1,
+            "row": 1,
+            "offset": {
+                "x": 42.66668701171875,
+                "y": 0
+            },
+            "width": 188,
+            "height": 115,
+            "tag": "chart",
+            "data": {
+                "baselineColorDown": "#EA6175",
+                "baselineColorUp": "#43C5B1",
+                "baselineMode": "text",
+                "title": {
+                    "text": "ADR"
+                },
+                "type": "scorecard",
+                "background": "#CFE2F3",
+                "keyValue": "Computations!S3",
+                "humanize": true,
+                "chartId": "c4c2c511-3743"
+            }
+        }, {
+            "id": "282af57a-9cc6",
+            "col": 3,
+            "row": 1,
+            "offset": {
+                "x": 60,
+                "y": 0
+            },
+            "width": 188,
+            "height": 115,
+            "tag": "chart",
+            "data": {
+                "baselineColorDown": "#EA6175",
+                "baselineColorUp": "#43C5B1",
+                "baselineMode": "text",
+                "title": {
+                    "text": "RevPAR"
+                },
+                "type": "scorecard",
+                "background": "#D9EAD3",
+                "keyValue": "Computations!S4",
+                "humanize": true,
+                "chartId": "5b8bb441-b1ae"
+            }
+        }, {
+            "id": "20e25748-28b9",
+            "col": 7,
+            "row": 1,
+            "offset": {
+                "x": 0,
+                "y": 0
+            },
+            "width": 188,
+            "height": 115,
+            "tag": "chart",
+            "data": {
+                "baselineColorDown": "#EA6175",
+                "baselineColorUp": "#43C5B1",
+                "baselineMode": "text",
+                "title": {
+                    "text": "Occupancy"
+                },
+                "type": "scorecard",
+                "background": "#FCE5CD",
+                "keyValue": "Computations!S2",
+                "humanize": true,
+                "chartId": "2ef36806-8801"
+            }
+        }, {
+            "id": "1ce68ec8-8b5f",
+            "col": 9,
+            "row": 1,
+            "offset": {
+                "x": 17.111083984375,
+                "y": 0
+            },
+            "width": 188,
+            "height": 115,
+            "tag": "chart",
+            "data": {
+                "baselineColorDown": "#EA6175",
+                "baselineColorUp": "#43C5B1",
+                "baselineMode": "text",
+                "title": {
+                    "text": "Pick-ups"
+                },
+                "type": "scorecard",
+                "background": "#D9D2E9",
+                "keyValue": "Computations!S5",
+                "keyDescr": {
+                    "align": "center",
+                    "fontSize": 32,
+                    "bold": false
+                },
+                "humanize": true,
+                "chartId": "22546bd6-58b4"
+            }
+        }],
+        "tables": [],
+        "areGridLinesVisible": true,
+        "isVisible": true,
+        "headerGroups": {
+            "ROW": [],
+            "COL": []
+        },
+        "comments": {}
+    }, {
+        "id": "a79e2887-f456",
+        "name": "Computations",
+        "colNumber": 19,
+        "rowNumber": 558,
+        "rows": {},
+        "cols": {
+            "9": {
+                "size": 20
+            },
+            "13": {
+                "size": 20
+            },
+            "16": {
+                "size": 20
+            }
+        },
+        "merges": [],
+        "cells": {
+            "A1": "=pivot(1)",
+            "K1": "=PIVOT(2)",
+            "O1": {
+                "N": "+1"
+            },
+            "R1": "KPIs",
+            "R2": "Occupancy",
+            "R3": "ARD",
+            "R4": "RevPAR",
+            "R5": "Pickup",
+            "S2": "=sum(C:C)/sum(B:B)",
+            "S3": {
+                "R": "H:H|I:I"
+            },
+            "S4": "=SUM(H:H)/sum(B:B)",
+            "S5": "=sum(G:G)"
+        },
+        "styles": {
+            "H1:I558": 3,
+            "J2:Q2": 4,
+            "R1": 4,
+            "R15": 4
+        },
+        "formats": {
+            "A1:A558": 1,
+            "D256:D558": 2,
+            "E1:F1": 3,
+            "E256:F558": 3,
+            "H71:H558": 3,
+            "S3:S4": 3,
+            "S2": 4
+        },
+        "borders": {},
+        "conditionalFormats": [],
+        "dataValidationRules": [],
+        "figures": [],
+        "tables": [],
+        "areGridLinesVisible": true,
+        "isVisible": true,
+        "isLocked": false,
+        "headerGroups": {
+            "ROW": [],
+            "COL": []
+        },
+        "comments": {}
+    }],
+    "styles": {
+        "1": {
+            "fontSize": 14,
+            "bold": true
+        },
+        "2": {
+            "textColor": "#01666b",
+            "bold": true,
+            "fontSize": 16
+        },
+        "3": {
+            "textColor": "#999999"
+        },
+        "4": {
+            "bold": true
+        }
+    },
+    "formats": {
+        "1": "mmm dd",
+        "2": "0.00%",
+        "3": "#,##0.00[$€]",
+        "4": "0.0%"
+    },
+    "borders": {
+        "1": {
+            "bottom": {
+                "style": "thin",
+                "color": "#CCCCCC"
+            }
+        }
+    },
+    "revisionId": "67f82f5f-0ee0-48e2-9264-6b284ab0495b",
+    "uniqueFigureIds": true,
+    "settings": {
+        "locale": {
+            "name": "English (US)",
+            "code": "en_US",
+            "thousandsSeparator": ",",
+            "decimalSeparator": ".",
+            "dateFormat": "mm/dd/yyyy",
+            "timeFormat": "hh:mm:ss a",
+            "formulaArgSeparator": ",",
+            "weekStart": 7
+        }
+    },
+    "pivots": {
+        "aec6f3e5-ae7b": {
+            "type": "ODOO",
+            "name": "Availability by Date (Day)",
+            "model": "x_availability",
+            "domain": ["|", ["x_active", "!=", false],
+                ["x_active", "=", false]
+            ],
+            "context": {},
+            "rows": [{
+                "fieldName": "x_date",
+                "granularity": "day"
+            }],
+            "columns": [],
+            "measures": [{
+                "id": "x_total_units:sum",
+                "fieldName": "x_total_units",
+                "aggregator": "sum"
+            }, {
+                "id": "x_booked:sum",
+                "fieldName": "x_booked",
+                "aggregator": "sum"
+            }, {
+                "id": "Occupancy:sum",
+                "fieldName": "Occupancy",
+                "aggregator": "sum",
+                "userDefinedName": "Occupancy",
+                "computedBy": {
+                    "sheetId": "a79e2887-f456",
+                    "formula": "='x_booked:sum'/'x_total_units:sum'"
+                },
+                "isHidden": false,
+                "format": "0%"
+            }, {
+                "id": "ARD:sum",
+                "fieldName": "ARD",
+                "aggregator": "sum",
+                "userDefinedName": "ARD",
+                "computedBy": {
+                    "sheetId": "a79e2887-f456",
+                    "formula": "=if('Quantity (ARD):sum'=0,0,'Amount (ARD):sum'/'Quantity (ARD):sum')"
+                },
+                "format": "#,##0.00[$€]"
+            }, {
+                "id": "RevPAR:sum",
+                "fieldName": "RevPAR",
+                "aggregator": "sum",
+                "userDefinedName": "RevPAR",
+                "computedBy": {
+                    "sheetId": "a79e2887-f456",
+                    "formula": "=if('x_total_units:sum'=0,0,'Amount (ARD):sum'/'x_total_units:sum')\n"
+                },
+                "format": "#,##0.00[$€]"
+            }, {
+                "id": "Pick-up:sum",
+                "fieldName": "Pick-up",
+                "aggregator": "sum",
+                "userDefinedName": "Pick-up",
+                "computedBy": {
+                    "formula": "=if(\n\tiserror(MATCH('x_date:day', O:O, 0)), \n\t0, \n\toffset(P$1, MATCH('x_date:day', O:O, 0)-1, 0)\n)",
+                    "sheetId": "a79e2887-f456"
+                }
+            }, {
+                "id": "Amount (ARD):sum",
+                "fieldName": "Amount (ARD)",
+                "aggregator": "sum",
+                "userDefinedName": "Amount (ARD)",
+                "computedBy": {
+                    "sheetId": "a79e2887-f456",
+                    "formula": "=if(\n\tiserror(MATCH('x_date:day', K:K, 0)), \n\t0,\n\toffset(L$1, MATCH('x_date:day', K:K, 0)-1, 0)\n)"
+                },
+                "format": "#,##0.00[$€]"
+            }, {
+                "id": "Quantity (ARD):sum",
+                "fieldName": "Quantity (ARD)",
+                "aggregator": "sum",
+                "userDefinedName": "Quantity (ARD)",
+                "computedBy": {
+                    "sheetId": "a79e2887-f456",
+                    "formula": "=if(\n\tiserror(MATCH('x_date:day', K:K, 0)), \n\t0,\n\toffset(M$1, MATCH('x_date:day', K:K, 0)-1, 0)\n)"
+                }
+            }],
+            "actionXmlId": "booking_engine.action_window_availability_occupancy",
+            "style": {
+                "tableStyleId": "PivotTableStyleMedium12",
+                "displayColumnHeaders": false,
+                "displayTotals": false,
+                "displayMeasuresRow": false
+            },
+            "formulaId": "1",
+            "fieldMatching": {
+                "9326b427-429f": {
+                    "chain": "x_date",
+                    "type": "date",
+                    "offset": 0
+                }
+            }
+        },
+        "4c132140-4648": {
+            "type": "ODOO",
+            "name": "sale_order_daily_line",
+            "model": "x_so_daily_line",
+            "rows": [{
+                "fieldName": "x_date",
+                "order": "asc",
+                "granularity": "day"
+            }],
+            "columns": [],
+            "measures": [{
+                "id": "x_amount:sum",
+                "fieldName": "x_amount",
+                "aggregator": "sum"
+            }, {
+                "id": "x_quantity:sum",
+                "fieldName": "x_quantity",
+                "aggregator": "sum"
+            }],
+            "style": {
+                "tableStyleId": "PivotTableStyleMedium12",
+                "displayTotals": false,
+                "displayColumnHeaders": false
+            },
+            "formulaId": "2",
+            "domain": [],
+            "fieldMatching": {
+                "9326b427-429f": {
+                    "chain": "x_date",
+                    "type": "date",
+                    "offset": 0
+                }
+            }
+        },
+        "1e75c3fc-9d22": {
+            "type": "ODOO",
+            "name": "Sales Orders by Order Date (Day)",
+            "model": "sale.order",
+            "domain": [
+                ["x_order_involves_room", "=", true]
+            ],
+            "context": {
+                "in_rental_app": 1,
+                "group_by": ["rental_status"]
+            },
+            "rows": [{
+                "fieldName": "date_order",
+                "granularity": "day"
+            }],
+            "columns": [],
+            "measures": [{
+                "id": "__count:sum",
+                "fieldName": "__count",
+                "aggregator": "sum"
+            }],
+            "actionXmlId": "booking_engine.booking_engine_rooms_order_action",
+            "style": {
+                "tableStyleId": "PivotTableStyleMedium12",
+                "displayTotals": false,
+                "displayColumnHeaders": false
+            },
+            "formulaId": "3",
+            "fieldMatching": {
+                "9326b427-429f": {
+                    "chain": "date_order",
+                    "type": "datetime",
+                    "offset": 0
+                }
+            }
+        }
+    },
+    "pivotNextId": 4,
+    "customTableStyles": {},
+    "globalFilters": [{
+        "id": "9326b427-429f",
+        "label": "Date",
+        "type": "date",
+        "defaultValue": "this_month"
+    }],
+    "lists": {},
+    "listNextId": 1,
+    "odooLinkReferences": {
+        "9c340420-b831": {
+            "type": "odooMenu",
+            "odooMenuId": "booking_engine.menu_availability_occupancy"
+        },
+        "b235909f-e931": {
+            "type": "odooMenu",
+            "odooMenuId": "booking_engine.booking_engine_orders_menu"
+        }
+    }
+}

--- a/campsite/__manifest__.py
+++ b/campsite/__manifest__.py
@@ -26,6 +26,7 @@
         'data/web_views.xml',
         'data/views.xml',
         'data/res_config_settings.xml',
+        'data/spreadsheet_dashboard.xml',
     ],
     'demo': [
         'demo/res_company.xml',

--- a/campsite/data/knowledge_article.xml
+++ b/campsite/data/knowledge_article.xml
@@ -287,6 +287,12 @@
         <h3>🚀 Strategic Oversight</h3>
         <hr/>
         <p>Beyond daily operations, the Steering menu serves as the "Captain’s Bridge" of your campsite. It provides a 500-day horizon to anticipate market trends, manage risks, and optimize your revenue.</p>
+        <div class="o_editor_banner user-select-none o-contenteditable-false lh-1 d-flex align-items-center alert alert-info pb-0 pt-3" data-oe-role="status">
+            <i class="o_editor_banner_icon mb-3 fst-normal" data-oe-aria-label="Banner Info">💡</i>
+            <div class="o_editor_banner_content o-contenteditable-true w-100 px-3">
+                <p>This capability is enabled by a setting you can set/unset.</p>
+            </div>
+        </div>
         <h4>Monitoring success with occupancy</h4>
         <p>The Occupancy view allows you to visualize your "Sales Success". It answers one simple question: <i>How well am I filling my campsite?</i></p>
         <ul>

--- a/campsite/data/knowledge_article.xml
+++ b/campsite/data/knowledge_article.xml
@@ -302,6 +302,17 @@
             <li>The Gantt chart is color-coded to reflect on the availability for you to work on filling in.</li>
             <li>Access to more details clicking the slot.</li>
         </ul>
+        <h4>Monitoring performance</h4>
+        <p>Because keeping an eye on your business performance matter, the module comes with a dedicated dashboard.</p>
+        <ul>
+            <li>Simply open the Dashboard App to land on the Performance dashboard.</li>
+        </ul>
+        <div class="o_editor_banner user-select-none o-contenteditable-false lh-1 d-flex align-items-center alert alert-success pb-0 pt-3" data-oe-role="status" contenteditable="false" role="status">
+            <i class="o_editor_banner_icon mb-3 fst-normal" data-oe-aria-label="Banner Success">✅</i>
+            <div class="o_editor_banner_content o-contenteditable-true w-100 px-3">
+                <div>Here you can monitor past and future performance in the books, with overall occupancy, average daily rate, revenue per available room and pickups!</div>
+            </div>
+        </div>
         <p><br/></p>
         <h3 >🔢 Running multiple places</h3>
         <hr/>

--- a/campsite/data/res_config_settings.xml
+++ b/campsite/data/res_config_settings.xml
@@ -13,4 +13,11 @@
             </xpath>
         </field>
     </record>
+    <data noupdate="1">
+        <record model="res.config.settings" id="res_config_settings_enable">
+            <field name="x_module_house_keeping" eval="1"/>
+            <field name="x_setting_steering" eval="1"/>
+        </record>
+        <function model="res.config.settings" name="execute" eval="[ref('res_config_settings_enable')]"/>
+    </data>
 </odoo>

--- a/campsite/data/spreadsheet_dashboard.xml
+++ b/campsite/data/spreadsheet_dashboard.xml
@@ -1,0 +1,6 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<odoo noupdate="1">
+    <record id="booking_engine.spreadsheet_dashboard_group_accomodation" model="spreadsheet.dashboard.group" forcecreate="0">
+        <field name="name">Campsite</field>
+    </record>
+</odoo>

--- a/campsite/static/description/index.html
+++ b/campsite/static/description/index.html
@@ -32,4 +32,7 @@
     <li>
         <strong>Satisfaction Survey:</strong> Automatically send emails to your guests few days after their stay to measure their satisfaction.
     </li>
+    <li>
+        <strong>Manager Dashboard:</strong> Monitor your business performance with a dedicated dashboard.
+    </li>
 </ul>

--- a/guest_house/__manifest__.py
+++ b/guest_house/__manifest__.py
@@ -21,6 +21,7 @@
         'data/planning_role_post.xml',
         'data/website_view.xml',
         'data/res_config_settings.xml',
+        'data/spreadsheet_dashboard.xml',
     ],
     'demo': [
         'demo/res_company.xml',

--- a/guest_house/data/knowledge_article.xml
+++ b/guest_house/data/knowledge_article.xml
@@ -331,6 +331,12 @@
         <h3>🚀 Strategic Oversight</h3>
         <hr/>
         <p>Beyond daily operations, the Steering menu serves as the "Captain’s Bridge" of your guest house. It provides a 500-day horizon to anticipate market trends, manage risks, and optimize your revenue.</p>
+        <div class="o_editor_banner user-select-none o-contenteditable-false lh-1 d-flex align-items-center alert alert-info pb-0 pt-3" data-oe-role="status">
+            <i class="o_editor_banner_icon mb-3 fst-normal" data-oe-aria-label="Banner Info">💡</i>
+            <div class="o_editor_banner_content o-contenteditable-true w-100 px-3">
+                <p>This capability is enabled by a setting you can set/unset.</p>
+            </div>
+        </div>
         <h4>Monitoring success with occupancy</h4>
         <p>The Occupancy view allows you to visualize your "Sales Success". It answers one simple question: <i>How well am I filling my guest house?</i></p>
         <ul>

--- a/guest_house/data/knowledge_article.xml
+++ b/guest_house/data/knowledge_article.xml
@@ -346,6 +346,17 @@
             <li>The Gantt chart is color-coded to reflect on the availability for you to work on filling in.</li>
             <li>Access to more details clicking the slot.</li>
         </ul>
+        <h4>Monitoring performance</h4>
+        <p>Because keeping an eye on your business performance matter, the module comes with a dedicated dashboard.</p>
+        <ul>
+            <li>Simply open the Dashboard App to land on the Performance dashboard.</li>
+        </ul>
+        <div class="o_editor_banner user-select-none o-contenteditable-false lh-1 d-flex align-items-center alert alert-success pb-0 pt-3" data-oe-role="status" contenteditable="false" role="status">
+            <i class="o_editor_banner_icon mb-3 fst-normal" data-oe-aria-label="Banner Success">✅</i>
+            <div class="o_editor_banner_content o-contenteditable-true w-100 px-3">
+                <div>Here you can monitor past and future performance in the books, with overall occupancy, average daily rate, revenue per available room and pickups!</div>
+            </div>
+        </div>
         <p><br/></p>
         <h3 >🔢 Running multiple places</h3>
         <hr/>

--- a/guest_house/data/res_config_settings.xml
+++ b/guest_house/data/res_config_settings.xml
@@ -13,4 +13,10 @@
             </xpath>
         </field>
     </record>
+    <data noupdate="1">
+        <record model="res.config.settings" id="res_config_settings_enable">
+            <field name="x_module_house_keeping" eval="1"/>
+        </record>
+        <function model="res.config.settings" name="execute" eval="[ref('res_config_settings_enable')]"/>
+    </data>
 </odoo>

--- a/guest_house/data/spreadsheet_dashboard.xml
+++ b/guest_house/data/spreadsheet_dashboard.xml
@@ -1,0 +1,6 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<odoo noupdate="1">
+    <record id="booking_engine.spreadsheet_dashboard_group_accomodation" model="spreadsheet.dashboard.group" forcecreate="0">
+        <field name="name">Guest House</field>
+    </record>
+</odoo>

--- a/guest_house/static/description/index.html
+++ b/guest_house/static/description/index.html
@@ -32,4 +32,7 @@
     <li>
         <strong>Satisfaction Survey:</strong> Automatically send emails to your guests few days after their stay to measure their satisfaction.
     </li>
+    <li>
+        <strong>Manager Dashboard:</strong> Monitor your business performance with a dedicated dashboard.
+    </li>
 </ul>

--- a/holiday_house/__manifest__.py
+++ b/holiday_house/__manifest__.py
@@ -22,6 +22,7 @@
         'data/ir_ui_view.xml',
         'data/web_views.xml',
         'data/res_config_settings.xml',
+        'data/spreadsheet_dashboard.xml',
     ],
     'demo': [
         'demo/res_company.xml',

--- a/holiday_house/data/knowledge_article.xml
+++ b/holiday_house/data/knowledge_article.xml
@@ -278,6 +278,12 @@ The Holiday House App relies on the Rental and Planning Apps binding, with a few
     <h3>🚀 Strategic Oversight</h3>
     <hr/>
     <p>Beyond daily operations, the Steering menu serves as the "Captain’s Bridge" of your holiday houses. It provides a 500-day horizon to anticipate market trends, manage risks, and optimize your revenue.</p>
+    <div class="o_editor_banner user-select-none o-contenteditable-false lh-1 d-flex align-items-center alert alert-info pb-0 pt-3" data-oe-role="status">
+        <i class="o_editor_banner_icon mb-3 fst-normal" data-oe-aria-label="Banner Info">💡</i>
+        <div class="o_editor_banner_content o-contenteditable-true w-100 px-3">
+            <p>This capability is enabled by a setting you can set/unset.</p>
+        </div>
+    </div>
     <h4>Monitoring success with occupancy</h4>
     <p>The Occupancy view allows you to visualize your "Sales Success". It answers one simple question: <i>How well am I filling my holiday houses?</i></p>
     <ul>

--- a/holiday_house/data/knowledge_article.xml
+++ b/holiday_house/data/knowledge_article.xml
@@ -293,6 +293,17 @@ The Holiday House App relies on the Rental and Planning Apps binding, with a few
         <li>The Gantt chart is color-coded to reflect on the availability for you to work on filling in.</li>
         <li>Access to more details clicking the slot.</li>
     </ul>
+    <h4>Monitoring performance</h4>
+        <p>Because keeping an eye on your business performance matter, the module comes with a dedicated dashboard.</p>
+        <ul>
+            <li>Simply open the Dashboard App to land on the Performance dashboard.</li>
+        </ul>
+        <div class="o_editor_banner user-select-none o-contenteditable-false lh-1 d-flex align-items-center alert alert-success pb-0 pt-3" data-oe-role="status" contenteditable="false" role="status">
+            <i class="o_editor_banner_icon mb-3 fst-normal" data-oe-aria-label="Banner Success">✅</i>
+            <div class="o_editor_banner_content o-contenteditable-true w-100 px-3">
+                <div>Here you can monitor past and future performance in the books, with overall occupancy, average daily rate, revenue per available room and pickups!</div>
+            </div>
+        </div>
     <p><br/></p>
     <h3 >🔢 Running multiple places</h3>
     <hr/>

--- a/holiday_house/data/res_config_settings.xml
+++ b/holiday_house/data/res_config_settings.xml
@@ -13,4 +13,10 @@
             </xpath>
         </field>
     </record>
+    <data noupdate="1">
+        <record model="res.config.settings" id="res_config_settings_enable">
+            <field name="x_module_house_keeping" eval="1"/>
+        </record>
+        <function model="res.config.settings" name="execute" eval="[ref('res_config_settings_enable')]"/>
+    </data>
 </odoo>

--- a/holiday_house/data/spreadsheet_dashboard.xml
+++ b/holiday_house/data/spreadsheet_dashboard.xml
@@ -1,0 +1,6 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<odoo noupdate="1">
+    <record id="booking_engine.spreadsheet_dashboard_group_accomodation" model="spreadsheet.dashboard.group" forcecreate="0">
+        <field name="name">Holiday House</field>
+    </record>
+</odoo>

--- a/holiday_house/static/description/index.html
+++ b/holiday_house/static/description/index.html
@@ -32,4 +32,7 @@
     <li>
         <strong>Satisfaction Survey:</strong> Automatically send emails to your guests few days after their stay to measure their satisfaction.
     </li>
+    <li>
+        <strong>Manager Dashboard:</strong> Monitor your business performance with a dedicated dashboard.
+    </li>
 </ul>

--- a/hotel/__manifest__.py
+++ b/hotel/__manifest__.py
@@ -24,6 +24,7 @@
         'data/mail_message.xml',
         'data/views.xml',
         'data/res_config_settings.xml',
+        'data/spreadsheet_dashboard.xml',
     ],
     'demo': [
         'demo/res_company.xml',

--- a/hotel/data/knowledge_article.xml
+++ b/hotel/data/knowledge_article.xml
@@ -403,6 +403,12 @@
         <h3>🚀 Strategic Oversight</h3>
         <hr/>
         <p>Beyond daily operations, the Steering menu serves as the "Captain’s Bridge" of your hotel. It provides a 500-day horizon to anticipate market trends, manage risks, and optimize your revenue.</p>
+        <div class="o_editor_banner user-select-none o-contenteditable-false lh-1 d-flex align-items-center alert alert-info pb-0 pt-3" data-oe-role="status">
+            <i class="o_editor_banner_icon mb-3 fst-normal" data-oe-aria-label="Banner Info">💡</i>
+            <div class="o_editor_banner_content o-contenteditable-true w-100 px-3">
+                <p>This capability is enabled by a setting you can set/unset.</p>
+            </div>
+        </div>
         <h4>Monitoring success with occupancy</h4>
         <p>The Occupancy view allows you to visualize your "Sales Success". It answers one simple question: <i>How well am I filling my hotel?</i></p>
         <ul>

--- a/hotel/data/knowledge_article.xml
+++ b/hotel/data/knowledge_article.xml
@@ -418,6 +418,17 @@
             <li>The Gantt chart is color-coded to reflect on the availability for you to work on filling in.</li>
             <li>Access to more details clicking the slot.</li>
         </ul>
+        <h4>Monitoring performance</h4>
+        <p>Because keeping an eye on your business performance matters, the module comes with a dedicated dashboard.</p>
+        <ul>
+            <li>Simply open the Dashboard App to land on the Performance dashboard.</li>
+        </ul>
+        <div class="o_editor_banner user-select-none o-contenteditable-false lh-1 d-flex align-items-center alert alert-success pb-0 pt-3" data-oe-role="status" contenteditable="false" role="status">
+            <i class="o_editor_banner_icon mb-3 fst-normal" data-oe-aria-label="Banner Success">✅</i>
+            <div class="o_editor_banner_content o-contenteditable-true w-100 px-3">
+                <div>Here you can monitor past and future performance in the books, with overall occupancy, average daily rate, revenue per available room and pickups!</div>
+            </div>
+        </div>
         <p><br/></p>
         <h3 >🔢 Running multiple places</h3>
         <hr/>

--- a/hotel/data/res_config_settings.xml
+++ b/hotel/data/res_config_settings.xml
@@ -13,4 +13,11 @@
             </xpath>
         </field>
     </record>
+    <data noupdate="1">
+        <record model="res.config.settings" id="res_config_settings_enable">
+            <field name="x_module_house_keeping" eval="1"/>
+            <field name="x_setting_steering" eval="1"/>
+        </record>
+        <function model="res.config.settings" name="execute" eval="[ref('res_config_settings_enable')]"/>
+    </data>
 </odoo>

--- a/hotel/data/spreadsheet_dashboard.xml
+++ b/hotel/data/spreadsheet_dashboard.xml
@@ -1,0 +1,6 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<odoo noupdate="1">
+    <record id="booking_engine.spreadsheet_dashboard_group_accomodation" model="spreadsheet.dashboard.group" forcecreate="0">
+        <field name="name">Hotel</field>
+    </record>
+</odoo>

--- a/hotel/static/description/index.html
+++ b/hotel/static/description/index.html
@@ -68,6 +68,9 @@
     <li>
         <strong>Satisfaction Survey:</strong> Automatically send emails to your guests few days after their stay to measure their satisfaction.
     </li>
+    <li>
+        <strong>Manager Dashboard:</strong> Monitor your business performance with a dedicated dashboard.
+    </li>
 </ul>
 <h2>Pricing</h2>
 <p>

--- a/tests/test_booking_engine/tests/test_action_server.py
+++ b/tests/test_booking_engine/tests/test_action_server.py
@@ -50,6 +50,11 @@ class BookingEngineAutomationsTestCase(TransactionCase):
         cls.stage_clean = cls.env.ref('booking_engine.project_task_type_17')
         cls.stage_ready = cls.env.ref('booking_engine.project_task_type_18')
         cls.today = Datetime.today()
+        cls.config = cls.env["res.config.settings"].create({
+            'x_module_house_keeping': True,
+            'x_setting_steering': True,
+        })
+        cls.config.execute()
 
     def _create_sale_line(self, product):
         order = self.env['sale.order'].with_context(in_rental_app=True).create({


### PR DESCRIPTION
This PR adds a dashboard to visualize informations for an hotel
such as occupancy rate or average daily rate. This dashboard uses a new
model linked to sale orders, x_so_daily_line, that are represented one
for each room and for each day of stayover.

Task-6176659