### PR TITLE
[FIX] *: Simplify code by removing useless browse

### DIFF
--- a/construction_developer/data/ir_actions_server.xml
+++ b/construction_developer/data/ir_actions_server.xml
@@ -224,7 +224,7 @@ if record.x_sale_order_line_id:
         'purchase_price': record.x_unit_cost,
     })
 elif record.x_targeted_so_id:
-    env['ir.actions.server'].browse(env.ref('construction_developer.server_action_create_product_for_wi').id).run()
+    env.ref('construction_developer.server_action_create_product_for_wi').run()
     sol = env['sale.order.line'].create({
         'order_id': record.x_targeted_so_id.id,
         'product_id': record.x_product_id.id,
@@ -274,7 +274,7 @@ env['x_work_item'].search([("x_active", "!=", False), ("id", "not in", records.i
 for record in records:
     partner_id = record.partner_id.id if not record.partner_id.parent_id else record.partner_id.parent_id.id
     for line in record.order_line:
-        server_action = env['ir.actions.server'].browse(env.ref('construction_developer.action_update_product_cost_and_vendor_list').id)
+        server_action = env.ref('construction_developer.action_update_product_cost_and_vendor_list')
         server_action.with_context(active_id=line.product_id.id, active_model="product.product", partner_id=partner_id, qty=line.product_qty, price=line.price_unit).sudo().run()
         ]]></field>
         <field name="model_id" ref="purchase.model_purchase_order"/>

--- a/excise_management/data/ir_model_fields.xml
+++ b/excise_management/data/ir_model_fields.xml
@@ -429,7 +429,7 @@ for record in self:
 # Not the cleanest, but allow for automatic update of the report without button
 for record in self:
     if record.x_state != "done" and record.x_from_date and record.x_to_date:
-        server_action = self.env['ir.actions.server'].browse(self.env.ref('excise_management.ir_action_compute_excise_report_line')).id
+        server_action = self.env.ref('excise_management.ir_action_compute_excise_report_line')
         server_action.with_context(active_ids=[record.id], active_model="x_excise_report").sudo().run()
         record['x_details_computation'] = True
         ]]></field>

--- a/real_estate/data/ir_actions_server.xml
+++ b/real_estate/data/ir_actions_server.xml
@@ -37,7 +37,7 @@
         <field name="usage">ir_cron</field>
         <field name="code"><![CDATA[
 for contact in model.search([('x_subscribe', '=', True), ('x_to_notify_property_ids', '!=', False)]):
-    if env['mail.template'].browse(env.ref('real_estate.mail_template_42').id).send_mail(res_id=contact.id):
+    if env.ref('real_estate.mail_template_42').send_mail(res_id=contact.id):
         contact['x_last_notification'] = datetime.datetime.now()
     ]]></field>
     </record>
@@ -115,7 +115,7 @@ for record in records:
         <field name="binding_model_id" ref="base.model_res_partner"/>
         <field name="state">code</field>
         <field name="code"><![CDATA[
-if env['mail.template'].browse(env.ref('real_estate.mail_template_42').id).send_mail(res_id=record.id):
+if env.ref('real_estate.mail_template_42').send_mail(res_id=record.id):
     record['x_last_notification'] = datetime.datetime.now()
         ]]></field>
     </record>

--- a/tests/test_excise_management/tests/test_action_server.py
+++ b/tests/test_excise_management/tests/test_action_server.py
@@ -90,7 +90,7 @@ class ActionServerTestCase(TransactionCase):
             "Fiscal positions that are deposit contains the purchase no excises tax")
 
     def test_fiscal_deposit_move_computation(self):
-        server_action = self.env['ir.actions.server'].browse(self.env.ref('excise_management.ir_action_compute_excise_report_line')).id
+        server_action = self.env.ref('excise_management.ir_action_compute_excise_report_line')
         customers = self.env['stock.location'].create({'name': 'Customers', 'usage': 'customer'})
         license1, license2 = self.env['x_excise_license'].create([
             {'x_name': 'License 1', 'x_active': True},

--- a/tests/test_handyman/tests/test_action_server.py
+++ b/tests/test_handyman/tests/test_action_server.py
@@ -43,7 +43,7 @@ class ActionServerTestCase(TransactionCase):
         move_line.analytic_distribution = False
         # Check that the automation is not triggered when move_line changes
         self.assertEqual(move_line.analytic_distribution, False)
-        server_action = self.env['ir.actions.server'].browse(self.env.ref('handyman.action_add_default_analytic_account').id)
+        server_action = self.env.ref('handyman.action_add_default_analytic_account')
         server_action.with_context(active_id=move_line.id, active_model="account.move.line").run()
         self.assertEqual(move_line.analytic_distribution, {f'{move_line.move_id.x_task_id.project_id.account_id.id}': 100.0})
 
@@ -56,6 +56,6 @@ class ActionServerTestCase(TransactionCase):
             project_task.name = "project_task_1"
             # Check that the automation is not triggered when project task is changed
             self.assertEqual(project_task.name, "project_task_1")
-            server_action = self.env['ir.actions.server'].browse(self.env.ref('handyman.action_add_section_task_name').id)
+            server_action = self.env.ref('handyman.action_add_section_task_name')
             server_action.with_context(active_ids=[project_task.id], active_model="project.task").run()
             self.assertEqual(project_task.name, "project_task_1 - section_1")

--- a/tests/test_real_estate/tests/test_action_server.py
+++ b/tests/test_real_estate/tests/test_action_server.py
@@ -65,7 +65,7 @@ class RealEstateAutomationsTestCase(TransactionCase):
             'name': 'Test Property',
         })
 
-        create_appointment = self.env['ir.actions.server'].browse(self.env.ref('real_estate.create_appointment_link_server_action').id)
+        create_appointment = self.env.ref('real_estate.create_appointment_link_server_action')
         create_appointment.with_context(active_ids=product.id, active_model="product.template").run()
 
         # Tests the 'create_appointment_link' server action
@@ -146,7 +146,7 @@ class RealEstateAutomationsTestCase(TransactionCase):
             'name': 'Test Property',
             'categ_id': self.env.ref('real_estate.product_category_5').id
         })
-        create_appointment = self.env['ir.actions.server'].browse(self.env.ref('real_estate.create_appointment_link_server_action').id)
+        create_appointment = self.env.ref('real_estate.create_appointment_link_server_action')
         create_appointment.with_context(active_ids=product.id, active_model="product.template").run()
 
         # create a lead and trigger visit action
@@ -156,7 +156,7 @@ class RealEstateAutomationsTestCase(TransactionCase):
             'email_from': 'test@email.com',
             'x_interested_in_id': product.id,
         })
-        visit = self.env['ir.actions.server'].browse(self.env.ref('real_estate.book_your_visit_server_action').id)
+        visit = self.env.ref('real_estate.book_your_visit_server_action')
         visit.with_context(active_ids=lead.id, active_model="crm.lead").run()
 
         email = self.env['mail.mail'].search([('recipient_ids.id', '=', lead.partner_id.id)], limit=1)
@@ -221,13 +221,13 @@ class RealEstateAutomationsTestCase(TransactionCase):
                          "Property 3 should be matched with the client")
 
         # check for send_matches_from_contact_server_action
-        send_matches_action = self.env['ir.actions.server'].browse(self.env.ref('real_estate.send_matches_from_contact_server_action').id)
+        send_matches_action = self.env.ref('real_estate.send_matches_from_contact_server_action')
         send_matches_action.with_context(active_id=client.id, active_model="res.partner").run()
         email = self.env['mail.mail'].search_count([('recipient_ids.id', '=', client.id)])
         self.assertEqual(email, 1, "One email should be sent to the client with matched properties")
 
         # check for notify_contacts_for_matches_server_action (also tests the x_to_notify_property_ids field)
-        notify_action = self.env['ir.actions.server'].browse(self.env.ref('real_estate.notify_contacts_for_matches_server_action').id)
+        notify_action = self.env.ref('real_estate.notify_contacts_for_matches_server_action')
         notify_action.run()
         email_count = self.env['mail.mail'].search_count([('recipient_ids.id', '=', client.id)])
         self.assertEqual(email_count, 2, "One email should be sent to the client after notification by notify_contacts_for_matches action")
@@ -302,7 +302,7 @@ class RealEstateAutomationsTestCase(TransactionCase):
             'x_criteria_ids': self.region_value_1,
         })
 
-        create_lead_action = self.env['ir.actions.server'].browse(self.env.ref('real_estate.create_lead_from_match_server_action').id)
+        create_lead_action = self.env.ref('real_estate.create_lead_from_match_server_action')
         create_lead_action.with_context(active_id=matching_client.id, active_model="res.partner", property_id=property.id).run()
 
         lead = self.env['crm.lead'].search([('partner_id', '=', matching_client.id)], limit=1)


### PR DESCRIPTION
This PR removes the useless wording of env.browse(ref().id) to use the reference directly instead.