### PR TITLE
[FIX] booking_engine: add res_config to CLoC exclude

### DIFF
--- a/booking_engine/__manifest__.py
+++ b/booking_engine/__manifest__.py
@@ -57,6 +57,7 @@
     },
     'license': 'OEEL-1',
     'cloc_exclude': [
+        'data/res_config_settings.xml',
         'data/website_view.xml',
         'static/src/scss/gantt.scss',
     ],


### PR DESCRIPTION
Before this commit, Any db with `booking_engine` installed would have the settings functions counted towards the CLoC of the db. The problem is that these settings allow users to enable/disable the housekeeping features, So users could be billed additional money for features they are not using. This commit fixes that by adding the `res_config_settings.xml` file into the CLoC exclude to preven these settings from being included into user billings.

task-6224889