### PR TITLE
[FIX] pet_groomer: update _get_visitor_from_request on ir.http

### DIFF
--- a/pet_groomer/__manifest__.py
+++ b/pet_groomer/__manifest__.py
@@ -64,6 +64,7 @@
         'demo/website.xml',
     ],
     'license': 'OEEL-1',
+    'version': '1.1',
     'cloc_exclude': [
         'data/knowledge_article.xml',
         'demo/website_view.xml',

--- a/pet_groomer/demo/website_view.xml
+++ b/pet_groomer/demo/website_view.xml
@@ -4,7 +4,7 @@
     <field name="arch" type="xml">
       <t name="Contact Us" t-name="website.contactus">
         <t t-call="website.layout">
-          <t t-set="logged_partner" t-value="request.env['website.visitor']._get_visitor_from_request().partner_id"/>
+          <t t-set="logged_partner" t-value="request.env['ir.http']._get_visitor_from_request().partner_id"/>
           <t t-set="contactus_form_values" t-value="{                 'email_to': res_company.email,                 'name': request.params.get('name', ''),                 'phone': request.params.get('phone', ''),                 'email_from': request.params.get('email_from', ''),                 'company': request.params.get('company', ''),                 'subject': request.params.get('subject', ''),             }"/>
           <span class="hidden" data-for="contactus_form" t-att-data-values="contactus_form_values"/>
           <div id="wrap" class="oe_structure oe_empty">


### PR DESCRIPTION
The method `_get_visitor_from_request()` was moved to the `ir.http` model. - [1]

[1]: https://github.com/odoo/odoo/commit/ef615ddc60f95293aeb32a43de75edbf8a98eb97

sentry-7477642623