### PR TITLE
[IMP] food_distribution: improve demo data and proportion formatting

### DIFF
--- a/food_distribution/__manifest__.py
+++ b/food_distribution/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Food Distribution',
-    'version': '1.2',
+    'version': '1.3',
     'category': 'Supply Chain',
     'author': 'Odoo S.A.',
     'depends': [

--- a/food_distribution/data/ir_model_fields.xml
+++ b/food_distribution/data/ir_model_fields.xml
@@ -116,8 +116,8 @@
     <field name="model_id" ref="model_x_product_template_ingredients"/>
     <field name="name">x_sequence</field>
   </record>
-  <record id="field_x_product_template_ingredients_share" model="ir.model.fields">
-    <field name="ttype">integer</field>
+  <record id="field_x_product_template_ingredients_proportion" model="ir.model.fields">
+    <field name="ttype">float</field>
     <field name="field_description">Proportion (%)</field>
     <field name="model_id" ref="model_x_product_template_ingredients"/>
     <field name="name">x_share</field>

--- a/food_distribution/data/product_template.xml
+++ b/food_distribution/data/product_template.xml
@@ -166,6 +166,18 @@ REFRIGERATE AFTER OPENING. DO NOT FREEZE.]]></field>
         (0, 0, {'x_nutritional_fact_id': ref('x_nutritional_facts_10'), 'x_per_100g': 1.5}),
     ]"/>
   </record>
+  <record id="product_template_16" model="product.template" context="{'create_product_product': False}">
+    <field name="name">Potatoes</field>
+    <field name="sale_ok" eval="False"/>
+    <field name="categ_id" ref="product_category_4"/>
+    <field name="is_storable" eval="True"/>
+    <field name="tracking">lot</field>
+    <field name="uom_id" ref="uom.product_uom_kgm"/>
+    <field name="purchase_method">receive</field>
+    <field name="service_type">manual</field>
+    <field name="invoice_policy">order</field>
+    <field name="service_policy">ordered_prepaid</field>
+  </record>
   <record id="product_template_14" model="product.template" context="{'create_product_product': False}">
     <field name="image_1920" type="base64" file="food_distribution/static/src/binary/product_template/14-image_1920"/>
     <field name="name">Fresh Potato Salad 250g</field>
@@ -189,6 +201,27 @@ REFRIGERATE AFTER OPENING. DO NOT FREEZE.]]></field>
     <field name="invoice_policy">order</field>
     <field name="service_policy">ordered_prepaid</field>
     <field name="route_ids" eval="[(6, 0, [ref('stock.route_warehouse0_mto')])]"/>
+    <field name="x_label_note"><![CDATA[May contain traces of NUTS.
+KEEP REFRIGERATED (0-4°C). ONCE OPENED, CONSUME WITHIN 24 TO 48 HOURS.]]></field>
+    <field name="x_is_allergen" eval="True"/>
+    <field name="x_ingredient_ids" eval="[
+        (0, 0, {'x_ingredient_id': ref('product_template_16'), 'x_share': 95.0}),
+        (0, 0, {'x_ingredient_id': ref('product_template_2'), 'x_share': 4.0}),
+        (0, 0, {'x_ingredient_id': ref('product_template_4'), 'x_share': 0.0}),
+        (0, 0, {'x_ingredient_id': ref('product_template_8'), 'x_share': 0.0}),
+        (0, 0, {'x_ingredient_id': ref('product_template_5'), 'x_share': 0.0}),
+        (0, 0, {'x_ingredient_id': ref('product_template_6'), 'x_share': 0.0}),
+        (0, 0, {'x_ingredient_id': ref('product_template_7'), 'x_share': 0.0}),
+    ]"/>
+    <field name="x_nutritional_fact_ids" eval="[
+        (0, 0, {'x_nutritional_fact_id': ref('x_nutritional_facts_1'), 'x_per_100g': 119.0}),
+        (0, 0, {'x_nutritional_fact_id': ref('x_nutritional_facts_2'), 'x_per_100g': 1.90}),
+        (0, 0, {'x_nutritional_fact_id': ref('x_nutritional_facts_7'), 'x_per_100g': 0.40}),
+        (0, 0, {'x_nutritional_fact_id': ref('x_nutritional_facts_3'), 'x_per_100g': 19.10}),
+        (0, 0, {'x_nutritional_fact_id': ref('x_nutritional_facts_6'), 'x_per_100g': 4.10}),
+        (0, 0, {'x_nutritional_fact_id': ref('x_nutritional_facts_4'), 'x_per_100g': 0.10}),
+        (0, 0, {'x_nutritional_fact_id': ref('x_nutritional_facts_10'), 'x_per_100g': 0.20}),
+    ]"/>
   </record>
   <record id="product_template_15" model="product.template" context="{'create_product_product': False}">
     <field name="image_1920" type="base64" file="food_distribution/static/src/binary/product_template/15-image_1920"/>
@@ -196,18 +229,6 @@ REFRIGERATE AFTER OPENING. DO NOT FREEZE.]]></field>
     <field name="categ_id" ref="product_category_6"/>
     <field name="standard_price">0.2</field>
     <field name="is_storable" eval="True"/>
-    <field name="purchase_method">receive</field>
-    <field name="service_type">manual</field>
-    <field name="invoice_policy">order</field>
-    <field name="service_policy">ordered_prepaid</field>
-  </record>
-  <record id="product_template_16" model="product.template" context="{'create_product_product': False}">
-    <field name="name">Raw Potatoes</field>
-    <field name="sale_ok" eval="False"/>
-    <field name="categ_id" ref="product_category_4"/>
-    <field name="is_storable" eval="True"/>
-    <field name="tracking">lot</field>
-    <field name="uom_id" ref="uom.product_uom_kgm"/>
     <field name="purchase_method">receive</field>
     <field name="service_type">manual</field>
     <field name="invoice_policy">order</field>

--- a/food_distribution/data/quality_point.xml
+++ b/food_distribution/data/quality_point.xml
@@ -6,6 +6,7 @@
     <field name="product_ids" eval="[(6, 0, [ref('product_product_12')])]"/>
     <field name="test_type_id" ref="mrp_workorder.test_type_register_consumed_materials"/>
     <field name="component_id" ref="product_product_3"/>
+    <field name="picking_type_ids" model="stock.warehouse" eval="[(4, obj().env.ref('stock.warehouse0').manu_type_id.id)]"/>
     <field name="operation_id" ref="mrp_routing_workcenter_3"/>
   </record>
   <record id="quality_point_17" model="quality.point">
@@ -14,6 +15,7 @@
     <field name="product_ids" eval="[(6, 0, [ref('product_product_13')])]"/>
     <field name="test_type_id" ref="mrp_workorder.test_type_register_consumed_materials"/>
     <field name="component_id" ref="product_product_3"/>
+    <field name="picking_type_ids" model="stock.warehouse" eval="[(4, obj().env.ref('stock.warehouse0').manu_type_id.id)]"/>
     <field name="operation_id" ref="mrp_routing_workcenter_4"/>
   </record>
   <record id="quality_point_4" model="quality.point">
@@ -22,6 +24,7 @@
     <field name="product_ids" eval="[(6, 0, [ref('product_product_3')])]"/>
     <field name="test_type_id" ref="mrp_workorder.test_type_register_consumed_materials"/>
     <field name="component_id" ref="product_product_8"/>
+    <field name="picking_type_ids" model="stock.warehouse" eval="[(4, obj().env.ref('stock.warehouse0').manu_type_id.id)]"/>
     <field name="operation_id" ref="mrp_routing_workcenter_1"/>
   </record>
   <record id="quality_point_5" model="quality.point">
@@ -30,6 +33,7 @@
     <field name="product_ids" eval="[(6, 0, [ref('product_product_3')])]"/>
     <field name="test_type_id" ref="mrp_workorder.test_type_register_consumed_materials"/>
     <field name="component_id" ref="product_product_4"/>
+    <field name="picking_type_ids" model="stock.warehouse" eval="[(4, obj().env.ref('stock.warehouse0').manu_type_id.id)]"/>
     <field name="operation_id" ref="mrp_routing_workcenter_1"/>
   </record>
   <record id="quality_point_6" model="quality.point">
@@ -38,6 +42,7 @@
     <field name="product_ids" eval="[(6, 0, [ref('product_product_3')])]"/>
     <field name="test_type_id" ref="mrp_workorder.test_type_register_consumed_materials"/>
     <field name="component_id" ref="product_product_5"/>
+    <field name="picking_type_ids" model="stock.warehouse" eval="[(4, obj().env.ref('stock.warehouse0').manu_type_id.id)]"/>
     <field name="operation_id" ref="mrp_routing_workcenter_1"/>
   </record>
   <record id="quality_point_7" model="quality.point">
@@ -46,6 +51,7 @@
     <field name="product_ids" eval="[(6, 0, [ref('product_product_3')])]"/>
     <field name="test_type_id" ref="mrp_workorder.test_type_register_consumed_materials"/>
     <field name="component_id" ref="product_product_7"/>
+    <field name="picking_type_ids" model="stock.warehouse" eval="[(4, obj().env.ref('stock.warehouse0').manu_type_id.id)]"/>
     <field name="operation_id" ref="mrp_routing_workcenter_1"/>
   </record>
   <record id="quality_point_8" model="quality.point">
@@ -54,6 +60,7 @@
     <field name="product_ids" eval="[(6, 0, [ref('product_product_3')])]"/>
     <field name="test_type_id" ref="mrp_workorder.test_type_register_consumed_materials"/>
     <field name="component_id" ref="product_product_6"/>
+    <field name="picking_type_ids" model="stock.warehouse" eval="[(4, obj().env.ref('stock.warehouse0').manu_type_id.id)]"/>
     <field name="operation_id" ref="mrp_routing_workcenter_1"/>
   </record>
   <record id="quality_point_3" model="quality.point">
@@ -63,6 +70,7 @@
     <field name="test_type_id" ref="mrp_workorder.test_type_register_consumed_materials"/>
     <field name="note"><![CDATA[<div>Gradually add the oil in the tank while mixing.</div>]]></field>
     <field name="component_id" ref="product_product_2"/>
+    <field name="picking_type_ids" model="stock.warehouse" eval="[(4, obj().env.ref('stock.warehouse0').manu_type_id.id)]"/>
     <field name="operation_id" ref="mrp_routing_workcenter_1"/>
   </record>
   <record id="quality_point_9" model="quality.point">
@@ -71,6 +79,7 @@
     <field name="product_ids" eval="[(6, 0, [ref('product_product_3')])]"/>
     <field name="test_type_id" ref="quality.test_type_instructions"/>
     <field name="note"><![CDATA[<div>Mix for 5 minutes.</div>]]></field>
+    <field name="picking_type_ids" model="stock.warehouse" eval="[(4, obj().env.ref('stock.warehouse0').manu_type_id.id)]"/>
     <field name="operation_id" ref="mrp_routing_workcenter_1"/>
   </record>
   <record id="quality_point_1" model="quality.point">
@@ -84,6 +93,7 @@
     <field name="tolerance_min">3.6</field>
     <field name="tolerance_max">4.0</field>
     <field name="norm_unit">-</field>
+    <field name="picking_type_ids" model="stock.warehouse" eval="[(4, obj().env.ref('stock.warehouse0').manu_type_id.id)]"/>
     <field name="operation_id" ref="mrp_routing_workcenter_1"/>
   </record>
   <record id="quality_point_12" model="quality.point">
@@ -91,6 +101,7 @@
     <field name="title">Add Lot</field>
     <field name="product_ids" eval="[(6, 0, [ref('product_product_12')])]"/>
     <field name="test_type_id" ref="mrp_workorder.test_type_register_production"/>
+    <field name="picking_type_ids" model="stock.warehouse" eval="[(4, obj().env.ref('stock.warehouse0').manu_type_id.id)]"/>
     <field name="operation_id" ref="mrp_routing_workcenter_3"/>
   </record>
   <record id="quality_point_13" model="quality.point">
@@ -98,6 +109,7 @@
     <field name="title">Add Lot</field>
     <field name="product_ids" eval="[(6, 0, [ref('product_product_13')])]"/>
     <field name="test_type_id" ref="mrp_workorder.test_type_register_production"/>
+    <field name="picking_type_ids" model="stock.warehouse" eval="[(4, obj().env.ref('stock.warehouse0').manu_type_id.id)]"/>
     <field name="operation_id" ref="mrp_routing_workcenter_4"/>
   </record>
   <record id="quality_point_14" model="quality.point">
@@ -111,6 +123,7 @@
     <field name="tolerance_max">75.0</field>
     <field name="norm_unit">°C</field>
     <field name="operation_id" ref="mrp_routing_workcenter_1"/>
+    <field name="picking_type_ids" model="stock.warehouse" eval="[(4, obj().env.ref('stock.warehouse0').manu_type_id.id)]"/>
   </record>
   <record id="quality_point_15" model="quality.point">
     <field name="name">QCP00015</field>
@@ -118,6 +131,7 @@
     <field name="product_ids" eval="[(6, 0, [ref('product_product_3')])]"/>
     <field name="test_type_id" ref="mrp_workorder.test_type_register_production"/>
     <field name="operation_id" ref="mrp_routing_workcenter_1"/>
+    <field name="picking_type_ids" model="stock.warehouse" eval="[(4, obj().env.ref('stock.warehouse0').manu_type_id.id)]"/>
   </record>
   <record id="quality_point_18" model="quality.point">
     <field name="title">Print Label</field>
@@ -137,7 +151,7 @@
   </record>
   <record id="quality_point_20" model="quality.point">
     <field name="name">QCP00001</field>
-    <field name="title">Ingredient: Raw Potatoes</field>
+    <field name="title">Ingredient: Potatoes</field>
     <field name="product_ids" eval="[(6, 0, [ref('product_product_14')])]"/>
     <field name="operation_id" ref="mrp_routing_workcenter_5"/>
     <field name="picking_type_ids" model="stock.warehouse" eval="[(4, obj().env.ref('stock.warehouse0').manu_type_id.id)]"/>

--- a/food_distribution/data/qweb_view.xml
+++ b/food_distribution/data/qweb_view.xml
@@ -48,7 +48,7 @@
                                                     <div style="font-size: 8px;" name="ingredients_list">
                                                         <strong>Ingredients: </strong>
                                                         <t t-foreach="o.product_id.x_ingredient_ids" t-as="line"><span t-out="line.x_ingredient_id.name.upper() if line.x_ingredient_id.x_is_allergen else line.x_ingredient_id.name"/>
-                                                            <span t-out="'(' + str(line.x_share) + '%)' if line.x_share &gt; 0 else ''"/><t t-if="not line_last">, </t>
+                                                            <span t-out="'(' + ('%.1f' % line.x_share) + '%)' if line.x_share &gt; 0 else ''"/><t t-if="not line_last">, </t>
                                                         </t>
                                                     </div>
                                                     <strong>


### PR DESCRIPTION
Changes
- Rename the demo product "Raw Potatoes" to "Potatoes".
- Update the demo food label data.
- Display ingredient proportions with one decimal place in the label report for a cleaner layout.
- Add the Manufacturing operation to BoM instruction Quality Control Points.

TaskId-6221680