### PR TITLE
[IMP] real_estate: improve property appointment creation flow

### DIFF
--- a/real_estate/__manifest__.py
+++ b/real_estate/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Real Estate Agency',
-    'version': '1.9',
+    'version': '1.10',
     'category': 'Services',
     'author': 'Odoo S.A.',
     'depends': [

--- a/real_estate/data/ir_actions_server.xml
+++ b/real_estate/data/ir_actions_server.xml
@@ -106,15 +106,35 @@ for record in records: record['x_technical_partner_id'] = env['res.partner'].cre
           ]]></field>
     </record>
 
+    <record id="server_action_property_appointments" model="ir.actions.server">
+        <field name="name">Open Appointments</field>
+        <field name="model_id" ref="product.model_product_template"/>
+        <field name="state">code</field>
+        <field name="code"><![CDATA[
+appointments = records.x_appointment_ids
+action = {
+    'type': 'ir.actions.act_window',
+    'res_model': 'appointment.type',
+}
+action.update({'view_mode': 'form', 'res_id': appointments.id}) if len(appointments) == 1 else action.update({'name': 'Appointments', 'view_mode': 'list,form', 'domain': [('id', 'in', appointments.ids)]})
+        ]]></field>
+    </record>
+
     <record id="create_appointment_link_server_action" model="ir.actions.server">
         <field name="name">Create Appointment &amp; Link</field>
         <field name="model_id" ref="product.model_product_template"/>
         <field name="binding_model_id" ref="product.model_product_template"/>
         <field name="state">code</field>
         <field name="code"><![CDATA[
+appointment_tz = env.ref('base.user_admin').tz or 'Europe/Brussels'
 for record in records:
+    if record.x_booking_link: continue
+    if not record.x_agent_id: raise UserError(f"Please assign an agent first.")
     link = env['appointment.invite'].create({'short_code': datetime.datetime.now().strftime("%M%m%S%d%Y%H") + str(record.id), 'display_name': record.name})
-    env['appointment.type'].create({'name': record.name, 'display_name': record.name, 'x_property_id': record.id, 'appointment_invite_ids': [Command.link(link.id)], 'location_id': record.x_technical_partner_id.id, 'image_1920': record.image_1920, 'appointment_tz': env.ref('base.user_admin').tz or 'Europe/Brussels', 'staff_user_ids': [Command.link(record.x_agent_id.id)] if record.x_agent_id else False, 'category': 'custom', 'event_videocall_source': False})
+    appointment = env['appointment.type'].create({'name': record.name, 'display_name': record.name, 'x_property_id': record.id, 'appointment_invite_ids': [Command.link(link.id)], 'location_id': record.x_technical_partner_id.id, 'image_1920': record.image_1920, 'appointment_tz': appointment_tz, 'staff_user_ids': [Command.link(record.x_agent_id.id)], 'category': 'custom', 'event_videocall_source': False})
+
+if env.context.get('from_form_view') and len(records) == 1:
+    action = {'type': 'ir.actions.act_window', 'res_model': 'appointment.type', 'view_mode': 'form', 'res_id': appointment.id}
         ]]></field>
     </record>
 

--- a/real_estate/data/ir_model_fields.xml
+++ b/real_estate/data/ir_model_fields.xml
@@ -322,6 +322,19 @@ for property in self: property['x_x_property_matches_contacts_res_partner_count'
         <field name="selectable" eval="False"/>
         <field name="store" eval="False"/>
     </record>
+    <record id="field_product_template_appointment_count" model="ir.model.fields">
+        <field name="compute"><![CDATA[
+for record in self:
+    record['x_appointment_count'] = len(record.x_appointment_ids)
+        ]]></field>
+        <field name="ttype">integer</field>
+        <field name="field_description">Appointment Count</field>
+        <field name="model_id" ref="product.model_product_template"/>
+        <field name="name">x_appointment_count</field>
+        <field name="readonly" eval="True"/>
+        <field name="selectable" eval="False"/>
+        <field name="store" eval="False"/>
+    </record>
     <record id="field_appointment_type_property_id" model="ir.model.fields">
         <field name="ttype">many2one</field>
         <field name="copied" eval="True"/>
@@ -514,6 +527,7 @@ for partner in self: partner['x_interested_in_ids'] = [(6, 0, data.get(partner.i
         <field name="related">x_appointment_ids.appointment_invite_ids.book_url</field>
         <field name="model_id" ref="product.model_product_template"/>
         <field name="name">x_booking_link</field>
+        <field name="field_description">Shared Link</field>
         <field name="readonly" eval="True"/>
         <field name="selectable" eval="False"/>
         <field name="store" eval="False"/>

--- a/real_estate/data/ir_ui_view.xml
+++ b/real_estate/data/ir_ui_view.xml
@@ -24,7 +24,7 @@
         </xpath>
         <xpath expr="//sheet[@name='product_form']" position="before">
           <header>
-            <button string="Create Visit Link" name="%(create_appointment_link_server_action)d" type="action" invisible="not x_is_properties or x_appointment_ids or x_is_closed"/>
+            <button string="Create Visit Link" name="%(create_appointment_link_server_action)d" type="action" invisible="not x_is_properties or x_appointment_ids or x_is_closed" context="{'from_form_view': True}"/>
           </header>
         </xpath>
         <xpath expr="//button[@name='action_view_sales']" position="after">
@@ -36,6 +36,9 @@
           </button>
           <button class="oe_stat_button" icon="fa-heart" type="action" name="%(matches_contact_act_window)d" invisible="not x_is_properties" context="{'property_id': id}">
             <field widget="statinfo" name="x_x_property_matches_contacts_res_partner_count" string="Matches"/>
+          </button>
+          <button class="oe_stat_button" icon="fa-calendar" type="action" name="%(server_action_property_appointments)d" invisible="not x_appointment_count">
+              <field widget="statinfo" name="x_appointment_count" string="Appointments"/>
           </button>
         </xpath>
         <xpath expr="//field[@name='default_code']" position="after">
@@ -340,7 +343,7 @@
     <field name="priority">200</field>
     <field name="type">form</field>
     <field name="arch" type="xml">
-        <xpath expr="//group[@name='left_details']/div[1]" position="after">
+        <xpath expr="//group[@name='left_details']/span[1]" position="after">
           <field name="appointment_invite_ids" widget="many2many_tags" options="{'edit_tags':true}"/>
         </xpath>
         <xpath expr="//group[@name='left_details']" position="inside">
@@ -475,6 +478,17 @@
     <field name="arch" type="xml">
         <xpath expr="//field[@name='create_variant']" position="after">
           <field name="x_is_matchmaking"/>
+        </xpath>
+    </field>
+  </record>
+  <record id="product_template_list_view_inherit" model="ir.ui.view">
+    <field name="name">product.template.list.inherit.real_estate</field>
+    <field name="model">product.template</field>
+    <field name="inherit_id" ref="product.product_template_tree_view"/>
+    <field name="active" eval="True"/>
+    <field name="arch" type="xml">
+        <xpath expr="//field[@name='default_code']" position="after">
+            <field name="x_agent_id" optional="hide"/>
         </xpath>
     </field>
   </record>

--- a/real_estate/demo/product_template.xml
+++ b/real_estate/demo/product_template.xml
@@ -37,6 +37,7 @@
         <field name="website_sequence">10060</field>
         <field name="public_categ_ids" eval="[(6, 0, [ref('product_public_category_1')])]"/>
         <field name="categ_id" ref="product_category_5"/>
+        <field name="x_agent_id" ref="base_industry_data.res_users_7"/>
         <field name="x_ribbon_stage_is_accounted" eval="True"/>
         <field name="is_published" eval="True"/>
         <field name="x_technical_partner_id" ref="res_partner_77"/>
@@ -52,6 +53,7 @@
         <field name="website_sequence">10055</field>
         <field name="public_categ_ids" eval="[(6, 0, [ref('product_public_category_2')])]"/>
         <field name="categ_id" ref="product_category_5"/>
+        <field name="x_agent_id" ref="base_industry_data.res_users_7"/>
         <field name="x_ribbon_stage_is_accounted" eval="True"/>
         <field name="is_published" eval="True"/>
         <field name="x_technical_partner_id" ref="res_partner_76"/>
@@ -87,6 +89,7 @@
         <field name="website_sequence">10065</field>
         <field name="public_categ_ids" eval="[(6, 0, [ref('product_public_category_2')])]"/>
         <field name="categ_id" ref="product_category_5"/>
+        <field name="x_agent_id" ref="base_industry_data.res_users_7"/>
         <field name="x_ribbon_stage_is_accounted" eval="True"/>
         <field name="is_published" eval="True"/>
         <field name="x_technical_partner_id" ref="res_partner_78"/>
@@ -102,6 +105,7 @@
         <field name="website_sequence">10050</field>
         <field name="public_categ_ids" eval="[(6, 0, [ref('product_public_category_1')])]"/>
         <field name="categ_id" ref="product_category_5"/>
+        <field name="x_agent_id" ref="base_industry_data.res_users_7"/>
         <field name="x_ribbon_stage_is_accounted" eval="True"/>
         <field name="is_published" eval="True"/>
         <field name="x_technical_partner_id" ref="res_partner_75"/>
@@ -135,6 +139,7 @@
         <field name="website_sequence">10045</field>
         <field name="public_categ_ids" eval="[(6, 0, [ref('product_public_category_2')])]"/>
         <field name="categ_id" ref="product_category_5"/>
+        <field name="x_agent_id" ref="base_industry_data.res_users_7"/>
         <field name="x_ribbon_stage_is_accounted" eval="True"/>
         <field name="is_published" eval="True"/>
         <field name="x_technical_partner_id" ref="res_partner_74"/>
@@ -150,6 +155,7 @@
         <field name="website_sequence">10070</field>
         <field name="public_categ_ids" eval="[(6, 0, [ref('product_public_category_1')])]"/>
         <field name="categ_id" ref="product_category_5"/>
+        <field name="x_agent_id" ref="base_industry_data.res_users_7"/>
         <field name="x_ribbon_stage_is_accounted" eval="True"/>
         <field name="is_published" eval="True"/>
         <field name="x_technical_partner_id" ref="res_partner_79"/>
@@ -179,6 +185,7 @@
         <field name="website_sequence">10040</field>
         <field name="public_categ_ids" eval="[(6, 0, [ref('product_public_category_1')])]"/>
         <field name="categ_id" ref="product_category_5"/>
+        <field name="x_agent_id" ref="base_industry_data.res_users_7"/>
         <field name="x_ribbon_stage_is_accounted" eval="True"/>
         <field name="is_published" eval="True"/>
         <field name="x_technical_partner_id" ref="res_partner_73"/>

--- a/tests/test_real_estate/tests/test_action_server.py
+++ b/tests/test_real_estate/tests/test_action_server.py
@@ -61,6 +61,7 @@ class RealEstateAutomationsTestCase(TransactionCase):
     def test_create_and_archive_appointment_types(self):
         product = self.env['product.template'].create({
             'name': 'Test Property',
+            'x_agent_id': self.env.ref('base.user_admin').id
         })
 
         create_appointment = self.env.ref('real_estate.create_appointment_link_server_action')
@@ -142,7 +143,8 @@ class RealEstateAutomationsTestCase(TransactionCase):
     def test_send_email_book_visit(self):
         product = self.env['product.template'].create({
             'name': 'Test Property',
-            'categ_id': self.env.ref('real_estate.product_category_5').id
+            'categ_id': self.env.ref('real_estate.product_category_5').id,
+            'x_agent_id': self.env.ref('base.user_admin').id
         })
         create_appointment = self.env.ref('real_estate.create_appointment_link_server_action')
         create_appointment.with_context(active_ids=product.id, active_model="product.template").run()


### PR DESCRIPTION
Appointment workflow:
- Add an "Appointments" smart button on the property form view.
- Display the total number of appointments linked to the property.
- Open the property's related appointments when clicking on the smart button.
- Redirect users to the created appointment records after clicking on the
"Create Visit Link" button.

Demo data and test update:
- Since the Agent field is mandatory for appointment creation, add x_agent_id in
the demo property records.
- Add x_agent_id in the property test data since the agent is required for visit
link creation.

Bug fix:

Issue:
- The "Create Appointment & Link" action was creating duplicate appointments
and links even for properties whose link was already generated.

Steps to reproduce:
- Open the property list view.
- Select properties whose appointments are already created, and a link is
generated.
- Click on Actions -> "Create Appointment & Link".

Solution:
- Skip properties whose link has already been generated when creating
appointments/link from the server action menu.
- Generate visit links and appointments only for selected properties whose links
are not already generated, and show a validation message when all selected
Properties already have existing links.

Task ID-6217777