### PR TITLE
[FIX] booking_engine: prevent traceback while saving rental order

### DIFF
--- a/booking_engine/__manifest__.py
+++ b/booking_engine/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Booking Engine',
-    'version': '1.13',
+    'version': '1.14',
     'category': 'Hidden/Tools',
     'author': 'Odoo S.A.',
     'depends': [

--- a/booking_engine/data/ir_actions_server.xml
+++ b/booking_engine/data/ir_actions_server.xml
@@ -60,7 +60,6 @@ for record in records:
     if pickup_time: record['rental_start_date'] = record.rental_start_date.replace(hour=int(pickup_time), minute=int(pickup_time % 1 * 60))
     if return_time: record['rental_return_date'] = record.rental_return_date.replace(hour=int(return_time), minute=int(return_time % 1 * 60))
     record.action_update_rental_prices()
-    record.order_line._compute_name()
 ]]></field>
     </record>
     <record id="apply_rental_check_out" model="ir.actions.server">


### PR DESCRIPTION
Before this commit, saving a rental order after creating shifts raised a traceback, preventing the order from being saved.

**Cause :**
- _compute_name() was explicitly called from the server action using record.order_line._compute_name(), even though it is already triggered internally by Odoo.

**Fix :**
- We removed the line as it was already been called priorly and calling it again makes  no sense

**OPW - 6218502**