### PR TITLE
[IMP] construction_developer: highlight over delivery quantities

### DIFF
--- a/construction/__manifest__.py
+++ b/construction/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Construction Builder',
-    'version': '1.3',
+    'version': '1.4',
     'category': 'Construction',
     'depends': [
         'base_industry_data',

--- a/construction/data/knowledge_article.xml
+++ b/construction/data/knowledge_article.xml
@@ -311,6 +311,16 @@
                 <p>This information reflects straight away in your quotations, whether send as pdf file or with a preview.</p>
             </div>
         </div>
+        <div
+            class="o_editor_banner user-select-none o-contenteditable-false lh-1 d-flex align-items-center alert alert-success pb-0 pt-3"
+            data-oe-role="status" contenteditable="false" role="status">
+            <i class="o_editor_banner_icon mb-3 fst-normal" data-oe-aria-label="Banner Success"
+                aria-label="Banner Success">✅</i>
+            <div class="o_editor_banner_content o-contenteditable-true w-100 px-3"
+                contenteditable="true">
+                <p>To warn you about customer over billing, exceeding quantities are highlighted in orange and red in the case of open book and fixed price contract types.</p>
+            </div>
+        </div>
         <h5>📊 Cost nature analysis (Construction Developer)</h5>
         <p>
             You setup a quote and now want to know how it breaks down in terms of cost nature, it is available at your finger tips!

--- a/construction_developer/__manifest__.py
+++ b/construction_developer/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Construction Developer',
-    'version': '1.15',
+    'version': '1.16',
     'category': 'Construction',
     'depends': [
         'base_industry_data',

--- a/construction_developer/data/ir_model_fields.xml
+++ b/construction_developer/data/ir_model_fields.xml
@@ -156,6 +156,32 @@ for record in self: record['x_display_button'] = record.display_type in ['line_s
         <field name="field_id" ref="field_sale_order_line_sol_contract_type"/>
         <field name="value">open_book</field>
     </record>
+    <record id="field_sale_order_line_qty_delivered_state" model="ir.model.fields">
+        <field name="name">x_qty_delivered_state</field>
+        <field name="field_description">Delivered Quantity State</field>
+        <field name="ttype">char</field>
+        <field name="readonly" eval="True"/>
+        <field name="store" eval="False"/>
+        <field name="model_id" ref="sale.model_sale_order_line"/>
+        <field name="depends">qty_delivered, product_uom_qty, x_sol_contract_type, product_template_id</field>
+        <field name="compute"><![CDATA[
+contract_types = {'open_book': 'warning', 'fixed_price': 'danger'}
+for sol in self: sol['x_qty_delivered_state'] = contract_types.get(sol.x_sol_contract_type, False) if sol.product_template_id.service_policy == 'delivered_manual' and sol.qty_delivered > sol.product_uom_qty else False
+        ]]></field>
+    </record>
+    <record id="field_sale_order_line_current_progress_state" model="ir.model.fields">
+        <field name="name">x_current_progress_state</field>
+        <field name="field_description">Current Progress State</field>
+        <field name="ttype">char</field>
+        <field name="readonly" eval="True"/>
+        <field name="store" eval="False"/>
+        <field name="model_id" ref="sale.model_sale_order_line"/>
+        <field name="depends">x_current_progress, x_sol_contract_type, product_template_id</field>
+        <field name="compute"><![CDATA[
+contract_types = {'open_book': 'warning', 'fixed_price': 'danger'}
+for sol in self: sol['x_current_progress_state'] = contract_types.get(sol.x_sol_contract_type, False) if sol.product_template_id.service_policy == 'delivered_manual' and sol.x_current_progress > 100 else False
+        ]]></field>
+    </record>
 
     <!-- x_work_item fields -->
     <record id="x_name_field_x_work_item" model="ir.model.fields">

--- a/construction_developer/data/ir_ui_view.xml
+++ b/construction_developer/data/ir_ui_view.xml
@@ -13,14 +13,14 @@
                 </header>
                 <field name="x_reference" readonly="True"/>
                 <field name="name" readonly="True"/>
-                <field name="x_sol_contract_type" optional="hide"/>
+                <field name="x_sol_contract_type" invisible="display_type" optional="hide"/>
                 <field name="product_uom_qty" string="Qty" readonly="True"
                     invisible="display_type"
                 />
                 <field name="product_uom_id" widget="many2one_uom" readonly="True" groups="uom.group_uom"
                     invisible="display_type"
                 />
-                <field name="x_delivered_progress" widget="progressbar" readonly="True"
+                <field name="x_delivered_progress" decoration-warning="x_qty_delivered_state == 'warning'" decoration-danger="x_qty_delivered_state == 'danger'" widget="progressbar" options="{'overflow_class': 'bg-primary'}" readonly="True"
                     invisible="x_is_undeliverable or x_delivered_progress == 0"
                 />
                 <field name="x_quantity_increment" width="130px"
@@ -31,7 +31,7 @@
                 />
                 <field name="id" column_invisible="True"/> <!-- this invisible field is necessary to pass the id field to the widget -->
                 <widget name="apply_to_section_widget"/>
-                <field name="x_current_progress" widget="progressbar" readonly="True"
+                <field name="x_current_progress" decoration-warning="x_current_progress_state == 'warning'" decoration-danger="x_current_progress_state == 'danger'" widget="progressbar" options="{'overflow_class': 'bg-primary'}" readonly="True"
                     invisible="display_type or x_is_undeliverable or x_current_progress == 0"
                 />
             </list>
@@ -80,10 +80,14 @@
             <xpath expr="//notebook//page[@name='order_lines']//list//field[@name='tax_ids']" position="attributes">
                 <attribute name="width">150px</attribute>
             </xpath>
+            <xpath expr="//notebook//page[@name='order_lines']//list//field[@name='qty_delivered']" position="attributes">
+                <attribute name="decoration-warning">x_qty_delivered_state == 'warning'</attribute>
+                <attribute name="decoration-danger">x_qty_delivered_state == 'danger'</attribute>
+            </xpath>
             <xpath expr="//notebook//page[@name='other_information']//field[@name='team_id']" position="after">
                 <field name="x_so_contract_type" readonly="state == 'sale'"/>
             </xpath>
-            <xpath expr="//notebook//page[@name='order_lines']//list//field[@name='tax_ids']" position="after">
+            <xpath expr="//notebook//page[@name='order_lines']//list//field[@name='product_uom_qty']" position="after">
                 <field name="x_sol_contract_type" optional="show" readonly="parent.state == 'sale'" invisible="not product_id" column_invisible="parent.x_so_contract_type != 'per_line'" width="150px"/>
             </xpath>
         </field>


### PR DESCRIPTION
Highlight delivery quantities that are greater than product uom qty to detect or warn you about customer overbilling; exceeded delivery quantities are highlighted in orange and red in the case of open book and fixed price contract types.

Open Book contracts: orange warning highlight.
Fixed Price contracts: red danger highlight.

Task ID: 6189611