### PR TITLE
[FIX] excise_management: prevent reporter value from being reset to default

### DIFF
--- a/excise_management/__manifest__.py
+++ b/excise_management/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Excise Management',
-    'version': '2.7',
+    'version': '2.8',
     'category': 'Inventory/Inventory',
     'author': 'Odoo S.A.',
     'depends': [

--- a/excise_management/data/ir_default.xml
+++ b/excise_management/data/ir_default.xml
@@ -16,8 +16,8 @@
         <field name="field_id" ref="state_excise_report"/>
         <field name="json_value">"progress"</field>
     </record>
-    <record id="default_res_config_reporter" model="ir.default">
-        <field name="field_id" ref="res_config_reporter"/>
+    <record id="default_res_company_reporter" model="ir.default">
+        <field name="field_id" ref="res_company_reporter"/>
         <field name="json_value" eval="ref('base.user_admin')"/>
     </record>
     <record id="default_excise_category_currency_id" model="ir.default">

--- a/excise_management/data/ir_ui_view.xml
+++ b/excise_management/data/ir_ui_view.xml
@@ -292,7 +292,7 @@
                     <setting>
                         <div title="Designated contact receiving weekly report activity">
                             <label for="x_reporter_id"/>
-                            <field name="x_reporter_id" class="text-center" company_dependent="1"/>
+                            <field name="x_reporter_id" class="text-center" company_dependent="1" domain="[('share', '=', False)]"/>
                         </div>
                         <div class="text-muted">
                             Designated contact receiving weekly report activity

--- a/excise_management/data/res_config_setting.xml
+++ b/excise_management/data/res_config_setting.xml
@@ -2,6 +2,7 @@
 <odoo noupdate="1">
     <record id="res_config_settings_enable" model="res.config.settings">
         <field name="group_uom" eval="1"/>
+        <field name="x_reporter_id" eval="ref('base.user_admin')"/>
     </record>
     <function model="res.config.settings" name="execute" eval="[ref('res_config_settings_enable')]"/>
 </odoo>


### PR DESCRIPTION
Currently, the Reporter setting is reset to Administrator after saving the 
Inventory settings.

Step to reproduce:
* Go to Inventory → Configuration → Settings.
* Change the Reporter field to another user.
* Save the settings.

Cause:
The Reporter field relies on an `ir.default` record to provide its default value.
However, the corresponding `ir.default` entry was not associated with a specific
company. As a result, when the settings were saved, Odoo reapplied the global
default value stored in `ir.default`, overriding the user-selected Reporter and
resetting the field to Administrator.

Solution:
Add the `res_company` model's field to the corresponding `ir.default` record so that 
the default value is applied in the correct company context and does not overwrite
the Reporter value saved by the user.


Task ID:6283344