### PR TITLE
[REF] stock: rename final location to forecasted location

### DIFF
--- a/bike_shop/demo/purchase_order_line.xml
+++ b/bike_shop/demo/purchase_order_line.xml
@@ -7,7 +7,7 @@
         <field name="price_unit">6.5</field>
         <field name="orderpoint_id" ref="stock_warehouse_orderpoint_1" />
         <field name="propagate_cancel" eval="False" />
-        <field name="location_final_id" ref="stock.stock_location_stock" />
+        <field name="forecasted_location_id" ref="stock.stock_location_stock" />
     </record>
     <record id="purchase_order_line_2" model="purchase.order.line">
         <field name="product_id" ref="product_product_24" />

--- a/dropshipping/demo/purchase_order_line.xml
+++ b/dropshipping/demo/purchase_order_line.xml
@@ -5,7 +5,7 @@
     <field name="order_id" ref="purchase_order_5"/>
     <field name="product_qty">1.0</field>
     <field name="propagate_cancel" eval="False"/>
-    <field name="location_final_id" ref="stock.stock_location_customers"/>
+    <field name="forecasted_location_id" ref="stock.stock_location_customers"/>
     <field name="sale_line_id" ref="sale_order_line_10"/>
   </record>
   <record id="purchase_order_line_5" model="purchase.order.line">
@@ -13,7 +13,7 @@
     <field name="order_id" ref="purchase_order_4"/>
     <field name="product_qty">1.0</field>
     <field name="propagate_cancel" eval="False"/>
-    <field name="location_final_id" ref="stock.stock_location_customers"/>
+    <field name="forecasted_location_id" ref="stock.stock_location_customers"/>
     <field name="sale_line_id" ref="sale_order_line_7"/>
   </record>
   <record id="purchase_order_line_4" model="purchase.order.line">
@@ -21,7 +21,7 @@
     <field name="order_id" ref="purchase_order_3"/>
     <field name="product_qty">1.0</field>
     <field name="propagate_cancel" eval="False"/>
-    <field name="location_final_id" ref="stock.stock_location_customers"/>
+    <field name="forecasted_location_id" ref="stock.stock_location_customers"/>
     <field name="sale_line_id" ref="sale_order_line_5"/>
   </record>
   <record id="purchase_order_line_2" model="purchase.order.line">
@@ -29,7 +29,7 @@
     <field name="order_id" ref="purchase_order_2"/>
     <field name="product_qty">1.0</field>
     <field name="propagate_cancel" eval="False"/>
-    <field name="location_final_id" ref="stock.stock_location_customers"/>
+    <field name="forecasted_location_id" ref="stock.stock_location_customers"/>
     <field name="sale_line_id" ref="sale_order_line_4"/>
   </record>
   <record id="purchase_order_line_3" model="purchase.order.line">
@@ -37,7 +37,7 @@
     <field name="order_id" ref="purchase_order_2"/>
     <field name="product_qty">1.0</field>
     <field name="propagate_cancel" eval="False"/>
-    <field name="location_final_id" ref="stock.stock_location_customers"/>
+    <field name="forecasted_location_id" ref="stock.stock_location_customers"/>
     <field name="sale_line_id" ref="sale_order_line_6"/>
   </record>
   <record id="purchase_order_line_1" model="purchase.order.line">
@@ -45,7 +45,7 @@
     <field name="order_id" ref="purchase_order_1"/>
     <field name="product_qty">1.0</field>
     <field name="propagate_cancel" eval="False"/>
-    <field name="location_final_id" ref="stock.stock_location_customers"/>
+    <field name="forecasted_location_id" ref="stock.stock_location_customers"/>
     <field name="sale_line_id" ref="sale_order_line_1"/>
   </record>
 </odoo>

--- a/food_distribution/demo/purchase_order_line.xml
+++ b/food_distribution/demo/purchase_order_line.xml
@@ -6,7 +6,7 @@
     <field name="product_qty">1330.0</field>
     <field name="price_unit">11.5</field>
     <field name="propagate_cancel" eval="False"/>
-    <field name="location_final_id" ref="stock.stock_location_stock"/>
+    <field name="forecasted_location_id" ref="stock.stock_location_stock"/>
   </record>
   <record id="purchase_order_line_3" model="purchase.order.line">
     <field name="product_id" ref="product_product_2"/>
@@ -14,7 +14,7 @@
     <field name="product_qty">5000.0</field>
     <field name="price_unit">1.92</field>
     <field name="propagate_cancel" eval="False"/>
-    <field name="location_final_id" ref="stock.stock_location_stock"/>
+    <field name="forecasted_location_id" ref="stock.stock_location_stock"/>
   </record>
   <record id="purchase_order_line_4" model="purchase.order.line">
     <field name="product_id" ref="product_product_8"/>
@@ -22,7 +22,7 @@
     <field name="product_qty">500.0</field>
     <field name="price_unit">21.0</field>
     <field name="propagate_cancel" eval="False"/>
-    <field name="location_final_id" ref="stock.stock_location_stock"/>
+    <field name="forecasted_location_id" ref="stock.stock_location_stock"/>
   </record>
   <record id="purchase_order_line_8" model="purchase.order.line">
     <field name="product_id" ref="product_product_4"/>
@@ -56,7 +56,7 @@
     <field name="product_qty">500.0</field>
     <field name="price_unit">1.25</field>
     <field name="propagate_cancel" eval="False"/>
-    <field name="location_final_id" ref="stock.stock_location_stock"/>
+    <field name="forecasted_location_id" ref="stock.stock_location_stock"/>
   </record>
   <record id="purchase_order_line_2" model="purchase.order.line">
     <field name="product_id" ref="product_product_10"/>
@@ -64,7 +64,7 @@
     <field name="product_qty">500.0</field>
     <field name="price_unit">11.5</field>
     <field name="propagate_cancel" eval="False"/>
-    <field name="location_final_id" ref="stock.stock_location_stock"/>
+    <field name="forecasted_location_id" ref="stock.stock_location_stock"/>
   </record>
   <record id="purchase_order_line_11" model="purchase.order.line">
     <field name="product_id" ref="product_product_15"/>

--- a/hvac_services/demo/purchase_order_line.xml
+++ b/hvac_services/demo/purchase_order_line.xml
@@ -6,7 +6,7 @@
         <field name="product_qty">15.0</field>
         <field name="price_unit">45.0</field>
         <field name="propagate_cancel" eval="False"/>
-        <field name="location_final_id" ref="stock.stock_location_stock"/>
+        <field name="forecasted_location_id" ref="stock.stock_location_stock"/>
     </record>
     <record id="purchase_order_line_2" model="purchase.order.line">
         <field name="product_id" ref="product_product_9"/>
@@ -14,14 +14,14 @@
         <field name="product_qty">15.0</field>
         <field name="price_unit">75.0</field>
         <field name="propagate_cancel" eval="False"/>
-        <field name="location_final_id" ref="stock.stock_location_stock"/>
+        <field name="forecasted_location_id" ref="stock.stock_location_stock"/>
     </record>
     <record id="purchase_order_line_3" model="purchase.order.line">
         <field name="product_id" ref="product_product_4"/>
         <field name="order_id" ref="purchase_order_1"/>
         <field name="product_qty">10.0</field>
         <field name="price_unit">90.0</field>
-        <field name="location_final_id" ref="stock.stock_location_stock"/>
+        <field name="forecasted_location_id" ref="stock.stock_location_stock"/>
     </record>
     <record id="purchase_order_line_4" model="purchase.order.line">
         <field name="product_id" ref="product_product_6"/>
@@ -29,20 +29,20 @@
         <field name="product_qty">8.0</field>
         <field name="price_unit">370.0</field>
         <field name="propagate_cancel" eval="False"/>
-        <field name="location_final_id" ref="stock.stock_location_stock"/>
+        <field name="forecasted_location_id" ref="stock.stock_location_stock"/>
     </record>
     <record id="purchase_order_line_5" model="purchase.order.line">
         <field name="product_id" ref="product_product_11"/>
         <field name="order_id" ref="purchase_order_2"/>
         <field name="product_qty">5.0</field>
         <field name="price_unit">300.0</field>
-        <field name="location_final_id" ref="stock.stock_location_stock"/>
+        <field name="forecasted_location_id" ref="stock.stock_location_stock"/>
     </record>
     <record id="purchase_order_line_6" model="purchase.order.line">
         <field name="product_id" ref="product_product_12"/>
         <field name="order_id" ref="purchase_order_2"/>
         <field name="product_qty">4.0</field>
         <field name="price_unit">2200.0</field>
-        <field name="location_final_id" ref="stock.stock_location_stock"/>
+        <field name="forecasted_location_id" ref="stock.stock_location_stock"/>
     </record>
 </odoo>

--- a/museum/demo/purchase_order_line.xml
+++ b/museum/demo/purchase_order_line.xml
@@ -6,6 +6,6 @@
     <field name="product_qty">46.0</field>
     <field name="orderpoint_id" ref="stock_warehouse_orderpoint_1"/>
     <field name="propagate_cancel" eval="False"/>
-    <field name="location_final_id" ref="stock.stock_location_stock"/>
+    <field name="forecasted_location_id" ref="stock.stock_location_stock"/>
   </record>
 </odoo>

--- a/tests/test_library/static/src/js/tours/industry_library_tour.js
+++ b/tests/test_library/static/src/js/tours/industry_library_tour.js
@@ -153,12 +153,12 @@ registry.category('web_tour.tours').add('industry_library_tour', {
             tooltipPosition: 'left'
         },
         {
-            trigger: '.o-checkbox > input[name=\'location_final_id\']',
+            trigger: '.o-checkbox > input[name=\'forecasted_location_id\']',
             run: 'click',
             tooltipPosition: 'left'
         },
         {
-            trigger: '.o-checkbox > input[name=\'location_final_id\']',
+            trigger: '.o-checkbox > input[name=\'forecasted_location_id\']',
             run: 'click',
             tooltipPosition: 'left'
         },

--- a/textile_manufacturing/demo/mrp_production.xml
+++ b/textile_manufacturing/demo/mrp_production.xml
@@ -16,13 +16,13 @@
   <record id="mrp_production_8" model="mrp.production">
     <field name="product_id" ref="product_product_233"/>
     <field name="product_qty">150.0</field>
-    <field name="location_final_id" ref="stock.stock_location_stock"/>
+    <field name="forecasted_location_id" ref="stock.stock_location_stock"/>
     <field name="user_id" ref="base.user_admin"/>
   </record>
   <record id="mrp_production_9" model="mrp.production">
     <field name="product_id" ref="product_product_234"/>
     <field name="product_qty">40.0</field>
-    <field name="location_final_id" ref="stock.stock_location_stock"/>
+    <field name="forecasted_location_id" ref="stock.stock_location_stock"/>
     <field name="user_id" ref="base.user_admin"/>
   </record>
   <record id="mrp_production_7" model="mrp.production">


### PR DESCRIPTION
The `location_final_id` field is renamed to `forecasted_location_id` to prevent user confusion. This field is only utilized for forecasting multi-step push routes and does not impact actual inventory operations.

COM PR:odoo/odoo#252781
ENT PR: odoo/enterprise#109989
Upgrade PR: odoo/upgrade#9651

task-4969349