### PR TITLE
[FIX] base_industry_data: remove dependency to digest

### DIFF
--- a/base_industry_data/__manifest__.py
+++ b/base_industry_data/__manifest__.py
@@ -5,7 +5,6 @@
     'category': 'Hidden/Tools',
     'depends': [
         'base',
-        'digest',
         'knowledge',
     ],
     'data': [


### PR DESCRIPTION
In [this commit], the code to deactivate the digest cron in demo data of industry moved from a setting to archiving the cron. By doing so, the dependency to digest is not useful anymore, as it unarchives the cron only if it exists.

[this commit]: https://github.com/odoo/industry/commit/b7be437b9486030a526bfa05dbc5ab339446322a