### PR TITLE
[IMP] booking_engine: early checkin and late checkout

### DIFF
--- a/booking_engine/__manifest__.py
+++ b/booking_engine/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Booking',
-    'version': '1.22',
+    'version': '1.23',
     'category': 'Hospitality',
     'author': 'Odoo S.A.',
     'depends': [
@@ -58,6 +58,7 @@
         ],
         'web.assets_backend_lazy': [
             'booking_engine/static/src/js/patch.js',  # web_gantt/gantt_renderer is lazy so this needs to be lazy too
+            'booking_engine/static/src/xml/gantt_pill_flags.xml',
         ],
     },
     'license': 'OEEL-1',
@@ -65,6 +66,7 @@
         'data/res_config_settings.xml',
         'data/website_view.xml',
         'static/src/scss/gantt.scss',
+        'static/src/xml/gantt_pill_flags.xml',
     ],
     'images': ['images/main.png'],
 }

--- a/booking_engine/data/ir_actions_server.xml
+++ b/booking_engine/data/ir_actions_server.xml
@@ -7,11 +7,11 @@
         <field name="code"><![CDATA[
 sequence, stay_tax_line = 0, False
 for so_line in record.x_sale_order_id.order_line:
-    if so_line.product_id.x_is_stay_tax: stay_tax_line = so_line
+    if so_line.product_id.x_accommodation_product == 'stay_tax': stay_tax_line = so_line
     sequence = max(sequence, so_line.sequence)
 if stay_tax_line: stay_tax_line.write({'product_uom_qty': record.x_total, 'qty_delivered': record.x_total, 'sequence': 1 + sequence})
 elif record.x_total > 0:
-    product = env['product.product'].search([('x_is_stay_tax', '=', True)], limit=1)
+    product = env['product.product'].search([('x_accommodation_product', '=', 'stay_tax')], limit=1)
     env['sale.order.line'].create({'order_id': record.x_sale_order_id.id, 'product_id': product.id, 'product_uom_qty': record.x_total, 'qty_delivered': record.x_total})
 ]]></field>
     </record>
@@ -130,8 +130,10 @@ if env['ir.config_parameter'].get_bool('booking_engine.x_approvers_setting', Fal
         <field name="code"><![CDATA[
 if (project := env['project.project'].search([('x_is_house_keeping_project', '=', True)], limit=1)):
     newtasks = []
-    last_midnight = datetime.datetime.today().replace(hour=0, minute=0)
-    for slot in env['planning.slot'].search([('start_datetime', '<', last_midnight),('end_datetime', '>=', last_midnight), ('resource_ids.x_category', '=', 'stay_offer')]):
+    last_midnight = datetime.datetime.today().replace(hour=0, minute=0, second=0, microsecond=0)
+    eci_product = env['product.product'].search([('x_accommodation_product', '=', 'early_checkin')], limit=1)
+    lco_product = env['product.product'].search([('x_accommodation_product', '=', 'late_checkout')], limit=1)
+    for slot in env['planning.slot'].search([('start_datetime', '<', last_midnight), ('end_datetime', '>=', last_midnight), ('resource_ids.x_category', '=', 'stay_offer')]):
         end_today = slot.end_datetime < last_midnight + datetime.timedelta(hours=24)
         cleaning_points = slot.sale_line_id.product_id.x_checkout_cleaning if end_today else slot.sale_line_id.product_id.x_stayover_cleaning
         if not cleaning_points: continue
@@ -145,6 +147,8 @@ if (project := env['project.project'].search([('x_is_house_keeping_project', '='
             'x_resource_id': slot.resource_ids[:1].id,
             'x_cleaning': 'checkout' if end_today else 'stayover',
             'x_cleaning_points': cleaning_points,
+            'x_priority_flag_ids': end_today and ([eci_product.id] if slot.x_has_eci_at_checkout else []) +
+                ([lco_product.id] if slot.x_has_late_checkout else []),
             'user_ids': [(5,0)],
         })
     env['project.task'].create(newtasks)

--- a/booking_engine/data/ir_model_fields.xml
+++ b/booking_engine/data/ir_model_fields.xml
@@ -134,12 +134,32 @@
     <field name="field_id" ref="product_model_product_template_x_offer_type" />
     <field name="value">SUI</field>
   </record>
-  <record id="product_model_product_template_x_is_stay_tax_field" model="ir.model.fields">
-    <field name="ttype">boolean</field>
+  <record id="product_model_product_template_x_accommodation_product_field" model="ir.model.fields">
+    <field name="ttype">selection</field>
     <field name="copied" eval="True"/>
-    <field name="field_description">Is City Tax</field>
+    <field name="field_description">Accommodation Product</field>
     <field name="model_id" ref="product.model_product_template"/>
-    <field name="name">x_is_stay_tax</field>
+    <field name="name">x_accommodation_product</field>
+    <field name="help">Provides specific behaviour related to accommodation needs:
+      - City Tax: Allows to automatically add this product during check out to sale orders.
+      - Early Check In: Flags sale orders, and house keeping tasks when part of a sale order (informative only).
+      - Late Check Out: Flags sale orders, and house keeping tasks when part of a sale order (informative only).
+    </field>
+  </record>
+  <record id="product_model_product_template_x_accommodation_product_field_selection_stay_tax" model="ir.model.fields.selection">
+    <field name="name">City Tax</field>
+    <field name="field_id" ref="product_model_product_template_x_accommodation_product_field" />
+    <field name="value">stay_tax</field>
+  </record>
+  <record id="product_model_product_template_x_accommodation_product_field_selection_early_checkin" model="ir.model.fields.selection">
+    <field name="name">Early Check In</field>
+    <field name="field_id" ref="product_model_product_template_x_accommodation_product_field" />
+    <field name="value">early_checkin</field>
+  </record>
+  <record id="product_model_product_template_x_accommodation_product_field_selection_late_checkout" model="ir.model.fields.selection">
+    <field name="name">Late Check Out</field>
+    <field name="field_id" ref="product_model_product_template_x_accommodation_product_field" />
+    <field name="value">late_checkout</field>
   </record>
   <record id="product_model_product_template_x_resource_ids_field" model="ir.model.fields">
     <field name="ttype">many2many</field>
@@ -148,6 +168,20 @@
     <field name="name">x_resource_ids</field>
     <field name="related">planning_role_id.resource_ids</field>
     <field name="relation">resource.resource</field>
+  </record>
+  <record id="sale_model_sale_order_x_priority_flag_ids_field" model="ir.model.fields">
+    <field name="ttype">many2many</field>
+    <field name="field_description">Priority Flags</field>
+    <field name="readonly" eval="True"/>
+    <field name="store" eval="False"/>
+    <field name="model_id" ref="sale.model_sale_order"/>
+    <field name="name">x_priority_flag_ids</field>
+    <field name="relation">product.product</field>
+    <field name="depends">order_line, order_line.product_id</field>
+    <field name="compute"><![CDATA[
+for record in self:
+    record['x_priority_flag_ids'] = record.order_line.product_id.filtered('x_accommodation_product').ids
+]]></field>
   </record>
   <record id="sale_order_x_order_involves_room" model="ir.model.fields">
     <field name="ttype">boolean</field>
@@ -232,6 +266,43 @@ for record in self: record['x_order_involves_room'] = any(line.product_id.x_is_a
     <field name="name">x_category</field>
     <field name="related">default_role_id.x_resource_category</field>
     <field name="store" eval="False"/>
+  </record>
+  <record id="model_planning_slot_x_has_early_checkin" model="ir.model.fields">
+    <field name="ttype">boolean</field>
+    <field name="field_description">Has Early Checkin</field>
+    <field name="model_id" ref="planning.model_planning_slot"/>
+    <field name="name">x_has_early_checkin</field>
+    <field name="depends">sale_order_id, sale_order_id.x_priority_flag_ids</field>
+    <field name="store" eval="False"/>
+    <field name="compute"><![CDATA[
+for record in self:
+    record['x_has_early_checkin'] = any(p.x_accommodation_product == 'early_checkin' for p in record.sale_order_id.x_priority_flag_ids)
+]]></field>
+  </record>
+  <record id="model_planning_slot_x_has_late_checkout" model="ir.model.fields">
+    <field name="ttype">boolean</field>
+    <field name="field_description">Has Late Checkout</field>
+    <field name="model_id" ref="planning.model_planning_slot"/>
+    <field name="name">x_has_late_checkout</field>
+    <field name="depends">sale_order_id, sale_order_id.x_priority_flag_ids</field>
+    <field name="store" eval="False"/>
+    <field name="compute"><![CDATA[
+for record in self:
+    record['x_has_late_checkout'] = any(p.x_accommodation_product == 'late_checkout' for p in record.sale_order_id.x_priority_flag_ids)
+]]></field>
+  </record>
+  <record id="model_planning_slot_x_has_eci_at_checkout" model="ir.model.fields">
+    <field name="ttype">boolean</field>
+    <field name="field_description">Has ECI at checkout</field>
+    <field name="model_id" ref="planning.model_planning_slot"/>
+    <field name="name">x_has_eci_at_checkout</field>
+    <field name="store" eval="False"/>
+    <field name="compute"><![CDATA[
+for record in self:
+    # if the next slot starts on the same day the current ends on, and the next slot has early checkin then there is an early checkin at the end of the current slot
+    next_slot = self.env['planning.slot'].search([('start_datetime', '>=', record.end_datetime), ('resource_ids', 'in', record.resource_ids.ids)], order='start_datetime', limit=1)
+    record['x_has_eci_at_checkout'] = next_slot.x_has_early_checkin and next_slot.start_datetime.date() == record.end_datetime.date()
+]]></field>
   </record>
   <record id="model_planning_slot_x_nights" model="ir.model.fields">
     <field name="ttype">integer</field>
@@ -471,6 +542,15 @@ for record in self: record['x_guests_count'] = self.env['x_guests_line'].search_
     </record>
 
     <!-- project.task fields -->
+    <record id="x_priority_flag_ids_field_project_task" model="ir.model.fields">
+        <field name="name">x_priority_flag_ids</field>
+        <field name="ttype">many2many</field>
+        <field name="field_description">Priority Flag</field>
+        <field name="model_id" ref="project.model_project_task"/>
+        <field name="relation">product.product</field>
+        <field name="domain" eval="[('x_accommodation_product', 'in', ['early_checkin', 'late_checkout'])]"/>
+        <field name="readonly" eval="True"/>
+    </record>
     <record id="x_resource_id_field_resource_resource" model="ir.model.fields">
         <field name="name">x_resource_id</field>
         <field name="ttype">many2one</field>

--- a/booking_engine/data/ir_ui_view.xml
+++ b/booking_engine/data/ir_ui_view.xml
@@ -56,7 +56,10 @@
         <xpath expr="//field[@name='is_rental_order']" position="after">
           <button string="City Tax" type="action" name="%(open_x_city_tax_action)d" context="{'search_default_x_sale_order_id': id, 'default_x_sale_order_id': id}" invisible="not x_order_involves_room"/>
         </xpath>
-        <xpath expr="//form[1]/sheet[1]/notebook[1]" position="inside">
+        <xpath expr="//group[@name='order_details']" postion="inside">
+          <field name="x_priority_flag_ids" widget="many2many_tags" invisible="not x_priority_flag_ids"/>
+        </xpath>
+        <xpath expr="//notebook" position="inside">
           <page string="Guests" invisible="not x_order_involves_room">
             <field name="x_guest_line_ids">
               <list default_order="x_sequence asc,id desc" editable="bottom">
@@ -159,23 +162,6 @@
     <field name="mode">extension</field>
     <field name="model">sale.order</field>
     <field name="name">sale.order.form.inherit.booking_engine</field>
-    <field name="priority">160</field>
-    <field name="type">form</field>
-    <field name="active" eval="True"/>
-  </record>
-  <record id="product_product_form_view" model="ir.ui.view">
-    <field name="arch" type="xml">
-      <xpath expr="//label[@for='lst_price']" position="attributes">
-        <attribute name="invisible">planning_role_id.x_resource_category</attribute>
-      </xpath>
-      <xpath expr="//div[@name='list_price_per_uom_id']" position="attributes">
-        <attribute name="invisible">x_is_a_room_offer</attribute>
-      </xpath>
-    </field>
-    <field name="inherit_id" ref="product.product_normal_form_view"/>
-    <field name="mode">extension</field>
-    <field name="model">product.product</field>
-    <field name="name">product.product.form.inherit.booking_engine</field>
     <field name="priority">160</field>
     <field name="type">form</field>
     <field name="active" eval="True"/>
@@ -407,41 +393,6 @@
     <field name="type">search</field>
     <field name="active" eval="True"/>
   </record>
-  <record id="booking_engine_order_search" model="ir.ui.view">
-    <field name="arch" type="xml">
-        <xpath expr="//filter[@name='my_sale_orders_filter']" position="before">
-          <filter domain="['|',
-            '&amp;', '&amp;', '&amp;',
-            ('rental_status', '=', 'return'),
-            ('rental_return_date', '&gt;=', datetime.datetime.combine(context_today(), datetime.time(0, 0, 0)).to_utc().strftime('%Y-%m-%d %H:%M:%S')),
-            ('rental_return_date', '&lt;', datetime.datetime.combine(context_today() + relativedelta(days = 1), datetime.time(0, 0, 0)).to_utc().strftime('%Y-%m-%d %H:%M:%S')),
-            ('state', '=', 'sale'),
-            '&amp;', '&amp;', '&amp;',
-            ('rental_status', '=', 'pickup'),
-            ('rental_start_date', '&gt;=', datetime.datetime.combine(context_today(), datetime.time(0, 0, 0)).to_utc().strftime('%Y-%m-%d %H:%M:%S')),
-            ('rental_start_date', '&lt;', datetime.datetime.combine(context_today() + relativedelta(days = 1), datetime.time(0, 0, 0)).to_utc().strftime('%Y-%m-%d %H:%M:%S')),
-            ('state', '=', 'sale')]"
-            name="filter_today" string="Today"/>
-          <separator/>
-        </xpath>
-        <xpath expr="//filter[@name='my_sale_orders_filter']" position="after">
-          <separator/>
-          <filter domain="[('rental_status', 'in', ['sent', 'draft'])]" name="filter_draft" string="Draft"/>
-          <filter domain="[('rental_status', '=', 'pickup'), ('state', '=', 'sale')]" name="filter_check_in" string="To Check In"/>
-          <filter domain="[('rental_status', '=', 'return'), ('state', '=', 'sale')]" name="filter_check_out" string="To Check Out"/>
-        </xpath>
-        <xpath expr="//filter[@name='salesperson']" position="before">
-          <filter string="Status" name="rental_status_group" context="{'group_by': 'rental_status'}"/>
-        </xpath>
-    </field>
-    <field name="inherit_id" ref="sale.view_sales_order_filter"/>
-    <field name="mode">primary</field>
-    <field name="model">sale.order</field>
-    <field name="name">sale.order.list.select.inherit.booking_engine</field>
-    <field name="priority">320</field>
-    <field name="type">search</field>
-    <field name="active" eval="True"/>
-  </record>
   <record id="booking_engine_schedule_form" model="ir.ui.view">
     <field name="arch" type="xml">
         <xpath expr="//field[@name='resource_ids']" position="attributes">
@@ -471,6 +422,10 @@
           <attribute name="form_view_id">%(booking_engine_schedule_form)d</attribute>
           <attribute name="multi_create_view"/>
           <attribute name="color">x_booking_color</attribute>
+        </xpath>
+        <xpath expr="/gantt" position="inside">
+          <field name="x_has_early_checkin"/>
+          <field name="x_has_late_checkout"/>
         </xpath>
     </field>
     <field name="inherit_id" ref="planning.planning_view_gantt"/>
@@ -591,7 +546,7 @@
     ]"/>
   </record>
   <record id="booking_engine_rooms_order_action" model="ir.actions.act_window">
-    <field name="search_view_id" ref="booking_engine_order_search"/>
+    <field name="search_view_id" ref="sale_renting.rental_order_view_search"/>
     <field name="view_ids" eval="[
       (5, 0, 0),
       (0, 0, {'view_mode': 'kanban', 'view_id': ref('booking_engine_orders_kanban')}),
@@ -702,6 +657,9 @@
     <!-- project.task views -->
     <record id="project_task_form_view_primary" model="ir.ui.view">
         <field name="arch" type="xml">
+            <xpath expr="//field[@name='project_id']" position="replace">
+              <field name="x_priority_flag_ids" widget="many2many_tags"/>
+            </xpath>
             <xpath expr="//field[@name='stage_id']" position="attributes">
                 <attribute name="options">{'clickable': '1', 'fold_field': 'auto_validation_state'}</attribute>
             </xpath>
@@ -734,6 +692,7 @@
                 <xpath expr="/list//field[@name='priority']" position="move"/>
             </xpath>
             <xpath expr="/list//field[@name='name']" position="after">
+                <field name="x_priority_flag_ids" widget="many2many_tags"/>
                 <field name="x_task_occupancy_color" column_invisible="True"/>
                 <field name="x_cleaning_color" column_invisible="True"/>
                 <field name="x_task_occupancy" optional="show" widget="badge" options="{'color_field': 'x_task_occupancy_color'}"/>

--- a/booking_engine/data/product_template.xml
+++ b/booking_engine/data/product_template.xml
@@ -9,7 +9,29 @@
         <field name="is_favorite" eval="True"/>
         <field name="service_type">manual</field>
         <field name="invoice_policy">delivery</field>
-        <field name="x_is_stay_tax" eval="True"/>
+        <field name="x_accommodation_product">stay_tax</field>
         <field name="taxes_id" eval="[(6, 0, [ref('account_tax_1')])]"/>
+    </record>
+    <record id="product_product_early_checkin" model="product.product">
+        <field name="name">Early Check In</field>
+        <field name="type">service</field>
+        <field name="categ_id" ref="product.product_category_services"/>
+        <field name="purchase_ok" eval="False"/>
+        <field name="is_favorite" eval="True"/>
+        <field name="service_type">manual</field>
+        <field name="invoice_policy">delivery</field>
+        <field name="x_accommodation_product">early_checkin</field>
+        <field name="list_price">15.0</field>
+    </record>
+    <record id="product_product_late_checkout" model="product.product">
+        <field name="name">Late Check Out</field>
+        <field name="type">service</field>
+        <field name="categ_id" ref="product.product_category_services"/>
+        <field name="purchase_ok" eval="False"/>
+        <field name="is_favorite" eval="True"/>
+        <field name="service_type">manual</field>
+        <field name="invoice_policy">delivery</field>
+        <field name="x_accommodation_product">late_checkout</field>
+        <field name="list_price">15.0</field>
     </record>
 </odoo>

--- a/booking_engine/static/src/xml/gantt_pill_flags.xml
+++ b/booking_engine/static/src/xml/gantt_pill_flags.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+    <t t-inherit="planning.PlanningGanttRenderer.Pill" t-inherit-mode="extension">
+        <xpath expr="//div[hasclass('o_gantt_pill')]" position="attributes">
+            <attribute name="t-attf-style">{{ pill.record.x_has_early_checkin ? 'padding-left: 16px !important;' : '' }} {{ pill.record.x_has_late_checkout ? 'padding-right: 16px !important;' : '' }}</attribute>
+        </xpath>
+        <xpath expr="//div[hasclass('o_gantt_pill')]" position="inside">
+            <span t-if="pill.record.x_has_early_checkin"
+                  class="fa fa-backward"
+                  style="position: absolute; left: 3px;"
+                  title="Early Check-in"/>
+            <span t-if="pill.record.x_has_late_checkout"
+                  class="fa fa-forward"
+                  style="position: absolute; right: 3px;"
+                  title="Late Check-out"/>
+        </xpath>
+    </t>
+
+</templates>

--- a/hotel/demo/sale_order_line.xml
+++ b/hotel/demo/sale_order_line.xml
@@ -26,6 +26,10 @@
     <field name="product_id" ref="product_product_15"/>
     <field name="product_uom_qty" eval="2"/>
   </record>
+  <record id="sale_order_line_3d" model="sale.order.line">
+    <field name="order_id" ref="sale_order_3"/>
+    <field name="product_id" ref="booking_engine.product_product_late_checkout"/>
+  </record>
   <record id="sale_order_line_4" model="sale.order.line">
     <field name="order_id" ref="sale_order_4"/>
     <field name="product_id" ref="standard_room_2p_1c"/>
@@ -51,9 +55,13 @@
     <field name="product_id" ref="standard_room_1p_breakfast"/>
     <field name="product_uom_qty">3</field>
   </record>
-  <record id="sale_order_line_9" model="sale.order.line">
+  <record id="sale_order_line_9a" model="sale.order.line">
     <field name="order_id" ref="sale_order_9"/>
     <field name="product_id" ref="standard_room_1p_breakfast"/>
+  </record>
+  <record id="sale_order_line_9b" model="sale.order.line">
+    <field name="order_id" ref="sale_order_9"/>
+    <field name="product_id" ref="booking_engine.product_product_early_checkin"/>
   </record>
   <record id="sale_order_line_10" model="sale.order.line">
     <field name="order_id" ref="sale_order_10"/>

--- a/hotel/demo/sale_order_post.xml
+++ b/hotel/demo/sale_order_post.xml
@@ -55,7 +55,7 @@
 
     <record id="pickup_wizard_9" model="rental.order.wizard">
         <field name="order_id" ref="sale_order_9"/>
-        <field name="rental_wizard_line_ids" eval="[(0, 0, {'order_line_id': ref('sale_order_line_9'), 'product_id': ref('standard_room_1p_breakfast'), 'qty_delivered': 1})]"/>
+        <field name="rental_wizard_line_ids" eval="[(0, 0, {'order_line_id': ref('sale_order_line_9a'), 'product_id': ref('standard_room_1p_breakfast'), 'qty_delivered': 1})]"/>
         <field name="status">pickup</field>
     </record>
 
@@ -152,7 +152,7 @@
 
     <function name="action_confirm" model="sale.order" eval="[ref('sale_order_9')]"/>
     <function name="write" model="planning.slot">
-        <value model="planning.slot" eval="obj().search([('sale_line_id', '=', ref('sale_order_line_9'))], limit=1).id"/>
+        <value model="planning.slot" eval="obj().search([('sale_line_id', '=', ref('sale_order_line_9a'))], limit=1).id"/>
         <value eval="{'resource_ids': [ref('planning_resource_2')]}"/>
     </function>
 

--- a/tests/test_booking_engine/tests/test_action_server.py
+++ b/tests/test_booking_engine/tests/test_action_server.py
@@ -263,7 +263,7 @@ class BookingEngineAutomationsTestCase(TransactionCase):
         product_template = self.env['product.template'].create({
             'name': 'Guest Product',
             'type': 'service',
-            'x_is_stay_tax': True,
+            'x_accommodation_product': 'stay_tax',
             'attribute_line_ids': [Command.create({
                 'attribute_id': attribute.id,
                 'value_ids': [Command.link(value.id)],
@@ -304,7 +304,7 @@ class BookingEngineAutomationsTestCase(TransactionCase):
         # ----------- Case 1: Stay tax line should be created -----------
         _, order_line, order_line_sequence, city_tax = _create_order_with_slot(product)
 
-        stay_tax_lines = order_line.filtered(lambda l: l.product_id.x_is_stay_tax)
+        stay_tax_lines = order_line.filtered(lambda l: l.product_id.x_accommodation_product == 'stay_tax')
         self.assertEqual(len(stay_tax_lines), 1,
                          "Server action should create a stay tax line if missing")
         self.assertEqual(stay_tax_lines.sequence, order_line_sequence + 1,
@@ -314,14 +314,14 @@ class BookingEngineAutomationsTestCase(TransactionCase):
         self.assertEqual(stay_tax_lines.qty_delivered, city_tax.x_total,
                          "Stay tax line delivered quantity should match city tax total")
 
-        # ----------- Case 2: Existing order line should be updated -----------
-        product.write({'x_is_stay_tax': False})
+        # ---------- Case 2: Existing order line should be updated ----------
+        product.write({'x_accommodation_product': False})
         order2, order_line2, _, city_tax2 = _create_order_with_slot(product)
         self.assertEqual(len(order2.order_line), 2,
                         "Server action should update existing order line")
         city_tax_line = order2.order_line - order_line2
 
-        self.assertTrue(city_tax_line.product_id.x_is_stay_tax, "City tax order line product should have x_is_stay_tax True")
+        self.assertEqual(city_tax_line.product_id.x_accommodation_product, "stay_tax", "City tax order line product should have x_accommodation_product = 'stay_tax'")
         self.assertEqual(city_tax_line.product_uom_qty, city_tax2.x_total, "City tax order line quantity should match city tax total")
         self.assertEqual(city_tax_line.qty_delivered, city_tax2.x_total, "City tax order line delivered quantity should match city tax total")
 


### PR DESCRIPTION
- Add products for early checkin and late checkout to optionally add them in SO.
- Add a priority flag system to check what kind of accommodation specific products are in SO.
- Modify house keeping task creation to indicate if the room has early checkin/late checkout on the same day

task-6150387