### PR TITLE
[FIX] test_booking_engine: assign calendar to overbooking test resource

### DIFF
--- a/tests/test_booking_engine/tests/test_action_server.py
+++ b/tests/test_booking_engine/tests/test_action_server.py
@@ -641,7 +641,7 @@ class BookingEngineAutomationsTestCase(TransactionCase):
             "Changing an untriggered field (like allocated_percentage) should NOT flag availabilities.",
         )
 
-    def _test_availability_flow_double_book_then_cancel(self):
+    def test_availability_flow_double_book_then_cancel(self):
         """Integration test to verify the actual math of availability computations during a booking flow."""
 
         # Setup
@@ -649,6 +649,7 @@ class BookingEngineAutomationsTestCase(TransactionCase):
         resource_2 = self.env['resource.resource'].create({
             'name': 'Test Room 2',
             'resource_type': 'material',
+            'calendar_id': False,
         })
 
         tmpl = self.product.product_tmpl_id


### PR DESCRIPTION
Explicitly assign calendar_id as False to the test resource. Since this calendar keeps the resource available on all days of the week, the test no longer depends on the weekday it runs on.