### PR TITLE
[19.0] [FIX] construction_developer: correctly duplicate work items on SO

### DIFF
--- a/construction_developer/data/ir_model_fields.xml
+++ b/construction_developer/data/ir_model_fields.xml
@@ -367,6 +367,7 @@ for record in self:
         <field name="model_id" ref="sale.model_sale_order_line"/>
         <field name="name">x_line_work_item_id</field>
         <field name="relation">x_work_item</field>
+        <field name="copied" eval="False"/>
     </record>
 
     <record id="x_work_item_template_id_field_product_product" model="ir.model.fields">


### PR DESCRIPTION
Fixes #2172.

When a sale.order is duplicated, the `Many2one` references are copied natively, meaning both the old and new sale.order.line referenced the exact same `x_work_item`. Modifying the work item on the new duplicate altered the pricing on the original SO.

This uses the Odoo Online compatible XML approach. By adding `copied=False` to the field definition in Studio (`ir_model_fields.xml`), the work item reference is appropriately stripped upon duplication. This subsequently triggers the existing standard automation `base_automation_sol_on_write` to re-instantiate a fresh Work Item directly from the product template.