### PR TITLE
[FIX] booking_engine: active filter group_by instead of context value

### DIFF
--- a/booking_engine/__manifest__.py
+++ b/booking_engine/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Booking Engine',
-    'version': '1.13',
+    'version': '1.14',
     'category': 'Hidden/Tools',
     'author': 'Odoo S.A.',
     'depends': [

--- a/booking_engine/data/ir_actions_act_window.xml
+++ b/booking_engine/data/ir_actions_act_window.xml
@@ -9,7 +9,7 @@
   </record>
   <record id="booking_engine_rooms_order_action" model="ir.actions.act_window">
     <field name="domain">[("x_order_involves_room", "=", True)]</field>
-    <field name="context">{'in_rental_app': 1, 'search_default_from_rental': 1, 'group_by': ['rental_status']}</field>
+    <field name="context">{'in_rental_app': 1, 'search_default_from_rental': 1, 'search_default_rental_status_group': 1}</field>
     <field name="name">Orders</field>
     <field name="res_model">sale.order</field>
     <field name="view_mode">kanban,list,form</field>


### PR DESCRIPTION
Steps to reproduce:
- Go to booking engine app > orders > open an order
- Open the product catalog
- Traceback

Reason:
the 'group_by' was kept in the context, although the view was changed to another model (product.template instead of sale.order). This leads to an error because the field (rental_status) does not exist on this model.

This commit fixes the issue by activating a group_by filter on the Orders view by default instead of hardcoding the groupby key in the context.

task-6218176