### PR TITLE
[CLN] test_industry: remove module.demo defined at install

### DIFF
--- a/tests/test_industry/cli/test_industry.py
+++ b/tests/test_industry/cli/test_industry.py
@@ -93,10 +93,8 @@ class Test_Industry(Command):
                         env = api.Environment(cr, api.SUPERUSER_ID, {})
                         with_demo = res.industry_demo
                         _logger.info('Loading module %s into database %s %s', industry_module, target_db, with_demo and 'with demo data' or '')
-                        existing_module = env['ir.module.module'].search([])
                         zip_content = utils.IndustryUtils().get_zip(industry_module)
                         env['ir.module.module']._import_zipfile(zip_content, force=False, with_demo=with_demo)
-                        env['ir.module.module'].search([('id', 'not in', existing_module.ids)]).demo = with_demo
                         env.cr.commit()
                 if test_enable:
                     try:


### PR DESCRIPTION
Since [this commit], the demo boolean is defined at module import. It is therefore useless to define it again within the industry cli install.

[this commit]: https://github.com/odoo/odoo/commit/fb45f57e448bffaa98d0ae388e14d7b451f3f30e