### PR TITLE
[FIX] real_estate: fix automation to link mail reference to properties

### DIFF
--- a/real_estate/__manifest__.py
+++ b/real_estate/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Real Estate Agency',
-    'version': '1.4',
+    'version': '1.5',
     'category': 'Services',
     'author': 'Odoo S.A.',
     'depends': [

--- a/real_estate/data/base_automation.xml
+++ b/real_estate/data/base_automation.xml
@@ -46,8 +46,8 @@
         <field name="model_id" ref="crm.model_crm_lead"/>
         <field name="action_server_ids" eval="[(6, 0, [ref('search_for_property_reference_server_action')])]"/>
         <field name="trigger">on_message_received</field>
-        <field name="filter_domain">[("x_interested_in_id", "=", False), ("has_message", "=", True)]</field>
-        <field name="filter_pre_domain">[("x_interested_in_id", "=", False), ("has_message", "=", False)]</field>
+        <field name="filter_domain">[("x_interested_in_id", "=", False)]</field>
+        <field name="filter_pre_domain">[("x_interested_in_id", "=", False)]</field>
     </record>
     <record id="base_automation_15" model="base.automation">
         <field name="name">Commission Plan</field>

--- a/real_estate/data/ir_actions_server.xml
+++ b/real_estate/data/ir_actions_server.xml
@@ -74,7 +74,16 @@ for product in records: product['x_last_notification_update'] = datetime.datetim
         <field name="state">code</field>
         <field name="usage">base_automation</field>
         <field name="code"><![CDATA[
-for record in records: record["x_interested_in_id"] = (env['product.template'].search([('x_is_properties', '=', True), ('x_reference_ids', 'any', ['|', '|', ('x_name', 'in', record.message_ids[0].body), ('x_name', 'in', record.message_ids[0].subject), ('x_name', 'in', record.message_ids[0].email_from)])], limit=1) or env['product.template']).id
+messages = env['mail.message'].search_fetch(domain=[('res_id', 'in', records.ids), ('model', '=', 'crm.lead'), ('message_type', '=', 'email')], field_names=['body', 'subject', 'res_id'], order='id asc')
+#id asc so that highest id is kept in the dict
+message_data = {message.res_id: (message.body or '') + (message.subject or '') for message in messages}
+
+reference_ids = env['x_product_template_line'].search_fetch(domain=[('x_product_template_id.active', '=', True)], field_names=['x_name', 'x_product_template_id'])
+for record in records:
+    for reference in reference_ids:
+        if not reference.x_name or reference.x_name not in message_data.get(record.id, ''): continue
+        record["x_interested_in_id"] = reference.x_product_template_id
+        break
         ]]></field>
     </record>
 


### PR DESCRIPTION
Before this commit, this automation was not working for several reasons. The first and major one is that the domain on references was the inverse of the expected behaviour: it looks for the content or subject of the email to be contained in one of the reference. The second issue is that has_message was not False when a lead is created, and therefore this automation was never triggered.

This commit fixes both issues by editing the domain triggering the action and by looking at the db level for the reference that could be included in the email.

opw-6272644