### PR TITLE
[FIX] booking_engine: prevent Owl error in hotel planning kanban

### DIFF
--- a/booking_engine/__manifest__.py
+++ b/booking_engine/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Booking Engine',
-    'version': '1.18',
+    'version': '1.19',
     'category': 'Hidden/Tools',
     'author': 'Odoo S.A.',
     'depends': [

--- a/booking_engine/data/ir_ui_view.xml
+++ b/booking_engine/data/ir_ui_view.xml
@@ -250,6 +250,7 @@
     <field name="active" eval="True"/>
     <field name="arch" type="xml">
       <xpath expr="//field[@name='sale_line_id']" position="replace"/>
+      <xpath expr="//div[@name='sale']" position="replace"/>
       <xpath expr="//footer/div" position="before">
         <field name="sale_order_id" widget="many2one" context="{'form_view_ref': 'booking_engine.rental_order_view', 'in_rental_app': 1}"/>
       </xpath>


### PR DESCRIPTION
**Steps to Reproduce:**
1. Go to Apps → Industry → Install Hotel (load demo data).
2. Open Hotel App.
3. Switch to the Kanban view.

**Result:**
<img width="978" height="710" alt="image" src="https://github.com/user-attachments/assets/247cc2a3-ac8f-4672-9dd2-2c96e0ce999b" />

**Cause of the Issue:**

- The sale_planning module adds the [`sale_line_id`](https://github.com/odoo/enterprise/blob/saas-19.2/sale_planning/views/planning_slot_views.xml#L143) field.

- Then, the booking_engine module removes the [`sale_line_id`](https://github.com/odoo/industry/blob/19.0/booking_engine/data/ir_ui_view.xml#L258) field from the kanban field declarations.

- However, the [`sale section`](https://github.com/odoo/enterprise/blob/saas-19.2/sale_planning/views/planning_slot_views.xml#L146) remains in the final template and still references: `record.sale_line_id.raw_value`

**As a result:**
Since `sale_line_id` is no longer loaded in the kanban record payload, the template attempts to access `record.sale_line_id.raw_value` on an undefined value, resulting in an OwlError.

**With this commit:**
Remove the corresponding sale section when removing `sale_line_id`. This keeps the kanban template consistent with the loaded fields and prevents the OwlError.

opw-6261815