### PR TITLE
[REV] booking_engine: slot kanban view extension

### DIFF
--- a/booking_engine/__manifest__.py
+++ b/booking_engine/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Booking Engine',
-    'version': '1.14',
+    'version': '1.15',
     'category': 'Hidden/Tools',
     'author': 'Odoo S.A.',
     'depends': [

--- a/booking_engine/data/ir_ui_view.xml
+++ b/booking_engine/data/ir_ui_view.xml
@@ -252,14 +252,22 @@
     <field name="type">form</field>
     <field name="active" eval="True"/>
   </record>
+  <record id="planning_kanban_view" model="ir.ui.view">
+    <field name="active" eval="True"/>
+    <field name="arch" type="xml">
+      <xpath expr="//field[@name='sale_line_id']" position="replace"/>
+      <xpath expr="//footer/div" position="before">
+        <field name="sale_order_id" widget="many2one" context="{'form_view_ref': 'booking_engine.rental_order_view', 'in_rental_app': 1}"/>
+      </xpath>
+    </field>
+    <field name="inherit_id" ref="sale_planning.planning_slot_view_kanban_inherit_sale_planning"/>
+    <field name="model">planning.slot</field>
+    <field name="priority">200</field>
+  </record>
   <record id="booking_engine_planning_kanban_view" model="ir.ui.view">
     <field name="arch" type="xml">
       <xpath expr="//kanban" position="attributes">
           <attribute name="default_group_by">x_rental_status</attribute>
-      </xpath>
-      <xpath expr="//field[@name='sale_line_id']" position="replace"/>
-      <xpath expr="//footer/div" position="before">
-        <field name="sale_order_id" widget="many2one" context="{'form_view_ref': 'booking_engine.rental_order_view', 'in_rental_app': 1}"/>
       </xpath>
     </field>
     <field name="inherit_id" ref="planning.planning_view_kanban"/>


### PR DESCRIPTION
In a recent commit, a planning view (extension) was replaced by another one (primary). This was meant to not pollute the standard planning kanban view with a default_group_by. The problem is that other xpath should remain in all views, i.e. in extension mode.

This commit brings back the previous view with the adaptation done in here-under mentioned commit, and only leaves the default_group_by attribute in the new primary view. It also fixes the inherit_id of the new view, which relies on sale_planning extension.

https://github.com/odoo/industry/commit/5e0786cc729de81779d68e59108cfbcfbed3d913