### PR TITLE
[FIX] 3pl_logistic_company: fix ownerless products on all users pages

### DIFF
--- a/3pl_logistic_company/__manifest__.py
+++ b/3pl_logistic_company/__manifest__.py
@@ -1,7 +1,7 @@
 {
     'name': '3PL Logistic Company',
     'author': 'Odoo S.A.',
-    'version': '1.2',
+    'version': '1.3',
     'category': 'Services',
     'depends': [
         'base_industry_data',

--- a/3pl_logistic_company/data/portal_templates.xml
+++ b/3pl_logistic_company/data/portal_templates.xml
@@ -15,7 +15,7 @@
     <template id="portal_products" name="Your Products">
         <t t-call="portal.portal_layout">
             <t t-set="logged_user" t-value="request.env.user"/>
-            <t t-set="user_products" t-value="request.env['stock.quant'].sudo().search([('product_id.x_owner_id', 'in', [logged_user.partner_id.id, logged_user.partner_id.parent_id.id]), ('location_id.usage', '=', 'internal'), ('quantity', '!=', '0')])"/>
+            <t t-set="user_products" t-value="request.env['stock.quant'].sudo().search([('owner_id', '!=', False), ('owner_id', 'parent_of', logged_user.partner_id), ('location_id.usage', '=', 'internal'), ('quantity', '!=', '0')])"/>
             <t t-call="portal.portal_searchbar">
                 <t t-set="title">Products</t>
             </t>


### PR DESCRIPTION
This PR fixes the issue of products that have all requirements to be displayed on the website products page of the user but no assigned owners are displayed on the page of some owners.

Issue was coming from the value of parent_id being false for some partners, explaining why a Falsy owner was still displayed.

This also changes the use of x_owner_id from the product to using the owner_id
of the stock quant, so that the user view the quants he has no matter the initial
x_owner_id on the product.

TASK-6234967