### PR TITLE
[FIX] test_booking_engine: assign calendar to overbooking test resource

### DIFF
--- a/tests/test_booking_engine/tests/test_overbooking.py
+++ b/tests/test_booking_engine/tests/test_overbooking.py
@@ -18,6 +18,7 @@ class TestOverbooking(PaymentHttpCommon):
         cls.resource = cls.env['resource.resource'].create({
             'name': 'Room 101',
             'resource_type': 'material',
+            'calendar_id': False,
         })
         cls.role = cls.env['planning.role'].create({
             'name': 'Stay Offer Role',


### PR DESCRIPTION
`Before PR:`

The test resource was created without an explicit calendar assignment. As a result, the default `Standard 40 hours/week` calendar was automatically assigned, making the resource available only from Monday to Friday.

Also, the rental start date is set as `today + 1` here [1] Because of this, when the test runs on Friday, the start date becomes Saturday. Since the resource is unavailable on weekends, the test fails with a 'resource not available' error. link[1]: https://github.com/odoo/industry/blob/d442610935aa38adcf7b735cdd6e0dab1154c746/tests/test_booking_engine/tests/test_overbooking.py#L47-L48

`After PR:`

Explicitly assign calendar_id as False to the test resource. Since this calendar keeps the resource available on all days of the week, the test no longer depends on the weekday it runs on.