### PR TITLE
[FIX] real_estate: create ribbons to avoid translations issues

### DIFF
--- a/real_estate/__manifest__.py
+++ b/real_estate/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Real Estate Agency',
-    'version': '1.4',
+    'version': '1.5',
     'category': 'Services',
     'author': 'Odoo S.A.',
     'depends': [

--- a/real_estate/data/product_ribbon.xml
+++ b/real_estate/data/product_ribbon.xml
@@ -1,28 +1,39 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-    <record id="website_sale.sale_ribbon" model="product.ribbon" forcecreate="1">
+    <record id="draft_ribbon" model="product.ribbon">
         <field name="name">Draft</field>
-        <field name="text_color">#ffffff</field>
         <field name="x_is_draft_ribbon" eval="True"/>
+        <field name="sequence">1</field>
     </record>
-    <record id="website_sale.sold_out_ribbon" model="product.ribbon" forcecreate="1">
+    <record id="pre_published_ribbon" model="product.ribbon">
         <field name="name">Pre-published</field>
         <field name="bg_color">#a3009e</field>
+        <field name="sequence">0</field>
     </record>
     <record id="website_sale.new_ribbon" model="product.ribbon" forcecreate="1">
-        <field name="name">New</field>
-        <field name="bg_color">#0275d8</field>
+        <field name="name">New!</field>
+        <field name="sequence">2</field>
     </record>
     <record id="product_ribbon_6" model="product.ribbon">
         <field name="name">Option</field>
         <field name="bg_color">#e0ce00</field>
+        <field name="sequence">3</field>
     </record>
     <record id="product_ribbon_7" model="product.ribbon">
         <field name="name">Sold</field>
         <field name="bg_color">#41a300</field>
         <field name="x_is_closed_ribbon" eval="True"/>
+        <field name="sequence">4</field>
     </record>
     <function model="product.ribbon" name="unlink">
-        <value model="product.ribbon" eval="(obj().env.ref('website_sale.out_of_stock_ribbon', raise_if_not_found=False) or obj().env['product.ribbon']).id"/>
+        <value model="product.ribbon" eval="[
+            ribbon.id for ribbon in [obj().env.ref(xmlid, raise_if_not_found=False) for xmlid in [
+                'website_sale.out_of_stock_ribbon',
+                'website_sale.sale_ribbon',
+                'website_sale.sold_out_ribbon',
+            ]] if ribbon
+                and not obj().env['product.product'].search_count([('variant_ribbon_id', '=', ribbon.id)], limit=1)
+                and not obj().env['product.template'].search_count([('website_ribbon_id', '=', ribbon.id)], limit=1)
+        ]"/>
     </function>
 </odoo>

--- a/real_estate/demo/product_template.xml
+++ b/real_estate/demo/product_template.xml
@@ -11,7 +11,7 @@
 <p>The spacious 700m² plot features a stunning swimming pool, creating an ideal outdoor entertainment space. The landscaped grounds provide both privacy and serenity, while still offering ample space for outdoor activities.</p>
 <p><img src="/web/image/real_estate.ir_attachment_1235" alt="" class="img img-fluid o_we_custom_image" loading="lazy" data-mimetype="image/png" data-original-id="1235" data-original-src="/web/image/real_estate.ir_attachment_1235" data-mimetype-before-conversion="image/png" style="width: 25% !important;"></p>
 <p><span class="s_badge badge o_animable oe_snippet_body text-bg-info" data-name="Badge" data-vxml="001" data-snippet="s_badge">Offers start at<br></span><br></p>]]></field>
-        <field name="website_ribbon_id" ref="website_sale.sold_out_ribbon"/>
+        <field name="website_ribbon_id" ref="pre_published_ribbon"/>
         <field name="website_sequence">10010</field>
         <field name="public_categ_ids" eval="[(6, 0, [ref('product_public_category_1')])]"/>
         <field name="categ_id" ref="product_category_5"/>

--- a/tests/test_real_estate/tests/test_action_server.py
+++ b/tests/test_real_estate/tests/test_action_server.py
@@ -48,14 +48,14 @@ class RealEstateAutomationsTestCase(TransactionCase):
     def test_publish_draft_product(self):
         product = self.env['product.template'].create({
             'name': 'Test Property',
-            'website_ribbon_id': self.env.ref('website_sale.sale_ribbon').id
+            'website_ribbon_id': self.env.ref('real_estate.draft_ribbon').id
         })
 
         product.is_published = True
         self.assertTrue(not product.is_published,
                         "The product should not be publishable when the ribbon is in draft state")
 
-        product.website_ribbon_id = self.env.ref('website_sale.sold_out_ribbon')
+        product.website_ribbon_id = self.env.ref('real_estate.pre_published_ribbon')
         product.is_published = True
         self.assertTrue(product.is_published,
                         "The product should be publishable when the ribbon is not in draft state")
@@ -83,7 +83,7 @@ class RealEstateAutomationsTestCase(TransactionCase):
             'name': 'Test Property',
         })
 
-        product.website_ribbon_id = self.env.ref('website_sale.sold_out_ribbon')
+        product.website_ribbon_id = self.env.ref('real_estate.pre_published_ribbon')
         self.assertTrue(product.x_ribbon_stage_is_accounted,
                         "The product ribbon should be marked as accounted when it is updated")
         self.assertTrue(product.x_last_notification_update,
@@ -93,7 +93,7 @@ class RealEstateAutomationsTestCase(TransactionCase):
         product = self.env['product.template'].create({
             'name': 'Test Property',
         })
-        product.website_ribbon_id = self.env.ref('website_sale.sold_out_ribbon')
+        product.website_ribbon_id = self.env.ref('real_estate.pre_published_ribbon')
         product.list_price = 100.0
         last_notification = product.x_last_notification_update
         product.list_price = 150.0

--- a/wine_merchant/__manifest__.py
+++ b/wine_merchant/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Wine Shop',
-    'version': '1.0',
+    'version': '1.1',
     'category': 'Retail',
     'author': 'Odoo S.A.',
     'depends': [

--- a/wine_merchant/data/product_attribute.xml
+++ b/wine_merchant/data/product_attribute.xml
@@ -1,33 +1,42 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-  <record id="website_sale.product_attribute_brand" model="product.attribute" forcecreate="1">
+  <record id="product_attribute_category" model="product.attribute">
     <field name="name">Product Category</field>
   </record>
   <record id="product_barcodelookup.product_attribute_lookup_1" model="product.attribute" forcecreate="1">
+    <field name="name">color</field>
+  </record>
+  <record id="product_attribute_region" model="product.attribute">
     <field name="name">Region</field>
   </record>
-  <record id="product_barcodelookup.product_attribute_lookup_2" model="product.attribute" forcecreate="1">
+  <record id="product_attribute_vintage" model="product.attribute">
     <field name="name">Vintage</field>
   </record>
-  <record id="product_barcodelookup.product_attribute_lookup_3" model="product.attribute" forcecreate="1">
+  <record id="product_attribute_grape_variety" model="product.attribute">
     <field name="name">Grape Variety</field>
   </record>
-  <record id="product_barcodelookup.product_attribute_lookup_4" model="product.attribute" forcecreate="1">
+  <record id="product_attribute_vineyard" model="product.attribute">
     <field name="name">Vineyard</field>
   </record>
-  <record id="product_barcodelookup.product_attribute_lookup_5" model="product.attribute" forcecreate="1">
-    <field name="name">Color</field>
+  <record id="product_barcodelookup.product_attribute_lookup_2" model="product.attribute" forcecreate="0">
+    <field name="visibility" eval="False"/>
+  </record>
+  <record id="product_barcodelookup.product_attribute_lookup_3" model="product.attribute" forcecreate="0">
+    <field name="visibility" eval="False"/>
+  </record>
+  <record id="product_barcodelookup.product_attribute_lookup_4" model="product.attribute" forcecreate="0">
+    <field name="visibility" eval="False"/>
+  </record>
+  <record id="product_barcodelookup.product_attribute_lookup_5" model="product.attribute" forcecreate="0">
+    <field name="visibility" eval="False"/>
   </record>
   <record id="product_barcodelookup.product_attribute_lookup_6" model="product.attribute" forcecreate="0">
-    <field name="name">brand</field>
     <field name="visibility" eval="False"/>
   </record>
   <record id="product_barcodelookup.product_attribute_lookup_7" model="product.attribute" forcecreate="0">
-    <field name="name">size</field>
     <field name="visibility" eval="False"/>
   </record>
   <record id="product_barcodelookup.product_attribute_lookup_8" model="product.attribute" forcecreate="0">
-    <field name="name">age group</field>
     <field name="visibility" eval="False"/>
   </record>
 </odoo>

--- a/wine_merchant/data/product_attribute_value.xml
+++ b/wine_merchant/data/product_attribute_value.xml
@@ -2,94 +2,94 @@
 <odoo noupdate="1">
   <record id="product_attribute_value_1" model="product.attribute.value">
     <field name="name">Wine</field>
-    <field name="attribute_id" ref="website_sale.product_attribute_brand"/>
+    <field name="attribute_id" ref="product_attribute_category"/>
   </record>
   <record id="product_attribute_value_2" model="product.attribute.value">
     <field name="name">Spirits</field>
-    <field name="attribute_id" ref="website_sale.product_attribute_brand"/>
+    <field name="attribute_id" ref="product_attribute_category"/>
   </record>
   <record id="product_attribute_value_3" model="product.attribute.value">
     <field name="name">Sparkling</field>
-    <field name="attribute_id" ref="website_sale.product_attribute_brand"/>
+    <field name="attribute_id" ref="product_attribute_category"/>
   </record>
   <record id="product_attribute_value_4" model="product.attribute.value">
     <field name="name">Accessories</field>
-    <field name="attribute_id" ref="website_sale.product_attribute_brand"/>
+    <field name="attribute_id" ref="product_attribute_category"/>
   </record>
   <record id="product_attribute_value_5" model="product.attribute.value">
     <field name="name">Bordeaux</field>
-    <field name="attribute_id" ref="product_barcodelookup.product_attribute_lookup_1"/>
+    <field name="attribute_id" ref="product_attribute_region"/>
   </record>
   <record id="product_attribute_value_6" model="product.attribute.value">
     <field name="name">Languedoc</field>
-    <field name="attribute_id" ref="product_barcodelookup.product_attribute_lookup_1"/>
+    <field name="attribute_id" ref="product_attribute_region"/>
   </record>
   <record id="product_attribute_value_8" model="product.attribute.value">
     <field name="name">Provence</field>
-    <field name="attribute_id" ref="product_barcodelookup.product_attribute_lookup_1"/>
+    <field name="attribute_id" ref="product_attribute_region"/>
   </record>
   <record id="product_attribute_value_7" model="product.attribute.value">
     <field name="name">Rhône</field>
-    <field name="attribute_id" ref="product_barcodelookup.product_attribute_lookup_1"/>
+    <field name="attribute_id" ref="product_attribute_region"/>
   </record>
   <record id="product_attribute_value_9" model="product.attribute.value">
     <field name="name">2023</field>
-    <field name="attribute_id" ref="product_barcodelookup.product_attribute_lookup_2"/>
+    <field name="attribute_id" ref="product_attribute_vintage"/>
   </record>
   <record id="product_attribute_value_10" model="product.attribute.value">
     <field name="name">2024</field>
-    <field name="attribute_id" ref="product_barcodelookup.product_attribute_lookup_2"/>
+    <field name="attribute_id" ref="product_attribute_vintage"/>
   </record>
   <record id="product_attribute_value_11" model="product.attribute.value">
     <field name="name">2025</field>
-    <field name="attribute_id" ref="product_barcodelookup.product_attribute_lookup_2"/>
+    <field name="attribute_id" ref="product_attribute_vintage"/>
   </record>
   <record id="product_attribute_value_12" model="product.attribute.value">
     <field name="name">Pinot Noir, Chardonnay</field>
-    <field name="attribute_id" ref="product_barcodelookup.product_attribute_lookup_3"/>
+    <field name="attribute_id" ref="product_attribute_grape_variety"/>
   </record>
   <record id="product_attribute_value_13" model="product.attribute.value">
     <field name="name">Grenache</field>
-    <field name="attribute_id" ref="product_barcodelookup.product_attribute_lookup_3"/>
+    <field name="attribute_id" ref="product_attribute_grape_variety"/>
   </record>
   <record id="product_attribute_value_15" model="product.attribute.value">
     <field name="name">Gamay</field>
-    <field name="attribute_id" ref="product_barcodelookup.product_attribute_lookup_3"/>
+    <field name="attribute_id" ref="product_attribute_grape_variety"/>
   </record>
   <record id="product_attribute_value_14" model="product.attribute.value">
     <field name="name">Syrah</field>
-    <field name="attribute_id" ref="product_barcodelookup.product_attribute_lookup_3"/>
+    <field name="attribute_id" ref="product_attribute_grape_variety"/>
   </record>
   <record id="product_attribute_value_16" model="product.attribute.value">
     <field name="name">Celestial Vineyard</field>
-    <field name="attribute_id" ref="product_barcodelookup.product_attribute_lookup_4"/>
+    <field name="attribute_id" ref="product_attribute_vineyard"/>
   </record>
   <record id="product_attribute_value_17" model="product.attribute.value">
     <field name="name">Legendary Vineyard</field>
-    <field name="attribute_id" ref="product_barcodelookup.product_attribute_lookup_4"/>
+    <field name="attribute_id" ref="product_attribute_vineyard"/>
   </record>
   <record id="product_attribute_value_18" model="product.attribute.value">
     <field name="name">Enchanted Vines</field>
-    <field name="attribute_id" ref="product_barcodelookup.product_attribute_lookup_4"/>
+    <field name="attribute_id" ref="product_attribute_vineyard"/>
   </record>
   <record id="product_attribute_value_23" model="product.attribute.value">
     <field name="name">Mystery Chateau</field>
-    <field name="attribute_id" ref="product_barcodelookup.product_attribute_lookup_4"/>
+    <field name="attribute_id" ref="product_attribute_vineyard"/>
   </record>
   <record id="product_attribute_value_19" model="product.attribute.value">
     <field name="name">Red</field>
-    <field name="attribute_id" ref="product_barcodelookup.product_attribute_lookup_5"/>
+    <field name="attribute_id" ref="product_barcodelookup.product_attribute_lookup_1"/>
   </record>
   <record id="product_attribute_value_21" model="product.attribute.value">
     <field name="name">Rosé</field>
-    <field name="attribute_id" ref="product_barcodelookup.product_attribute_lookup_5"/>
+    <field name="attribute_id" ref="product_barcodelookup.product_attribute_lookup_1"/>
   </record>
   <record id="product_attribute_value_22" model="product.attribute.value">
     <field name="name">Orange</field>
-    <field name="attribute_id" ref="product_barcodelookup.product_attribute_lookup_5"/>
+    <field name="attribute_id" ref="product_barcodelookup.product_attribute_lookup_1"/>
   </record>
   <record id="product_attribute_value_24" model="product.attribute.value">
     <field name="name">White</field>
-    <field name="attribute_id" ref="product_barcodelookup.product_attribute_lookup_5"/>
+    <field name="attribute_id" ref="product_barcodelookup.product_attribute_lookup_1"/>
   </record>
 </odoo>

--- a/wine_merchant/data/product_template_attribute_line.xml
+++ b/wine_merchant/data/product_template_attribute_line.xml
@@ -2,132 +2,132 @@
 <odoo noupdate="1">
   <record id="product_template_attribute_line_1" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_9"/>
-    <field name="attribute_id" ref="website_sale.product_attribute_brand"/>
+    <field name="attribute_id" ref="product_attribute_category"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_1')])]"/>
   </record>
   <record id="product_template_attribute_line_7" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_10"/>
-    <field name="attribute_id" ref="website_sale.product_attribute_brand"/>
+    <field name="attribute_id" ref="product_attribute_category"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_1')])]"/>
   </record>
   <record id="product_template_attribute_line_13" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_11"/>
-    <field name="attribute_id" ref="website_sale.product_attribute_brand"/>
+    <field name="attribute_id" ref="product_attribute_category"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_1')])]"/>
   </record>
   <record id="product_template_attribute_line_19" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_12"/>
-    <field name="attribute_id" ref="website_sale.product_attribute_brand"/>
+    <field name="attribute_id" ref="product_attribute_category"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_1')])]"/>
   </record>
   <record id="product_template_attribute_line_25" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_13"/>
-    <field name="attribute_id" ref="website_sale.product_attribute_brand"/>
+    <field name="attribute_id" ref="product_attribute_category"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_2')])]"/>
   </record>
   <record id="product_template_attribute_line_6" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_9"/>
-    <field name="attribute_id" ref="product_barcodelookup.product_attribute_lookup_5"/>
+    <field name="attribute_id" ref="product_barcodelookup.product_attribute_lookup_1"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_19')])]"/>
   </record>
   <record id="product_template_attribute_line_12" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_10"/>
-    <field name="attribute_id" ref="product_barcodelookup.product_attribute_lookup_5"/>
+    <field name="attribute_id" ref="product_barcodelookup.product_attribute_lookup_1"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_24')])]"/>
   </record>
   <record id="product_template_attribute_line_18" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_11"/>
-    <field name="attribute_id" ref="product_barcodelookup.product_attribute_lookup_5"/>
+    <field name="attribute_id" ref="product_barcodelookup.product_attribute_lookup_1"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_24')])]"/>
   </record>
   <record id="product_template_attribute_line_24" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_12"/>
-    <field name="attribute_id" ref="product_barcodelookup.product_attribute_lookup_5"/>
+    <field name="attribute_id" ref="product_barcodelookup.product_attribute_lookup_1"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_19'), ref('product_attribute_value_21'), ref('product_attribute_value_24')])]"/>
   </record>
   <record id="product_template_attribute_line_2" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_9"/>
-    <field name="attribute_id" ref="product_barcodelookup.product_attribute_lookup_1"/>
+    <field name="attribute_id" ref="product_attribute_region"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_5')])]"/>
   </record>
   <record id="product_template_attribute_line_8" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_10"/>
-    <field name="attribute_id" ref="product_barcodelookup.product_attribute_lookup_1"/>
+    <field name="attribute_id" ref="product_attribute_region"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_6')])]"/>
   </record>
   <record id="product_template_attribute_line_14" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_11"/>
-    <field name="attribute_id" ref="product_barcodelookup.product_attribute_lookup_1"/>
+    <field name="attribute_id" ref="product_attribute_region"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_6')])]"/>
   </record>
   <record id="product_template_attribute_line_20" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_12"/>
-    <field name="attribute_id" ref="product_barcodelookup.product_attribute_lookup_1"/>
+    <field name="attribute_id" ref="product_attribute_region"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_6')])]"/>
   </record>
   <record id="product_template_attribute_line_3" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_9"/>
-    <field name="attribute_id" ref="product_barcodelookup.product_attribute_lookup_2"/>
+    <field name="attribute_id" ref="product_attribute_vintage"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_9')])]"/>
   </record>
   <record id="product_template_attribute_line_9" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_10"/>
-    <field name="attribute_id" ref="product_barcodelookup.product_attribute_lookup_2"/>
+    <field name="attribute_id" ref="product_attribute_vintage"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_9')])]"/>
   </record>
   <record id="product_template_attribute_line_15" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_11"/>
-    <field name="attribute_id" ref="product_barcodelookup.product_attribute_lookup_2"/>
+    <field name="attribute_id" ref="product_attribute_vintage"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_10')])]"/>
   </record>
   <record id="product_template_attribute_line_21" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_12"/>
-    <field name="attribute_id" ref="product_barcodelookup.product_attribute_lookup_2"/>
+    <field name="attribute_id" ref="product_attribute_vintage"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_10')])]"/>
   </record>
   <record id="product_template_attribute_line_27" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_13"/>
-    <field name="attribute_id" ref="product_barcodelookup.product_attribute_lookup_2"/>
+    <field name="attribute_id" ref="product_attribute_vintage"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_10')])]"/>
   </record>
   <record id="product_template_attribute_line_4" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_9"/>
-    <field name="attribute_id" ref="product_barcodelookup.product_attribute_lookup_3"/>
+    <field name="attribute_id" ref="product_attribute_grape_variety"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_13')])]"/>
   </record>
   <record id="product_template_attribute_line_10" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_10"/>
-    <field name="attribute_id" ref="product_barcodelookup.product_attribute_lookup_3"/>
+    <field name="attribute_id" ref="product_attribute_grape_variety"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_14')])]"/>
   </record>
   <record id="product_template_attribute_line_16" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_11"/>
-    <field name="attribute_id" ref="product_barcodelookup.product_attribute_lookup_3"/>
+    <field name="attribute_id" ref="product_attribute_grape_variety"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_14')])]"/>
   </record>
   <record id="product_template_attribute_line_22" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_12"/>
-    <field name="attribute_id" ref="product_barcodelookup.product_attribute_lookup_3"/>
+    <field name="attribute_id" ref="product_attribute_grape_variety"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_14')])]"/>
   </record>
   <record id="product_template_attribute_line_5" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_9"/>
-    <field name="attribute_id" ref="product_barcodelookup.product_attribute_lookup_4"/>
+    <field name="attribute_id" ref="product_attribute_vineyard"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_16')])]"/>
   </record>
   <record id="product_template_attribute_line_11" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_10"/>
-    <field name="attribute_id" ref="product_barcodelookup.product_attribute_lookup_4"/>
+    <field name="attribute_id" ref="product_attribute_vineyard"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_17')])]"/>
   </record>
   <record id="product_template_attribute_line_17" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_11"/>
-    <field name="attribute_id" ref="product_barcodelookup.product_attribute_lookup_4"/>
+    <field name="attribute_id" ref="product_attribute_vineyard"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_18')])]"/>
   </record>
   <record id="product_template_attribute_line_23" model="product.template.attribute.line" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
     <field name="product_tmpl_id" ref="product_template_12"/>
-    <field name="attribute_id" ref="product_barcodelookup.product_attribute_lookup_4"/>
+    <field name="attribute_id" ref="product_attribute_vineyard"/>
     <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_23')])]"/>
   </record>
 </odoo>


### PR DESCRIPTION
[FIX] real_estate: create ribbons to avoid translations issues

Before this commit, the standard ecommerce ribbons were renamed in the
industry module. While this works fine in English, the translation
mechanism will only search for translated terms from the standard
module. In such a case, the industry term and the translated ones can
have very different meanings.

This commit creates new ribbons instead, and unlinks standard ones (only
if they are not linked to any product yet).

[FIX] wine_merchant: new attribute, no renaming of standard records

Before this commit, the standard product attributes were renamed in the
industry module. While this works fine in English, the translation
mechanism will only search for translated terms from the standard
module. In such a case, the industry term and the translated ones can
have very different meanings.

This commit creates new attributes instead.

task-6003598