### PR TITLE
[IMP] real_estate: add matchmaking email settings and improve visits navigation

### DIFF
--- a/real_estate/__manifest__.py
+++ b/real_estate/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Real Estate Agency',
-    'version': '1.10',
+    'version': '1.11',
     'category': 'Services',
     'author': 'Odoo S.A.',
     'depends': [
@@ -21,7 +21,6 @@
         'website_sale',
     ],
     'data': [
-        'data/res_config_settings.xml',
         'data/ir_model.xml',
         'data/website_base_unit.xml',
         'data/ir_model_fields.xml',
@@ -44,6 +43,7 @@
         'data/ir_ui_menu.xml',
         'data/ir_model_access.xml',
         'data/ir_default.xml',
+        'data/res_config_settings.xml',
         'data/crm_stage.xml',
         'data/project_task_type.xml',
         'data/project_project.xml',

--- a/real_estate/data/ir_actions_act_window.xml
+++ b/real_estate/data/ir_actions_act_window.xml
@@ -66,16 +66,21 @@
         <field name="domain">[('x_property_id', '=', active_id)]</field>
         <field name="res_model">calendar.event</field>
     </record>
-    <record id="visits_appointment_act_window" model="ir.actions.act_window">
-        <field name="name">Visits</field>
-        <field name="res_model">appointment.type</field>
-        <field name="view_mode">calendar,kanban,list,form</field>
-        <field name="domain">[("x_property_id", "!=", False)]</field>
+    <record id="staff_bookings_act_window" model="ir.actions.act_window">
+        <field name="name">Staff Bookings</field>
+        <field name="res_model">calendar.event</field>
+        <field name="view_mode">calendar,gantt,list,activity</field>
+        <field name="view_id" ref="appointment.calendar_event_view_calendar"/>
     </record>
     <record id="attributes_act_window" model="ir.actions.act_window">
         <field name="name">Attributes</field>
         <field name="res_model">product.attribute</field>
         <field name="view_mode">list,form</field>
+    </record>
+    <record id="settings_act_window" model="ir.actions.act_window">
+        <field name="name">Settings</field>
+        <field name="res_model">res.config.settings</field>
+        <field name="view_mode">form</field>
     </record>
     <record id="crm_lead_sign_request_action" model="ir.actions.act_window">
         <field name="name">Documents</field>

--- a/real_estate/data/ir_actions_server.xml
+++ b/real_estate/data/ir_actions_server.xml
@@ -36,8 +36,9 @@
         <field name="state">code</field>
         <field name="usage">ir_cron</field>
         <field name="code"><![CDATA[
+template = env.company.x_matchmaking_email_template_id
 for contact in model.search([('x_subscribe', '=', True), ('x_to_notify_property_ids', '!=', False)]):
-    if env.ref('real_estate.mail_template_42').send_mail(res_id=contact.id):
+    if template and template.send_mail(res_id=contact.id):
         contact['x_last_notification'] = datetime.datetime.now()
     ]]></field>
     </record>
@@ -144,7 +145,8 @@ if env.context.get('from_form_view') and len(records) == 1:
         <field name="binding_model_id" ref="base.model_res_partner"/>
         <field name="state">code</field>
         <field name="code"><![CDATA[
-if env.ref('real_estate.mail_template_42').send_mail(res_id=record.id):
+template = env.company.x_matchmaking_email_template_id
+if template and template.send_mail(res_id=record.id):
     record['x_last_notification'] = datetime.datetime.now()
         ]]></field>
     </record>

--- a/real_estate/data/ir_default.xml
+++ b/real_estate/data/ir_default.xml
@@ -24,4 +24,8 @@
         <field name="field_id" ref="x_is_matchmaking_field_product_attribute"/>
         <field name="json_value">true</field>
     </record>
+    <record id="ir_default_x_matchmaking_email_template_id" model="ir.default">
+        <field name="field_id" ref="field_res_company_x_matchmaking_email_template_id"/>
+        <field name="json_value" eval="ref('mail_template_42')"/>
+    </record>
 </odoo>

--- a/real_estate/data/ir_model_fields.xml
+++ b/real_estate/data/ir_model_fields.xml
@@ -606,4 +606,20 @@ for request in self:    request['x_property_id'] = request.x_crm_lead_id.x_inter
 for property in self:   property['x_sign_request_count'] = property.env['sign.request'].search_count([('x_property_id', '=', property.id)])
         ]]></field>
     </record>
+    <record id="field_res_company_x_matchmaking_email_template_id" model="ir.model.fields">
+        <field name="name">x_matchmaking_email_template_id</field>
+        <field name="field_description">Match Making Email</field>
+        <field name="ttype">many2one</field>
+        <field name="relation">mail.template</field>
+        <field name="model_id" ref="base.model_res_company"/>
+    </record>
+    <record id="field_res_config_settings_x_matchmaking_email_template_id" model="ir.model.fields">
+        <field name="field_description">Match Making Email</field>
+        <field name="name">x_matchmaking_email_template_id</field>
+        <field name="ttype">many2one</field>
+        <field name="relation">mail.template</field>
+        <field name="model_id" ref="base.model_res_config_settings"/>
+        <field name="related">company_id.x_matchmaking_email_template_id</field>
+        <field name="store" eval="False"/>
+    </record>
 </odoo>

--- a/real_estate/data/ir_ui_menu.xml
+++ b/real_estate/data/ir_ui_menu.xml
@@ -7,9 +7,10 @@
         <menuitem id="properties_properties_menu" name="Properties" action="properties_act_window" sequence="1"/>
         <menuitem id="properties_map_menu" name="Map" action="map_act_window" sequence="2"/>
         <menuitem id="properties_buyers_menu" name="Buyers" action="opportunities_act_window" sequence="3"/>
-        <menuitem id="properties_visits_menu" name="Visits" action="visits_appointment_act_window" sequence="4"/>
+        <menuitem id="properties_visits_menu" name="Visits" action="staff_bookings_act_window" sequence="4"/>
         <menuitem id="properties_reporting_menu" name="Reporting" action="reporting_act_window" sequence="5"/>
         <menuitem id="properties_configuration_menu" name="Configuration" sequence="6">
+            <menuitem id="properties_settings_menu" name="Settings" action="settings_act_window"/>
             <menuitem id="properties_attributes_menu" name="Attributes" action="attributes_act_window"/>
         </menuitem>
     </menuitem>

--- a/real_estate/data/ir_ui_view.xml
+++ b/real_estate/data/ir_ui_view.xml
@@ -449,24 +449,6 @@
         (0, 0, {'view_mode': 'graph', 'view_id': ref('crm_opportunity_view_graph')}),
     ]"/>
   </record>
-  <record id="calendar_view_for_appointment_type" model="ir.ui.view">
-      <field name="name">calendar view for appointment.type</field>
-      <field name="model">appointment.type</field>
-      <field name="active" eval="True"/>
-      <field name="arch" type="xml">
-        <calendar date_start="start_datetime" date_stop="end_datetime" string="Calendar"/>
-      </field>
-  </record>
-  <record id="visits_appointment_act_window" model="ir.actions.act_window">
-    <field name="name">Visits</field>
-    <field name="res_model">appointment.type</field>
-    <field name="view_mode">calendar,kanban,list,form</field>
-    <field name="domain">[("x_property_id", "!=", False)]</field>
-    <field name="view_ids" eval="[
-        (5, 0, 0),
-        (0, 0, {'view_mode': 'calendar', 'view_id': ref('calendar_view_for_appointment_type')}),
-    ]"/>
-  </record>
   <record id="product_attribute_form_view_extended" model="ir.ui.view">
     <field name="name">product.attribute.form.inherit.real_estate</field>
     <field name="inherit_id" ref="product.product_attribute_view_form"/>
@@ -488,7 +470,25 @@
     <field name="active" eval="True"/>
     <field name="arch" type="xml">
         <xpath expr="//field[@name='default_code']" position="after">
-            <field name="x_agent_id" optional="hide"/>
+          <field name="x_agent_id" optional="hide"/>
+        </xpath>
+    </field>
+  </record>  
+  <record id="res_config_settings_form_view_inherited_real_estate" model="ir.ui.view">
+    <field name="name">res.config.settings.form.view.inherited.real.estate</field>
+    <field name="model">res.config.settings</field>
+    <field name="priority" eval="2"/>
+    <field name="active" eval="True"/>
+    <field name="inherit_id" ref="base.res_config_settings_view_form"/>
+    <field name="arch" type="xml">
+        <xpath expr="//form" position="inside">
+            <app string="Properties" name="properties" logo="/real_estate/static/description/icon.png">
+                <block title="Emails" name="real_estate_email_block">
+                    <setting id="real_estate_matchmaking_email_setting" help="Select the email template used for sending property matches to contacts.">
+                        <field name="x_matchmaking_email_template_id" required="1"/>
+                    </setting>
+                </block>
+            </app>
         </xpath>
     </field>
   </record>

--- a/real_estate/data/mail_template.xml
+++ b/real_estate/data/mail_template.xml
@@ -707,5 +707,6 @@
     <field name="model_id" ref="base.model_res_partner"/>
     <field name="name">New matches notification</field>
     <field name="subject">New properties matching your criteria</field>
+    <field name="description">Email used to send property matches to the contact.</field>
   </record>
 </odoo>

--- a/real_estate/data/res_config_settings.xml
+++ b/real_estate/data/res_config_settings.xml
@@ -4,6 +4,7 @@
         <field name="group_product_variant" eval="True"/>
         <field name="group_product_pricelist" eval="True"/>
         <field name="group_show_uom_price" eval="True"/>
+        <field name="x_matchmaking_email_template_id" ref="mail_template_42"/>
     </record>
     <function model="res.config.settings" name="execute">
         <value eval="[ref('res_config_settings_enable_real_estate')]"/>


### PR DESCRIPTION
Settings Configuration
- Add a dedicated Properties section in Settings.
- Add a mandatory Match Making Email setting under the Properties configuration.
- Configure a default matchmaking email template.

Email Template Update
- Add a description to the matchmaking email template.

Visits Navigation Update
- Update the Visits menu to open the Appointment Staff Schedule view by default.

Task ID-6245650