### PR TITLE
[FIX] booking_engine: fix day added on rental order confirm

### DIFF
--- a/booking_engine/data/ir_actions_server.xml
+++ b/booking_engine/data/ir_actions_server.xml
@@ -30,11 +30,10 @@ elif record.x_total > 0:
         <field name="code"><![CDATA[
 for record in (records or []):
     if not (record.role_id.x_is_a_room_offer and record.start_datetime and record.end_datetime): continue
-    pickup_time = env.context.get('pickup_time', record.sale_line_id.product_id.pickup_time)
-    return_time = env.context.get('return_time', record.sale_line_id.product_id.return_time)
-    start_datetime = record.start_datetime.replace(hour=int(pickup_time), minute=int(pickup_time % 1 * 60)) if pickup_time else record.start_datetime
-    end_datetime = record.end_datetime.replace(hour=int(return_time), minute=int(return_time % 1 * 60)) if return_time else record.end_datetime
-    end_datetime += datetime.timedelta(days=(record.end_datetime - record.start_datetime).days - (end_datetime - start_datetime).days)
+    pickup_time = record.sale_line_id.product_id.pickup_time
+    return_time = record.sale_line_id.product_id.return_time
+    start_datetime = record.start_datetime.astimezone(timezone(env.user.tz or 'UTC')).replace(hour=int(pickup_time), minute=int(pickup_time % 1 * 60)).astimezone(timezone('UTC')).replace(tzinfo=None) if pickup_time else record.start_datetime
+    end_datetime = record.end_datetime.astimezone(timezone(env.user.tz or 'UTC')).replace(hour=int(return_time), minute=int(return_time % 1 * 60)).astimezone(timezone('UTC')).replace(tzinfo=None) if return_time else record.end_datetime
     if record.start_datetime != start_datetime or record.end_datetime != end_datetime:
         record.write({'start_datetime': start_datetime, 'end_datetime': end_datetime})
         ]]></field>
@@ -58,9 +57,7 @@ for slot in records:
         <field name="code"><![CDATA[
 server_action = record.env['ir.actions.server'].browse(record.env.ref('booking_engine.industry_fix_slot_times')).id
 for record in records:
-    pickup_time = record.order_line.filtered('product_id.rent_periodicity').mapped('product_id')[:1].pickup_time
-    return_time = record.order_line.filtered('product_id.rent_periodicity').mapped('product_id')[:1].return_time
-    server_action.with_context(active_ids=record.order_line.planning_slot_ids.ids, active_model='planning.slot', pickup_time=pickup_time, return_time=return_time).run()
+    server_action.with_context(active_ids=record.order_line.planning_slot_ids.ids, active_model='planning.slot').run()
     record.action_update_rental_prices()
     record.order_line._compute_name()
 ]]></field>

--- a/tests/test_booking_engine/tests/test_action_server.py
+++ b/tests/test_booking_engine/tests/test_action_server.py
@@ -1,6 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, UTC
 
 from odoo import Command
 from odoo.exceptions import UserError
@@ -65,30 +65,26 @@ class BookingEngineAutomationsTestCase(TransactionCase):
         })
         return order, order.order_line
 
-    def _expected_rental_datetimes(self, start_datetime, end_datetime):
-        expected_start = start_datetime.replace(
+    def _expected_slot_datetimes(self, start_datetime, end_datetime):
+        expected_start = start_datetime
+        if start_datetime.astimezone(self.env.user.tz or UTC).hour < 5:
+            expected_start += timedelta(days=-1)
+        expected_start = expected_start.astimezone(self.env.user.tz or UTC).replace(
             hour=18,
             minute=0,
             second=0,
             microsecond=0,
-        )
-        expected_end = end_datetime.replace(
+        ).astimezone(UTC).replace(tzinfo=None)
+        expected_end = end_datetime
+        if end_datetime.astimezone(self.env.user.tz or UTC).hour > 19:
+            expected_end += timedelta(days=1)
+        expected_end = expected_end.astimezone(self.env.user.tz or UTC).replace(
             hour=9,
             minute=0,
             second=0,
             microsecond=0,
-        )
+        ).astimezone(UTC).replace(tzinfo=None)
         return expected_start, expected_end
-
-    def _expected_slot_datetimes(self, start_datetime, end_datetime):
-        expected_start, expected_end = self._expected_rental_datetimes(start_datetime, end_datetime)
-        expected_end += timedelta(
-            days=(end_datetime - start_datetime).days - (expected_end - expected_start).days
-        )
-        return expected_start, expected_end
-
-    def _expected_nights(self, start_datetime, end_datetime):
-        return int(((end_datetime - start_datetime).total_seconds() + 86399) // 86400)
 
     def test_automation_fix_slot_times_on_create_and_write(self):
         """Test for the industry_fix_slot_times automation."""


### PR DESCRIPTION
This commit fixes the incorrect behavior where confirming a rental order corrects the time period of the order incorrectly. It should only change the hours to correspond to the arrival and departure hours defined, but this also currently set the departure date to 1 day later than what we defined.

This is now fixed by taking timezones into account, so that the
changes are not modifying the days unwillingly.

TASK-6218267