### PR TITLE
[FIX] *: prevent an error while validating the payment

### DIFF
--- a/bike_shop/__manifest__.py
+++ b/bike_shop/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Bike Shop',
-    'version': '1.1',
+    'version': '1.2',
     'category': 'Retail',
     'author': 'Odoo S.A.',
     'depends': [

--- a/bike_shop/data/pos_payment_method.xml
+++ b/bike_shop/data/pos_payment_method.xml
@@ -1,7 +1,12 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
+  <record id="cash" model="account.journal">
+    <field name="name">Cash (Bike Shop)</field>
+    <field name="type">cash</field>
+  </record>
   <record id="pos_payment_method_2" model="pos.payment.method">
     <field name="name">Card</field>
+    <field name="journal_id" ref="account.1_bank"/>
   </record>
   <record id="pos_payment_method_3" model="pos.payment.method">
     <field name="name">Customer Account</field>
@@ -9,8 +14,10 @@
   </record>
   <record id="pos_payment_method_1" model="pos.payment.method">
     <field name="name">Cash</field>
+    <field name="journal_id" ref="cash"/>
   </record>
   <record id="pos_payment_method_4" model="pos.payment.method">
     <field name="name">Pay Later</field>
+    <field name="journal_id" ref="account.1_bank"/>
   </record>
 </odoo>

--- a/florist/__manifest__.py
+++ b/florist/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Florist',
-    'version': '1.0',
+    'version': '1.1',
     'category': 'Retail',
     'author': 'Odoo S.A.',
     'depends': [

--- a/florist/data/pos_payment_method.xml
+++ b/florist/data/pos_payment_method.xml
@@ -1,7 +1,12 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
+    <record id="cash" model="account.journal">
+        <field name="name">Cash (Florist)</field>
+        <field name="type">cash</field>
+    </record>
     <record id="pos_payment_method_2" model="pos.payment.method">
         <field name="name">Card</field>
+        <field name="journal_id" ref="account.1_bank"/>
     </record>
     <record id="pos_payment_method_3" model="pos.payment.method">
         <field name="name">Customer Account</field>
@@ -9,5 +14,6 @@
     </record>
     <record id="pos_payment_method_1" model="pos.payment.method">
         <field name="name">Cash</field>
+        <field name="journal_id" ref="cash"/>
     </record>
 </odoo>

--- a/museum/__manifest__.py
+++ b/museum/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Museum',
-    'version': '1.0',
+    'version': '1.1',
     'category': 'Services',
     'author': 'Odoo S.A.',
     'depends': [

--- a/museum/data/pos_payment_method.xml
+++ b/museum/data/pos_payment_method.xml
@@ -1,7 +1,12 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
+  <record id="cash" model="account.journal">
+    <field name="name">Cash (Museum)</field>
+    <field name="type">cash</field>
+  </record>
   <record id="pos_payment_method_2" model="pos.payment.method">
     <field name="name">Card</field>
+    <field name="journal_id" ref="account.1_bank"/>
   </record>
   <record id="pos_payment_method_3" model="pos.payment.method">
     <field name="name">Customer Account</field>
@@ -9,5 +14,6 @@
   </record>
   <record id="pos_payment_method_1" model="pos.payment.method">
     <field name="name">Cash</field>
+    <field name="journal_id" ref="cash"/>
   </record>
 </odoo>

--- a/takeaway_restaurant/__manifest__.py
+++ b/takeaway_restaurant/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Takeaway Restaurant',
-    'version': '1.0',
+    'version': '1.1',
     'category': 'Hospitality',
     'author': 'Odoo S.A.',
     'depends': [

--- a/takeaway_restaurant/data/pos_config.xml
+++ b/takeaway_restaurant/data/pos_config.xml
@@ -4,6 +4,7 @@
         <field name="name">Restaurant</field>
         <field name="tip_product_id" eval="False"/>
         <field name="module_pos_restaurant" eval="True"/>
+        <field name="payment_method_ids" eval="[(6, 0, [ref('pos_payment_method_1')])]"/>
         <field name="self_ordering_image_home_ids" eval="[(6, 0, [ref('ir_attachment_1318'), ref('ir_attachment_1317'), ref('ir_attachment_1316')])]"/>
         <field name="iface_splitbill" eval="True"/>
         <field name="self_ordering_pay_after">each</field>
@@ -16,7 +17,7 @@
         <field name="available_preset_ids" eval="[(6, 0, [ref('pos_restaurant.pos_takeout_preset'), ref('pos_restaurant.pos_delivery_preset')])]"/>
         <field name="self_ordering_image_home_ids" eval="[(6, 0, [ref('ir_attachment_1279')])]"/>
         <field name="module_pos_restaurant" eval="True"/>
-        <field name="payment_method_ids" eval="[(6, 0, [ref('pos_payment_method_3'), ref('pos_payment_method_1')])]"/>
+        <field name="payment_method_ids" eval="[(6, 0, [ref('pos_payment_method_3'), ref('pos_payment_method_2')])]"/>
         <field name="show_product_images" eval="False"/>
         <field name="show_category_images" eval="False"/>
         <field name="iface_printbill" eval="True"/>

--- a/takeaway_restaurant/data/pos_payment_method.xml
+++ b/takeaway_restaurant/data/pos_payment_method.xml
@@ -4,7 +4,20 @@
         <field name="name">Customer Account</field>
         <field name="split_transactions" eval="True"/>
     </record>
+    <record id="cash_restaurant" model="account.journal">
+        <field name="name">Cash (Restaurent)</field>
+        <field name="type">cash</field>
+    </record>
     <record id="pos_payment_method_1" model="pos.payment.method">
         <field name="name">Cash</field>
+        <field name="journal_id" ref="cash_restaurant"/>
+    </record>
+    <record id="cash_online_orders" model="account.journal">
+        <field name="name">Cash (Online Orders)</field>
+        <field name="type">cash</field>
+    </record>
+    <record id="pos_payment_method_2" model="pos.payment.method">
+        <field name="name">Cash</field>
+        <field name="journal_id" ref="cash_online_orders"/>
     </record>
 </odoo>

--- a/wine_merchant/__manifest__.py
+++ b/wine_merchant/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Wine Shop',
-    'version': '1.0',
+    'version': '1.1',
     'category': 'Retail',
     'author': 'Odoo S.A.',
     'depends': [

--- a/wine_merchant/data/pos_payment_method.xml
+++ b/wine_merchant/data/pos_payment_method.xml
@@ -1,7 +1,12 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
+  <record id="cash" model="account.journal">
+    <field name="name">Cash (Wine Merchant)</field>
+    <field name="type">cash</field>
+  </record>
   <record id="pos_payment_method_2" model="pos.payment.method">
     <field name="name">Card</field>
+    <field name="journal_id" ref="account.1_bank"/>
   </record>
   <record id="pos_payment_method_3" model="pos.payment.method">
     <field name="name">Customer Account</field>
@@ -9,5 +14,6 @@
   </record>
   <record id="pos_payment_method_1" model="pos.payment.method">
     <field name="name">Cash</field>
+    <field name="journal_id" ref="cash"/>
   </record>
 </odoo>


### PR DESCRIPTION
 *= ['florist', 'bike_shop', 'museum', 'takeaway_restaurant', 'wine_merchant']

Currently, an error occurs while validating a POS payment in above industries.

Step to reproduce:

- Install the florist industry.
- Open a POS session.
- Validate a payment.

ValidationError: Journal is required for payment methods.

The issue occurs because some POS payment methods are created without a
journal_id. The journal_id field is mandatory for payment methods,
and payment validation expects valid journals on all configured payment
methods.

To fix this issue, create a cash journal and assign it to the cash payment
method, and assign a bank journal to the card payment method.

In the takeaway restaurant, the same cash payment method was used across
multiple POS configurations. If a journal is assigned to the shared cash payment
method, it raises a validation error because the same cash payment method
cannot be used in different POS configurations. To fix this issue, create
separate cash journals for different POS configurations and assign them to
their respective cash payment methods.

Task ID-6193655