### PR TITLE
[FIX] condominium, property_assets_distribution: fix error on property deletion

### DIFF
--- a/condominium/__manifest__.py
+++ b/condominium/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Property Owner Association',
-    'version': '3.1',
+    'version': '3.2',
     'category': 'Services',
     'depends': [
         'account_check_printing',

--- a/condominium/data/base_automation.xml
+++ b/condominium/data/base_automation.xml
@@ -37,4 +37,10 @@
         <field name="action_server_ids" eval="[(6, 0, [ref('action_update_voter_line_for_motion')])]"/>
         <field name="trigger_field_ids" eval="[(6, 0, [ref('field_calendar_attendee_is_attending'), ref('field_calendar_attendee_is_delegating')])]"/>
     </record>
+    <record id="automation_archive_related_accounts" model="base.automation">
+        <field name="name">On property deletion</field>
+        <field name="model_id" ref="property_assets_distribution.model_x_property"/>
+        <field name="action_server_ids" eval="[(6, 0, [ref('action_archive_related_accounts')])]"/>
+        <field name="trigger">on_unlink</field>
+    </record>
 </odoo>

--- a/condominium/data/ir_actions_server.xml
+++ b/condominium/data/ir_actions_server.xml
@@ -264,4 +264,13 @@ for motion_line in record.event_id.x_motion_ids:
         <field name="name">Update Voter Lines Of Motion</field>
         <field name="usage">base_automation</field>
     </record>
+    <record id="action_archive_related_accounts" model="ir.actions.server">
+        <field name="code">
+record.x_owner_ids.x_account.write({'active': False})
+        </field>
+        <field name="model_id" ref="property_assets_distribution.model_x_property"/>
+        <field name="state">code</field>
+        <field name="name">Archive related accounts</field>
+        <field name="usage">base_automation</field>
+    </record>
 </odoo>

--- a/property_assets_distribution/__manifest__.py
+++ b/property_assets_distribution/__manifest__.py
@@ -1,5 +1,6 @@
 {
     'name': 'Property Assets & Distribution',
+    'version': '1.1',
     'category': 'Hidden/Tools',
     'depends': [
         'sale_subscription',

--- a/property_assets_distribution/data/base_automation.xml
+++ b/property_assets_distribution/data/base_automation.xml
@@ -7,12 +7,6 @@
         <field name="trigger">on_create_or_write</field>
         <field name="trigger_field_ids" eval="[(6, 0, [ref('field_meter_reading_date'), ref('field_meter_reading_quantity'), ref('field_meter_reading_meter_id')])]"/>
     </record>
-    <record id="automation_archive_related_accounts" model="base.automation">
-        <field name="name">On property deletion</field>
-        <field name="model_id" ref="model_x_property"/>
-        <field name="action_server_ids" eval="[(6, 0, [ref('action_archive_related_accounts')])]"/>
-        <field name="trigger">on_unlink</field>
-    </record>
     <record id="automation_validate_property_stake_holder_dates" model="base.automation">
         <field name="name">Validate stakeholder dates</field>
         <field name="model_id" ref="model_x_stake_holder"/>

--- a/property_assets_distribution/data/ir_actions_server.xml
+++ b/property_assets_distribution/data/ir_actions_server.xml
@@ -44,13 +44,4 @@ for line in records:
         }).id
         </field>
     </record>
-    <record id="action_archive_related_accounts" model="ir.actions.server">
-        <field name="code">
-record.x_owner_ids.x_account.write({'active': False})
-        </field>
-        <field name="model_id" ref="model_x_property"/>
-        <field name="state">code</field>
-        <field name="name">Archive related accounts</field>
-        <field name="usage">base_automation</field>
-    </record>
 </odoo>


### PR DESCRIPTION
Currently, an error occurs when a user deletes a property record.

**Steps to Reproduce:**
 - Install `industry_real_estate` with demo data.
 - Go to `Leasing` > `Properties` > `Properties`.
 - Delete a `property` record.

`ValueError: AttributeError("'x_property' object has no attribute 'x_owner_ids'") while evaluating
"record.x_owner_ids.x_account.write({'active': False})"`

After a [recent commit], the x_owner_ids field was defined on x_property in the condominium 
module [1]. The error occurs when a property record is deleted and a server action [2] is triggered 
through a base automation rule [3] to archive the owners' account records. Since x_owner_ids is 
defined in the condominium module, accessing it raises an error when the condominium module 
is not installed.

This commit moves the server action and the corresponding base automation rule to the 
condominium module, where the x_owner_ids field is defined.

[recent commit]: https://github.com/odoo/industry/commit/8e166b3bb8bb66e53da5c2f9e6e15a9751f7aa38#diff-70ae8e6ca07f28b93f3e4d02c124d0217e4e951b2b5f77a92cc9651142c22c0d

[1]: https://github.com/odoo/industry/blob/d0b2141b47115dc8dd7a5e5fca4131a227125435/condominium/data/ir_model_fields.xml#L200-L208

[2]- https://github.com/odoo/industry/blob/d0b2141b47115dc8dd7a5e5fca4131a227125435/property_assets_distribution/data/ir_actions_server.xml#L47-L55

[3]: https://github.com/odoo/industry/blob/d0b2141b47115dc8dd7a5e5fca4131a227125435/property_assets_distribution/data/base_automation.xml#L10-L15

sentry-7511045457