### PR TITLE
Master website and res config fixes aras

### DIFF
--- a/3pl_logistic_company/__manifest__.py
+++ b/3pl_logistic_company/__manifest__.py
@@ -6,6 +6,7 @@
     'depends': [
         'base_industry_data',
         'crm_sale_subscription',
+        'delivery',
         'documents_hr',
         'knowledge',
         'product_expiry',

--- a/3pl_logistic_company/data/res_config_settings.xml
+++ b/3pl_logistic_company/data/res_config_settings.xml
@@ -5,13 +5,11 @@
         <field name="group_stock_production_lot" eval="True"/>
         <field name="group_warning_stock" eval="True"/>
         <field name="group_stock_tracking_owner" eval="True"/>
-        <field name="module_delivery" eval="True"/>
         <field name="group_stock_tracking_lot" eval="True"/>
         <field name="group_stock_adv_location" eval="True"/>
         <field name="group_lot_on_delivery_slip" eval="True"/>
         <field name="group_expiry_date_on_delivery_slip" eval="True"/>
         <field name="group_uom" eval="True"/>
-        <field name="module_delivery_sendcloud" eval="True"/>
         <field name="group_sale_order_template" eval="True"/>
         <field name="group_mrp_wo_shop_floor" eval="False"/>
     </record>

--- a/3pl_logistic_company/demo/qweb_view.xml
+++ b/3pl_logistic_company/demo/qweb_view.xml
@@ -129,7 +129,7 @@
     <field name="key">3pl_logistic_company.contactus</field>
     <field name="name">Contact Us</field>
     <field name="type">qweb</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
     <field name="active" eval="True"/>
   </record>
   <record id="ir_ui_view_2473" model="ir.ui.view">
@@ -175,11 +175,11 @@
     <field name="key">3pl_logistic_company.homepage</field>
     <field name="name">Home</field>
     <field name="type">qweb</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
     <field name="active" eval="True"/>
   </record>
   <function model="ir.ui.view" name="write">
-    <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('website.default_website').id).viewref('website.homepage').id"/>
+    <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('base.default_website').id).viewref('website.homepage').id"/>
     <value model="ir.ui.view" eval="{'arch': obj().env.ref('3pl_logistic_company.ir_ui_view_2473').arch}"/>
   </function>
 </odoo>

--- a/3pl_logistic_company/demo/website.xml
+++ b/3pl_logistic_company/demo/website.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-    <record id="website.default_website" model="website" forcecreate="1">
+    <record id="base.default_website" model="website" forcecreate="1">
         <field name="name">Logistic-company</field>
         <field name="configurator_done" eval="True"/>
         <field name="logo" type="bytes" file="3pl_logistic_company/static/description/icon.png"/>

--- a/agriculture_shop/data/website_theme_apply.xml
+++ b/agriculture_shop/data/website_theme_apply.xml
@@ -2,7 +2,7 @@
 <odoo>
     <function name="write" model="ir.ui.view">
         <value model="ir.ui.view"
-            eval="obj().env['website'].with_context(website_id=ref('website.default_website')).viewref('website.contactus').id" />
+            eval="obj().env['website'].with_context(website_id=ref('base.default_website')).viewref('website.contactus').id" />
         <value model="ir.ui.view" eval="{'arch': obj().env.ref('agriculture_shop.contactus').arch}" />
     </function>
 

--- a/agriculture_shop/data/website_view.xml
+++ b/agriculture_shop/data/website_view.xml
@@ -5,7 +5,7 @@
         <field name="key">agriculture_shop.contactus</field>
         <field name="type">qweb</field>
         <field name="active" eval="True"/>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="arch" type="xml">
             <t name="Contact Us" t-name="website.contactus">
                 <t t-call="website.layout"

--- a/agriculture_shop/demo/sale_order.xml
+++ b/agriculture_shop/demo/sale_order.xml
@@ -3,7 +3,7 @@
     <record id="sale_order_1" model="sale.order">
         <field name="partner_id" ref="res_partner_10"/>
         <field name="user_id" ref="base.user_admin"/>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="carrier_id" ref="delivery.free_delivery_carrier"/>
         <field name="code_enabled_rule_ids" eval="[(6, 0, [ref('loyalty_rule_2')])]"/>
     </record>

--- a/agriculture_shop/demo/website.xml
+++ b/agriculture_shop/demo/website.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-    <record id="website.default_website" model="website" forcecreate="1">
+    <record id="base.default_website" model="website" forcecreate="1">
         <field name="name">Agriculture</field>
         <field name="theme_id" search="[('id', '=', ref('base.module_theme_enark', raise_if_not_found=False))]"/>
         <field name="logo" type="bytes" file="agriculture_shop/static/src/binary/website/1-logo"/>

--- a/agriculture_shop/demo/website_ir_attachment.xml
+++ b/agriculture_shop/demo/website_ir_attachment.xml
@@ -3,19 +3,19 @@
     <record id="ir_attachment_663" model="ir.attachment">
         <field name="name">agriculture_shop</field>
         <field name="raw" type="bytes" file="agriculture_shop/static/src/binary/ir_attachment/1.jpg"/>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
     </record>
     <record id="ir_attachment_664" model="ir.attachment">
         <field name="name">tomato</field>
         <field name="raw" type="bytes" file="agriculture_shop/static/src/binary/ir_attachment/3.jpg"/>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
     </record>
     <record id="ir_attachment_665" model="ir.attachment">
         <field name="name">vermi compost</field>
         <field name="raw" type="bytes" file="agriculture_shop/static/src/binary/ir_attachment/2.jpg"/>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
     </record>
 </odoo>

--- a/agriculture_shop/demo/website_menu.xml
+++ b/agriculture_shop/demo/website_menu.xml
@@ -3,23 +3,23 @@
     <record id="website_menu_17" model="website.menu">
         <field name="name">Product Stories</field>
         <field name="url">/productstories</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="parent_id" model="website.menu" eval="obj().search([
-                ('website_id', '=', ref('website.default_website')),
+                ('website_id', '=', ref('base.default_website')),
                 ('url', '=', '#'),
         ], limit=1).id"/>
     </record>
     <record id="website_menu_18" model="website.menu">
         <field name="name">Vermi Compost Powder</field>
         <field name="url">/soil-guard-vermi-compost-powder</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="page_id" ref="website_page_10"/>
         <field name="parent_id" ref="website_menu_17"/>
     </record>
     <record id="website_menu_19" model="website.menu">
         <field name="name">Tomato Seeds</field>
         <field name="url">/red-revolution-tomato-seeds</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="page_id" ref="website_page_8"/>
         <field name="parent_id" ref="website_menu_17"/>
     </record>

--- a/agriculture_shop/demo/website_page.xml
+++ b/agriculture_shop/demo/website_page.xml
@@ -1,19 +1,19 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
     <record id="website_page_6" model="website.page">
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="url">/pricing</field>
         <field name="view_id" ref="pricing"/>
         <field name="is_published" eval="True"/>
     </record>
     <record id="website_page_8" model="website.page">
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="url">/red-revolution-tomato-seeds</field>
         <field name="view_id" ref="red_revolution_tomato_seeds"/>
         <field name="is_published" eval="True"/>
     </record>
     <record id="website_page_10" model="website.page">
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="url">/soil-guard-vermi-compost-powder</field>
         <field name="view_id" ref="soil_guard_vermi_compost_powder"/>
         <field name="is_published" eval="True"/>

--- a/agriculture_shop/demo/website_theme_apply.xml
+++ b/agriculture_shop/demo/website_theme_apply.xml
@@ -2,13 +2,13 @@
 <odoo>
     <function name="button_choose_theme" model="ir.module.module" eval="[ref('base.module_theme_enark', raise_if_not_found=False) or ref('base.module_theme_default')]"/>
     
-    <function name="make_scss_customization" model="website.assets" context="{'website_id': ref('website.default_website')}">
+    <function name="make_scss_customization" model="website.assets" context="{'website_id': ref('base.default_website')}">
         <value eval="'/website/static/src/scss/options/colors/user_color_palette.scss'"/>
         <value eval="{'o-color-1': '#7d8a2f','o-color-2': '#080903','o-color-3': '#FBFBFB','o-color-4': '#FFFFFF','o-color-5': '#5E6823', 'menu': 1}"/>
     </function>
 
     <function name="write" model="ir.ui.view">
-        <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=ref('website.default_website')).viewref('website.homepage').id"/>
+        <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=ref('base.default_website')).viewref('website.homepage').id"/>
         <value model="ir.ui.view" eval="{'arch': obj().env.ref('agriculture_shop.homepage').arch}"/>
     </function>
 </odoo>

--- a/agriculture_shop/demo/website_view.xml
+++ b/agriculture_shop/demo/website_view.xml
@@ -4,7 +4,7 @@
         <field name="name">Home</field>
         <field name="key">agriculture_shop.homepage</field>
         <field name="type">qweb</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="arch" type="xml">
             <t name="Homepage" t-name="website.homepage">
                 <t t-call="website.layout" pageName.f="homepage">
@@ -30,7 +30,7 @@
         <field name="name">Pricing</field>
         <field name="key">website.pricing-1</field>
         <field name="type">qweb</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="arch" type="xml">
             <t name="Pricing" t-name="website.pricing-1">
                 <t t-call="website.layout">
@@ -140,7 +140,7 @@
         <field name="name">Red Revolution - Tomato Seeds</field>
         <field name="key">website.red-revolution-tomato-seeds</field>
         <field name="type">qweb</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="arch" type="xml">
             <t t-name="website.red-revolution-tomato-seeds">
                 <t t-call="website.layout">
@@ -190,7 +190,7 @@
         <field name="name">Soil Guard - Vermi Compost Powder</field>
         <field name="key">website.soil-guard-vermi-compost-powder</field>
         <field name="type">qweb</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="arch" type="xml">
             <t t-name="website.soil-guard-vermi-compost-powder">
                 <t t-call="website.layout">

--- a/architects/data/website_theme_apply.xml
+++ b/architects/data/website_theme_apply.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo>
     <function model="ir.ui.view" name="write">
-        <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('website.default_website').id).viewref('website.contactus').id"/>
+        <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('base.default_website').id).viewref('website.contactus').id"/>
         <value model="ir.ui.view" eval="{'arch': obj().env.ref('architects.contactus').arch.replace(
         '*base_user_admin*', str(obj().env.ref('base.user_admin').id)).replace(
         '*sales_team_team_sales_department*', str(obj().env.ref('sales_team.team_sales_department').id)

--- a/architects/data/website_view.xml
+++ b/architects/data/website_view.xml
@@ -5,7 +5,7 @@
         <field name="key">architects.contactus</field>
         <field name="type">qweb</field>
         <field name="active" eval="True"/>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="arch" type="xml">
           <t name="Contact Us" t-name="website.contactus">
             <t t-call="website.layout"

--- a/architects/demo/website.xml
+++ b/architects/demo/website.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-    <record id="website.default_website" model="website" forcecreate="1">
+    <record id="base.default_website" model="website" forcecreate="1">
         <field name="name">Architect</field>
         <field name="theme_id" search="[('id', '=', ref('base.module_theme_nano', raise_if_not_found=False))]"/>
         <field name="configurator_done" eval="True"/>

--- a/architects/demo/website_theme_apply.xml
+++ b/architects/demo/website_theme_apply.xml
@@ -39,7 +39,7 @@
     </function>
 
     <function model="ir.ui.view" name="write">
-        <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('website.default_website').id).viewref('website.homepage').id"/>
+        <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('base.default_website').id).viewref('website.homepage').id"/>
         <value model="ir.ui.view" eval="{'arch': obj().env.ref('architects.homepage').arch}"/>
     </function>
 </odoo>

--- a/architects/demo/website_view.xml
+++ b/architects/demo/website_view.xml
@@ -4,7 +4,7 @@
         <field name="name">Home</field>
         <field name="key">architects.homepage</field>
         <field name="type">qweb</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="arch" type="xml">
             <t name="Homepage" t-name="website.homepage">
               <t t-call="website.layout" pageName.f="homepage">

--- a/art_craft/data/product_pricelist.xml
+++ b/art_craft/data/product_pricelist.xml
@@ -2,7 +2,7 @@
 <odoo noupdate="1">
     <record id="product_pricelist_2" model="product.pricelist">
         <field name="name">B2B Pricelist</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
     </record>
     <record id="product_pricelist_3" model="product.pricelist">
         <field name="name">Default Pricelist B2C</field>

--- a/art_craft/data/website_view.xml
+++ b/art_craft/data/website_view.xml
@@ -5,7 +5,7 @@
         <field name="key">art_craft.contactus</field>
         <field name="type">qweb</field>
         <field name="active" eval="True"/>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="arch" type="xml">
             <t name="Contact Us" t-name="website.contactus">
                 <t t-call="website.layout"
@@ -265,7 +265,7 @@
         </field>
     </record>
     <function model="ir.ui.view" name="write">
-        <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('website.default_website').id).viewref('website.contactus').id"/>
+        <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('base.default_website').id).viewref('website.contactus').id"/>
         <value model="ir.ui.view" eval="{'arch': obj().env.ref('art_craft.contactus').arch.replace(
         '*base_user_admin*', str(obj().env.ref('base.user_admin').id)
         )}"/>

--- a/art_craft/demo/sale_order.xml
+++ b/art_craft/demo/sale_order.xml
@@ -8,7 +8,7 @@
     <record id="sale_order_3" model="sale.order">
         <field name="partner_id" ref="res_partner_19"/>
         <field name="carrier_id" ref="website_sale_collect.carrier_pick_up_in_store"/>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="user_id" ref="base.user_admin"/>
     </record>
     <record id="sale_order_5" model="sale.order">

--- a/art_craft/demo/website.xml
+++ b/art_craft/demo/website.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-    <record id="website.default_website" model="website" forcecreate="1">
+    <record id="base.default_website" model="website" forcecreate="1">
         <field name="name">The Art Store</field>
         <field name="theme_id" search="[('id', '=', ref('base.module_theme_artists', raise_if_not_found=False))]"/>
         <field name="logo" type="bytes" file="art_craft/static/src/binary/website/1-logo"/>

--- a/art_craft/demo/website_ir_attachment.xml
+++ b/art_craft/demo/website_ir_attachment.xml
@@ -4,140 +4,140 @@
         <field name="name">PTG.00086 (2).jpg</field>
         <field name="raw" type="bytes" file="art_craft/static/src/binary/ir_attachment/752-PTG.00086(2).jpg"/>
         <field name="res_model">ir.ui.view</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
     </record>
     <record id="ir_attachment_754" model="ir.attachment">
         <field name="name">IMG-20220702-WA0012.jpg</field>
         <field name="raw" type="bytes" file="art_craft/static/src/binary/ir_attachment/754-IMG-20220702-WA0012.jpg"/>
         <field name="res_model">ir.ui.view</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
     </record>
     <record id="ir_attachment_755" model="ir.attachment">
         <field name="name">MAC.00485.jpg</field>
         <field name="raw" type="bytes" file="art_craft/static/src/binary/ir_attachment/755-MAC.00485.jpg"/>
         <field name="res_model">ir.ui.view</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
     </record>
     <record id="ir_attachment_756" model="ir.attachment">
         <field name="name">PTG.00086 (2).jpg</field>
         <field name="raw" type="bytes" file="art_craft/static/src/binary/ir_attachment/756-PTG.00086(2).jpg"/>
         <field name="res_model">ir.ui.view</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
     </record>
     <record id="ir_attachment_757" model="ir.attachment">
         <field name="name">IMG-20220702-WA0012.jpg</field>
         <field name="raw" type="bytes" file="art_craft/static/src/binary/ir_attachment/757-IMG-20220702-WA0012.jpg"/>
         <field name="res_model">ir.ui.view</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
     </record>
     <record id="ir_attachment_758" model="ir.attachment">
         <field name="name">MAC.00485.jpg</field>
         <field name="raw" type="bytes" file="art_craft/static/src/binary/ir_attachment/758-MAC.00485.jpg"/>
         <field name="res_model">ir.ui.view</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
     </record>
     <record id="ir_attachment_772" model="ir.attachment">
         <field name="name">IMG-20220702-WA0007.jpg</field>
         <field name="raw" type="bytes" file="art_craft/static/src/binary/ir_attachment/772-IMG-20220702-WA0007.jpg"/>
         <field name="res_model">ir.ui.view</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
     </record>
     <record id="configurator_1_library_image_03" model="ir.attachment">
         <field name="name">website.library_image_03</field>
         <field name="raw" type="bytes" file="art_craft/static/src/binary/ir_attachment/729-website.library_image_03"/>
         <field name="key">website.library_image_03</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
     </record>
     <record id="configurator_1_library_image_05" model="ir.attachment">
         <field name="name">website.library_image_05</field>
         <field name="raw" type="bytes" file="art_craft/static/src/binary/ir_attachment/732-website.library_image_05"/>
         <field name="key">website.library_image_05</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
     </record>
     <record id="configurator_1_library_image_10" model="ir.attachment">
         <field name="name">website.library_image_10</field>
         <field name="raw" type="bytes" file="art_craft/static/src/binary/ir_attachment/730-website.library_image_10"/>
         <field name="key">website.library_image_10</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
     </record>
     <record id="configurator_1_library_image_13" model="ir.attachment">
         <field name="name">website.library_image_13</field>
         <field name="raw" type="bytes" file="art_craft/static/src/binary/ir_attachment/731-website.library_image_13"/>
         <field name="key">website.library_image_13</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
     </record>
     <record id="configurator_1_library_image_14" model="ir.attachment">
         <field name="name">website.library_image_14</field>
         <field name="raw" type="bytes" file="art_craft/static/src/binary/ir_attachment/733-website.library_image_14"/>
         <field name="key">website.library_image_14</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
     </record>
     <record id="configurator_1_library_image_16" model="ir.attachment">
         <field name="name">website.library_image_16</field>
         <field name="raw" type="bytes" file="art_craft/static/src/binary/ir_attachment/734-website.library_image_16"/>
         <field name="key">website.library_image_16</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
     </record>
     <record id="configurator_1_s_banner_default_image" model="ir.attachment">
         <field name="name">art_craft.s_banner_default_image</field>
         <field name="raw" type="bytes" file="art_craft/static/src/binary/ir_attachment/713-website.s_banner_default_image"/>
         <field name="key">art_craft.s_banner_default_image</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
     </record>
     <record id="configurator_1_s_carousel_default_image_3" model="ir.attachment">
         <field name="name">art_craft.s_carousel_default_image_3</field>
         <field name="raw" type="bytes" file="art_craft/static/src/binary/ir_attachment/712-website.s_carousel_default_image_3"/>
         <field name="key">art_craft.s_carousel_default_image_3</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
     </record>
     <record id="configurator_1_s_cover_default_image" model="ir.attachment">
         <field name="name">art_craft.s_cover_default_image</field>
         <field name="raw" type="bytes" file="art_craft/static/src/binary/ir_attachment/703-website.s_cover_default_image"/>
         <field name="key">art_craft.s_cover_default_image</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
     </record>
     <record id="configurator_1_s_image_text_default_image" model="ir.attachment">
         <field name="name">art_craft.s_image_text_default_image</field>
         <field name="raw" type="bytes" file="art_craft/static/src/binary/ir_attachment/723-website.s_image_text_default_image"/>
         <field name="key">art_craft.s_image_text_default_image</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
     </record>
     <record id="configurator_1_s_text_image_default_image" model="ir.attachment">
         <field name="name">art_craft.s_text_image_default_image</field>
         <field name="raw" type="bytes" file="art_craft/static/src/binary/ir_attachment/724-website.s_text_image_default_image"/>
         <field name="key">art_craft.s_text_image_default_image</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
     </record>
     <record id="configurator_1_s_three_columns_default_image_1" model="ir.attachment">
         <field name="name">art_craft.s_three_columns_default_image_1</field>
         <field name="raw" type="bytes" file="art_craft/static/src/binary/ir_attachment/725-website.s_three_columns_default_image_1"/>
         <field name="key">art_craft.s_three_columns_default_image_1</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
     </record>
     <record id="configurator_1_s_three_columns_default_image_3" model="ir.attachment">
         <field name="name">art_craft.s_three_columns_default_image_3</field>
         <field name="raw" type="bytes" file="art_craft/static/src/binary/ir_attachment/727-website.s_three_columns_default_image_3"/>
         <field name="key">art_craft.s_three_columns_default_image_3</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
     </record>
 </odoo>

--- a/art_craft/demo/website_menu.xml
+++ b/art_craft/demo/website_menu.xml
@@ -4,10 +4,10 @@
         <field name="name">About Us</field>
         <field name="url">/about-us</field>
         <field name="sequence">50</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="page_id" ref="website_page_5"/>
         <field name="parent_id" model="website.menu" eval="obj().search([
-                ('website_id', '=', ref('website.default_website')),
+                ('website_id', '=', ref('base.default_website')),
                 ('url', '=', '#'),
         ], limit=1).id"/>
     </record>

--- a/art_craft/demo/website_page.xml
+++ b/art_craft/demo/website_page.xml
@@ -3,7 +3,7 @@
     <record id="website_page_5" model="website.page">
         <field name="url">/about-us</field>
         <field name="view_id" ref="about-us"/>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="is_published" eval="True"/>
     </record>
 </odoo>

--- a/art_craft/demo/website_theme_apply.xml
+++ b/art_craft/demo/website_theme_apply.xml
@@ -2,12 +2,12 @@
 <odoo>
     <function name="button_choose_theme" model="ir.module.module" eval="[ref('base.module_theme_artists', raise_if_not_found=False) or ref('base.module_theme_default')]"/>
     
-    <function model="website.assets" name="make_scss_customization" context="{'website_id': ref('website.default_website')}">
+    <function model="website.assets" name="make_scss_customization" context="{'website_id': ref('base.default_website')}">
         <value eval="'/website/static/src/scss/options/colors/user_color_palette.scss'"/>
         <value eval="{'o-color-1': '#ae7b7c','o-color-2': '#7f8291','o-color-3': '#F2F3F4','o-color-4': '#FFFFFF','o-color-5': '#835C5D', 'menu': 1}"/>
     </function>
     <function model="ir.ui.view" name="write">
-        <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('website.default_website').id).viewref('website.homepage').id"/>
+        <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('base.default_website').id).viewref('website.homepage').id"/>
         <value model="ir.ui.view" eval="{'arch': obj().env.ref('art_craft.homepage').arch.replace(
             '*filter_newest_products_art_craft*', str(obj().env.ref('website_sale.dynamic_filter_newest_products').id)
         )}"/>

--- a/art_craft/demo/website_view.xml
+++ b/art_craft/demo/website_view.xml
@@ -4,7 +4,7 @@
         <field name="name">Home</field>
         <field name="key">art_craft.homepage</field>
         <field name="type">qweb</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="arch" type="xml">
             <t name="Homepage" t-name="website.homepage">
                 <t t-call="website.layout" pageName.f="homepage">
@@ -317,7 +317,7 @@
         <field name="name">About Us</field>
         <field name="key">art_craft.about-us</field>
         <field name="type">qweb</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="arch" type="xml">
             <t name="About Us" t-name="website.about-us">
                 <t t-call="website.layout">

--- a/bakery/demo/sale_order.xml
+++ b/bakery/demo/sale_order.xml
@@ -9,14 +9,14 @@
         <field name="partner_id" ref="base.partner_admin"/>
         <field name="partner_shipping_id" ref="base.main_partner"/>
         <field name="carrier_id" ref="website_sale_collect.carrier_pick_up_in_store"/>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="user_id" ref="base.user_admin"/>
     </record>
     <record id="sale_order_2" model="sale.order">
         <field name="partner_id" ref="base.partner_admin"/>
         <field name="partner_shipping_id" ref="base.main_partner"/>
         <field name="carrier_id" ref="website_sale_collect.carrier_pick_up_in_store"/>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="user_id" ref="base.user_admin"/>
     </record>
 </odoo>

--- a/bakery/demo/website.xml
+++ b/bakery/demo/website.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-    <record id="website.default_website" model="website" forcecreate="1">
+    <record id="base.default_website" model="website" forcecreate="1">
         <field name="name">Odoo Bakery</field>
         <field name="logo" type="bytes" file="bakery/static/description/icon.png"/>
         <field name="favicon" type="bytes" file="bakery/static/description/icon.png"/>

--- a/bakery/demo/website_theme_apply.xml
+++ b/bakery/demo/website_theme_apply.xml
@@ -1,18 +1,18 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo>
-    <function model="website.assets" name="make_scss_customization" context="{'website_id': ref('website.default_website')}">
+    <function model="website.assets" name="make_scss_customization" context="{'website_id': ref('base.default_website')}">
         <value eval="'/website/static/src/scss/options/colors/user_color_palette.scss'"/>
         <value eval="{'o-color-1': '#B8B8FF','o-color-2': '#FFF4DD','o-color-3': '#F9F8F8','o-color-4': '#FFFFFF','o-color-5': '#202642'}"/>
     </function>
 
     <function model="ir.ui.view" name="write">
-        <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=ref('website.default_website')).viewref('website.homepage').id"/>
+        <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=ref('base.default_website')).viewref('website.homepage').id"/>
         <value model="ir.ui.view" eval="{'arch': obj().env.ref('bakery.homepage').arch.replace(
             '*filter_newest_products_bakery*', str(obj().env.ref('website_sale.dynamic_filter_newest_products').id)
         )}"/>
     </function>
     <function model="ir.ui.view" name="write">
-        <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=ref('website.default_website')).viewref('website.contactus').id"/>
+        <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=ref('base.default_website')).viewref('website.contactus').id"/>
         <value model="ir.ui.view" eval="{'arch': obj().env.ref('bakery.ir_ui_view_3528').arch}"/>
     </function>
     <function model="ir.ui.view" name="write">
@@ -23,13 +23,13 @@
         <function model="website.checkout.step" name="write">
             <value model="website.checkout.step" eval="obj().search([
                 ('step_href', '=', '/shop/extra_info'),
-                ('website_id', '=', ref('website.default_website')),
+                ('website_id', '=', ref('base.default_website')),
             ]).ids"/>
             <value eval="{'is_published': True}"/>
         </function>
     </data>
     <function model="ir.ui.view" name="write">
-        <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('website.default_website').id).viewref('website_sale.extra_info').id"/>
+        <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('base.default_website').id).viewref('website_sale.extra_info').id"/>
         <value model="ir.ui.view" eval="{'arch': obj().env.ref('bakery.ir_ui_view_3576').arch}"/>
     </function>
 </odoo>

--- a/bakery/demo/website_view.xml
+++ b/bakery/demo/website_view.xml
@@ -53,7 +53,7 @@
         <field name="key">bakery.extra_info</field>
         <field name="name">Checkout Extra Info</field>
         <field name="type">qweb</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
     </record>
     <record id="ir_ui_view_3528" model="ir.ui.view">
         <field name="arch" type="xml">
@@ -145,7 +145,7 @@
         <field name="key">bakery.contactus</field>
         <field name="name">Contact Us</field>
         <field name="type">qweb</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
     </record>
     <record id="ir_ui_view_3529" model="ir.ui.view">
         <field name="arch" type="xml">
@@ -229,7 +229,7 @@
         <field name="mode">extension</field>
         <field name="name">Default</field>
         <field name="type">qweb</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
     </record>
     <record id="ir_ui_view_3524" model="ir.ui.view">
         <field name="arch" type="xml">
@@ -252,7 +252,7 @@
         <field name="mode">extension</field>
         <field name="name">Header Call to Action</field>
         <field name="type">qweb</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
     </record>
     <record id="homepage" model="ir.ui.view">
         <field name="arch" type="xml">
@@ -324,6 +324,6 @@
         <field name="key">bakery.homepage</field>
         <field name="name">Home</field>
         <field name="type">qweb</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
     </record>
 </odoo>

--- a/beauty_parlor/demo/website.xml
+++ b/beauty_parlor/demo/website.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-  <record id="website.default_website" model="website" forcecreate="1">
+  <record id="base.default_website" model="website" forcecreate="1">
     <field name="name">My Website</field>
     <field name="configurator_done" eval="True"/>
     <field name="logo" type="bytes" file="beauty_parlor/static/description/icon.png"/>

--- a/beauty_parlor/demo/website_menu.xml
+++ b/beauty_parlor/demo/website_menu.xml
@@ -4,9 +4,9 @@
     <field name="name">Services</field>
     <field name="page_id" ref="website_page_6"/>
     <field name="url">/our-services</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
     <field name="parent_id" model="website.menu" eval="obj().search([
-      ('website_id', '=', ref('website.default_website')),
+      ('website_id', '=', ref('base.default_website')),
       ('url', '=', '#'),
     ], limit=1).id"/>
   </record>

--- a/beauty_parlor/demo/website_theme_apply.xml
+++ b/beauty_parlor/demo/website_theme_apply.xml
@@ -3,12 +3,12 @@
   <function name="button_choose_theme" model="ir.module.module" eval="[ref('base.module_theme_artists', raise_if_not_found=False)]"/>
 
   <function model="ir.ui.view" name="write">
-    <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('website.default_website').id).viewref('website.homepage').id"/>
+    <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('base.default_website').id).viewref('website.homepage').id"/>
     <value model="ir.ui.view" eval="{'arch': obj().env.ref('beauty_parlor.homepage').arch}"/>
   </function>
 
   <function model="ir.ui.view" name="write">
-    <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=ref('website.default_website')).viewref('website.footer_custom').id"/>
+    <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=ref('base.default_website')).viewref('website.footer_custom').id"/>
     <value eval="{'active': False}"/>
   </function>
 
@@ -63,7 +63,7 @@
 
   <data noupdate="1">
     <function model="website.menu" name="unlink">
-      <value model="website.menu" eval="obj().search([('website_id', '=', ref('website.default_website')), ('url', '=', '/appointment')]).ids"/>
+      <value model="website.menu" eval="obj().search([('website_id', '=', ref('base.default_website')), ('url', '=', '/appointment')]).ids"/>
     </function>
   </data>
 

--- a/beauty_parlor/demo/website_view.xml
+++ b/beauty_parlor/demo/website_view.xml
@@ -13,7 +13,7 @@
     <field name="key">beauty_parlor.website.contactus</field>
     <field name="name">Contact Us</field>
     <field name="type">qweb</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
   </record>
   <record id="ir_ui_view_3734" model="ir.ui.view">
     <field name="arch" type="xml">
@@ -34,7 +34,7 @@
     <field name="mode">extension</field>
     <field name="name">Header Call to Action</field>
     <field name="type">qweb</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
   </record>
   <record id="homepage" model="ir.ui.view">
     <field name="arch" type="xml">
@@ -205,7 +205,7 @@ Our goal is simple: make beauty care accessible, human, and enjoyable; whether i
     <field name="key">beauty_parlor.website.homepage</field>
     <field name="name">Home</field>
     <field name="type">qweb</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
   </record>
   <record id="ir_ui_view_3092" model="ir.ui.view">
     <field name="arch" type="xml">
@@ -382,6 +382,6 @@ Our goal is simple: make beauty care accessible, human, and enjoyable; whether i
     <field name="key">beauty_parlor.website.services</field>
     <field name="name">Services</field>
     <field name="type">qweb</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
   </record>
 </odoo>

--- a/beverage_distributor/demo/website.xml
+++ b/beverage_distributor/demo/website.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-    <record id="website.default_website" model="website" forcecreate="1">
+    <record id="base.default_website" model="website" forcecreate="1">
         <field name="name">beverages-distributor</field>
         <field name="theme_id" search="[('id', '=', ref('base.module_theme_zap', raise_if_not_found=False))]"/>
         <field name="logo" type="bytes" file="beverage_distributor/static/description/icon.png"/>

--- a/beverage_distributor/demo/website_theme_apply.xml
+++ b/beverage_distributor/demo/website_theme_apply.xml
@@ -2,7 +2,7 @@
 <odoo>
     <function name="button_choose_theme" model="ir.module.module" eval="[ref('base.module_theme_zap', raise_if_not_found=False) or ref('base.module_theme_default')]"/>
     <function name="write" model="ir.ui.view">
-        <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('website.default_website').id).viewref('website.homepage').id"/>
+        <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('base.default_website').id).viewref('website.homepage').id"/>
         <value model="ir.ui.view" eval="{'arch': obj().env.ref('beverage_distributor.homepage').arch}"/>
     </function>
     <function model="website.assets" name="make_scss_customization">

--- a/beverage_distributor/demo/website_view.xml
+++ b/beverage_distributor/demo/website_view.xml
@@ -3,7 +3,7 @@
     <record id="homepage" model="ir.ui.view">
         <field name="name">Home</field>
         <field name="key">beverage_distributor.homepage</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="type">qweb</field>
         <field name="arch" type="xml">
       <t name="Homepage" t-name="website.homepage">

--- a/bike_leasing/data/ir_attachment_post.xml
+++ b/bike_leasing/data/ir_attachment_post.xml
@@ -5,48 +5,48 @@
         <field name="raw" type="bytes" file="bike_leasing/static/src/binary/ir_attachment/918-logo-1.png"/>
         <field name="res_model">ir.ui.view</field>
         <field name="public" eval="1"/>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
     </record>
     <record id="ir_attachment_930" model="ir.attachment">
         <field name="name">morespacious.jpg</field>
         <field name="raw" type="bytes" file="bike_leasing/static/src/binary/ir_attachment/930-morespacious.jpg"/>
         <field name="res_model">ir.ui.view</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="1"/>
     </record>
     <record id="ir_attachment_931" model="ir.attachment">
         <field name="name">Cases-7-768x758 (1).jpg</field>
         <field name="raw" type="bytes" file="bike_leasing/static/src/binary/ir_attachment/931-Cases-7-768x758(1).jpg"/>
         <field name="res_model">ir.ui.view</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="1"/>
     </record>
     <record id="ir_attachment_932" model="ir.attachment">
         <field name="name">Cases-4-768x758.jpg</field>
         <field name="raw" type="bytes" file="bike_leasing/static/src/binary/ir_attachment/932-Cases-4-768x758.jpg"/>
         <field name="res_model">ir.ui.view</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="1"/>
     </record>
     <record id="ir_attachment_933" model="ir.attachment">
         <field name="name">Cases-7-768x758 (1).webp</field>
         <field name="raw" type="bytes" file="bike_leasing/static/src/binary/ir_attachment/933-Cases-7-768x758(1).webp"/>
         <field name="res_model">ir.ui.view</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="1"/>
     </record>
     <record id="ir_attachment_934" model="ir.attachment">
         <field name="name">morespacious.webp</field>
         <field name="raw" type="bytes" file="bike_leasing/static/src/binary/ir_attachment/934-morespacious.webp"/>
         <field name="res_model">ir.ui.view</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="1"/>
     </record>
     <record id="ir_attachment_935" model="ir.attachment">
         <field name="name">Cases-4-768x758.webp</field>
         <field name="raw" type="bytes" file="bike_leasing/static/src/binary/ir_attachment/935-Cases-4-768x758.webp"/>
         <field name="res_model">ir.ui.view</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="1"/>
     </record>
 </odoo>

--- a/bike_leasing/data/product_pricelist.xml
+++ b/bike_leasing/data/product_pricelist.xml
@@ -4,19 +4,19 @@
         <field name="name">Monthly</field>
         <field name="sequence">1</field>
         <field name="selectable" eval="True"/>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="x_auto_post_pricelist">monthly</field>
     </record>
     <record id="product_pricelist_3" model="product.pricelist">
         <field name="name">Quarterly</field>
         <field name="selectable" eval="True"/>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="x_auto_post_pricelist">quarterly</field>
     </record>
     <record id="product_pricelist_4" model="product.pricelist">
         <field name="name">Yearly</field>
         <field name="selectable" eval="True"/>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="x_auto_post_pricelist">yearly</field>
     </record>
 </odoo>

--- a/bike_leasing/demo/website.xml
+++ b/bike_leasing/demo/website.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-    <record id="website.default_website" model="website" forcecreate="1">
+    <record id="base.default_website" model="website" forcecreate="1">
         <field name="name">My Website</field>
         <field name="configurator_done" eval="True"/>
         <field name="cart_recovery_mail_template_id" eval="False"/>

--- a/bike_leasing/demo/website.xml
+++ b/bike_leasing/demo/website.xml
@@ -5,7 +5,6 @@
         <field name="configurator_done" eval="True"/>
         <field name="cart_recovery_mail_template_id" eval="False"/>
         <field name="logo" type="bytes" file="bike_leasing/static/src/binary/website/1-logo"/>
-        <field name="add_to_cart_action">go_to_cart</field>
         <field name="theme_id" search="[('id', '=', ref('base.module_theme_vehicle', raise_if_not_found=False))]"/>
     </record>
 </odoo>

--- a/bike_leasing/demo/website_menu.xml
+++ b/bike_leasing/demo/website_menu.xml
@@ -6,9 +6,9 @@
         <field name="sequence">30</field>
         <field name="page_id" ref="website_page_7"/>
         <field name="parent_id" model="website.menu" eval="obj().search([
-            ('website_id', '=', ref('website.default_website')),
+            ('website_id', '=', ref('base.default_website')),
             ('url', '=', '#'),
         ], limit=1).id"/>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
     </record>
 </odoo>

--- a/bike_leasing/demo/website_page.xml
+++ b/bike_leasing/demo/website_page.xml
@@ -3,12 +3,12 @@
     <record id="website_page_5" model="website.page">
         <field name="url">/catalogue</field>
         <field name="view_id" ref="catalogue"/>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
     </record>
     <record id="website_page_7" model="website.page">
         <field name="is_published" eval="True"/>
         <field name="url">/partnership</field>
         <field name="view_id" ref="partnership"/>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
     </record>
 </odoo>

--- a/bike_leasing/demo/website_theme_apply.xml
+++ b/bike_leasing/demo/website_theme_apply.xml
@@ -3,14 +3,14 @@
     <function name="button_choose_theme" model="ir.module.module" eval="[ref('base.module_theme_vehicle', raise_if_not_found=False) or ref('base.module_theme_default')]"/>
 
     <function name="write" model="ir.ui.view">
-        <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('website.default_website').id).viewref('website.homepage').id"/>
+        <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('base.default_website').id).viewref('website.homepage').id"/>
         <value model="ir.ui.view" eval="{'arch': obj().env.ref('bike_leasing.homepage').arch}"/>
     </function>
 
     <data noupdate="1">
         <function model="website.menu" name="write">
             <value model="website.menu" eval="obj().search([
-                ('website_id', '=', ref('website.default_website')),
+                ('website_id', '=', ref('base.default_website')),
                 ('url', '=', '/shop'),
             ], limit=1).id"/>
             <value eval="{'name': 'Bike Leasing'}"/>
@@ -18,7 +18,7 @@
 
         <function model="website.menu" name="unlink">
             <value model="website.menu" eval="obj().search([
-                ('website_id', '=', ref('website.default_website')),
+                ('website_id', '=', ref('base.default_website')),
                 ('url', '=', '/helpdesk/customer-care-1'),
             ]).ids"/>
         </function>

--- a/bike_leasing/demo/website_view.xml
+++ b/bike_leasing/demo/website_view.xml
@@ -3,7 +3,7 @@
     <record id="homepage" model="ir.ui.view">
         <field name="name">Home</field>
         <field name="key">bike_leasing.homepage</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="type">qweb</field>
         <field name="arch" type="xml">
             <t name="Homepage" t-name="website.homepage">
@@ -45,7 +45,7 @@
     <record id="partnership" model="ir.ui.view">
         <field name="name">Partnership</field>
         <field name="key">bike_leasing.partnership</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="type">qweb</field>
         <field name="arch" type="xml">
             <t t-name="website.partnership">
@@ -82,7 +82,7 @@
     <record id="catalogue" model="ir.ui.view">
         <field name="name">Catalogue</field>
         <field name="key">bike_leasing.catalogue</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="type">qweb</field>
         <field name="arch" type="xml">
             <t t-name="website.catalogue">
@@ -159,7 +159,7 @@
         <field name="mode">extension</field>
         <field name="name">footer_copyright_company_name</field>
         <field name="type">qweb</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
     </record>
     <record id="ir_ui_view_2744" model="ir.ui.view">
         <field name="arch" type="xml">
@@ -176,6 +176,6 @@
         <field name="mode">extension</field>
         <field name="name">Minimalist</field>
         <field name="type">qweb</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
     </record>
 </odoo>

--- a/bike_shop/data/qweb_views.xml
+++ b/bike_shop/data/qweb_views.xml
@@ -5,7 +5,7 @@
         <field name="name">website_helpdesk.team_form_2</field>
         <field name="type">qweb</field>
         <field name="active" eval="True" />
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="arch" type="xml">
             <t name="Helpdesk: Submit a Ticket Form" t-name="website_helpdesk.ticket_submit_form">
                 <div class="container">

--- a/bike_shop/demo/helpdesk_team.xml
+++ b/bike_shop/demo/helpdesk_team.xml
@@ -3,6 +3,6 @@
   <record id="helpdesk_team_1" model="helpdesk.team">
     <field name="alias_id" ref="helpdesk_team_1_mail_alias" />
     <field name="is_published" eval="True"/>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
   </record>
 </odoo>

--- a/bike_shop/demo/website.xml
+++ b/bike_shop/demo/website.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-    <record id="website.default_website" model="website" forcecreate="1">
+    <record id="base.default_website" model="website" forcecreate="1">
         <field name="name">Bike Shop</field>
         <field name="configurator_done" eval="True" />
         <field name="logo" type="bytes" file="bike_shop/static/description/icon.png" />

--- a/bike_shop/demo/website_menu.xml
+++ b/bike_shop/demo/website_menu.xml
@@ -2,50 +2,50 @@
 <odoo noupdate="1" auto_sequence="1">
     <function model="website.menu" name="unlink">
         <value model="website.menu"
-            eval="obj().search([('website_id', '=', ref('website.default_website')), ('url', '=', '#')]).ids"
+            eval="obj().search([('website_id', '=', ref('base.default_website')), ('url', '=', '#')]).ids"
         />
     </function>
     <record id="website_menu_4" model="website.menu">
         <field name="name">Top Menu for Website 1</field>
-        <field name="website_id" ref="website.default_website" />
+        <field name="website_id" ref="base.default_website" />
     </record>
     <record id="website_menu_5" model="website.menu">
         <field name="name">Home</field>
         <field name="page_id" ref="website_page_4" />
         <field name="url">/</field>
-        <field name="website_id" ref="website.default_website" />
+        <field name="website_id" ref="base.default_website" />
         <field name="parent_id" ref="website_menu_4" />
     </record>
     <record id="website_menu_6" model="website.menu">
         <field name="name">Shop</field>
         <field name="url">/shop</field>
-        <field name="website_id" ref="website.default_website" />
+        <field name="website_id" ref="base.default_website" />
         <field name="parent_id" ref="website_menu_4" />
     </record>
     <record id="website_menu_7" model="website.menu">
         <field name="name">Services</field>
         <field name="page_id" ref="website_page_4" />
-        <field name="website_id" ref="website.default_website" />
+        <field name="website_id" ref="base.default_website" />
         <field name="parent_id" ref="website_menu_4" />
     </record>
     <record id="website_menu_8" model="website.menu">
         <field name="name">Maintenance &amp; Repairs</field>
         <field name="page_id" ref="website_page_6" />
         <field name="url">/repairs</field>
-        <field name="website_id" ref="website.default_website" />
+        <field name="website_id" ref="base.default_website" />
         <field name="parent_id" ref="website_menu_7" />
     </record>
     <record id="website_menu_9" model="website.menu">
         <field name="name">Bike Testing</field>
         <field name="url">/appointment</field>
-        <field name="website_id" ref="website.default_website" />
+        <field name="website_id" ref="base.default_website" />
         <field name="parent_id" ref="website_menu_7" />
     </record>
     <record id="website_menu_10" model="website.menu">
         <field name="name">Contact us</field>
         <field name="page_id" ref="website_page_7" />
         <field name="url">/contactus</field>
-        <field name="website_id" ref="website.default_website" />
+        <field name="website_id" ref="base.default_website" />
         <field name="parent_id" ref="website_menu_4" />
     </record>
 </odoo>

--- a/bike_shop/demo/website_page.xml
+++ b/bike_shop/demo/website_page.xml
@@ -2,19 +2,19 @@
 <odoo noupdate="1">
     <record id="website_page_4" model="website.page">
         <field name="view_id" ref="homepage" />
-        <field name="website_id" ref="website.default_website" />
+        <field name="website_id" ref="base.default_website" />
         <field name="is_published" eval="True" />
         <field name="url">/</field>
     </record>
     <record id="website_page_6" model="website.page">
         <field name="view_id" ref="repairs" />
-        <field name="website_id" ref="website.default_website" />
+        <field name="website_id" ref="base.default_website" />
         <field name="is_published" eval="True" />
         <field name="url">/repairs</field>
     </record>
     <record id="website_page_7" model="website.page">
         <field name="view_id" ref="contactus" />
-        <field name="website_id" ref="website.default_website" />
+        <field name="website_id" ref="base.default_website" />
         <field name="is_published" eval="True" />
         <field name="url">/contactus</field>
     </record>

--- a/bike_shop/demo/website_theme_apply.xml
+++ b/bike_shop/demo/website_theme_apply.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo>
     <function model="ir.ui.view" name="write">
-        <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('website.default_website').id).viewref('website.homepage').id" />
+        <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('base.default_website').id).viewref('website.homepage').id" />
         <value model="ir.ui.view" eval="{'arch': obj().env.ref('bike_shop.homepage').arch}" />
     </function>
     <function model="website.assets" name="make_scss_customization">
@@ -32,7 +32,7 @@
     <data noupdate="1">
 
         <function model="website.menu" name="unlink">
-            <value model="website.menu" eval="obj().search([('website_id', '=', ref('website.default_website')), ('url', '=', '/appointment')]).ids"/>
+            <value model="website.menu" eval="obj().search([('website_id', '=', ref('base.default_website')), ('url', '=', '/appointment')]).ids"/>
         </function>
 
     </data>

--- a/bike_shop/demo/website_view.xml
+++ b/bike_shop/demo/website_view.xml
@@ -4,7 +4,7 @@
         <field name="key">bike_shop.homepage</field>
         <field name="name">Home</field>
         <field name="type">qweb</field>
-        <field name="website_id" ref="website.default_website" />
+        <field name="website_id" ref="base.default_website" />
         <field name="arch" type="xml">
             <t name="Homepage" t-name="website.homepage">
                 <t t-call="website.layout" pageName.f="homepage">
@@ -285,7 +285,7 @@
         <field name="key">bike_shop.repairs</field>
         <field name="name">Repairs</field>
         <field name="type">qweb</field>
-        <field name="website_id" ref="website.default_website" />
+        <field name="website_id" ref="base.default_website" />
         <field name="arch" type="xml">
             <t t-name="website.repairs">
                 <t t-call="website.layout">
@@ -456,7 +456,7 @@
         <field name="key">bike_shop.contactus</field>
         <field name="name">Contact Us</field>
         <field name="type">qweb</field>
-        <field name="website_id" ref="website.default_website" />
+        <field name="website_id" ref="base.default_website" />
         <field name="arch" type="xml">
             <t name="Contact Us" t-name="website.contactus">
                 <t t-call="website.layout"

--- a/billboard_rental/data/website_theme_apply.xml
+++ b/billboard_rental/data/website_theme_apply.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo>
     <function name="write" model="ir.ui.view">
-        <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=ref('website.default_website')).viewref('website.contactus').id"/>
+        <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=ref('base.default_website')).viewref('website.contactus').id"/>
         <value model="ir.ui.view" eval="{'arch': obj().env.ref('billboard_rental.contactus').arch}"/>
     </function>
 </odoo>

--- a/billboard_rental/data/website_view.xml
+++ b/billboard_rental/data/website_view.xml
@@ -4,7 +4,7 @@
         <field name="name">Contact Us</field>
         <field name="key">billboard_rental.contactus</field>
         <field name="type">qweb</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="active" eval="True"/>
         <field name="arch" type="xml">
             <t name="Contact Us" t-name="website.contactus">

--- a/billboard_rental/demo/website.xml
+++ b/billboard_rental/demo/website.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-    <record id="website.default_website" model="website" forcecreate="1">
+    <record id="base.default_website" model="website" forcecreate="1">
         <field name="logo" type="bytes" file="billboard_rental/static/description/icon.png"/>
         <field name="favicon" type="bytes" file="billboard_rental/static/description/icon.png"/>
         <field name="name">My Website</field>

--- a/billboard_rental/demo/website_theme_apply.xml
+++ b/billboard_rental/demo/website_theme_apply.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo>
     <function name="write" model="ir.ui.view">
-        <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('website.default_website').id).viewref('website.homepage').id"/>
+        <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('base.default_website').id).viewref('website.homepage').id"/>
         <value model="ir.ui.view" eval="{'arch': obj().env.ref('billboard_rental.homepage').arch}"/>
     </function>
 </odoo>

--- a/billboard_rental/demo/website_view.xml
+++ b/billboard_rental/demo/website_view.xml
@@ -4,7 +4,7 @@
         <field name="name">Home</field>
         <field name="key">billboard_rental.homepage</field>
         <field name="type">qweb</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="arch" type="xml">
             <t name="Homepage" t-name="website.homepage">
                 <t t-call="website.layout" pageName.f="homepage">

--- a/booking_engine/data/product_pricelist.xml
+++ b/booking_engine/data/product_pricelist.xml
@@ -3,6 +3,6 @@
     <record id="product_pricelist_1" model="product.pricelist">
         <field name="name">Default</field>
         <field name="selectable" eval="True"/>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
     </record>
 </odoo>

--- a/booking_engine/data/res_config_settings.xml
+++ b/booking_engine/data/res_config_settings.xml
@@ -7,7 +7,6 @@
             <field name="portal_confirmation_pay" eval="1"/>
             <field name="group_product_variant" eval="1"/>
             <field name="show_line_subtotals_tax_selection">tax_included</field>
-            <field name="add_to_cart_action">go_to_cart</field>
             <field name="automatic_invoice" eval="1"/>
             <field name="tz" model="res.config.settings" eval="obj().env.context.get('tz') or 'Europe/Brussels'"/>
         </record>

--- a/booking_engine/data/website_menu.xml
+++ b/booking_engine/data/website_menu.xml
@@ -2,7 +2,7 @@
 <odoo auto_sequence="1" noupdate="1">
   <function model="website.menu" name="write">
     <value model="website.menu" 
-      eval="obj().search([('website_id', '=', ref('website.default_website')), ('url', '=', '/shop')]).ids" />
+      eval="obj().search([('website_id', '=', ref('base.default_website')), ('url', '=', '/shop')]).ids" />
     <value eval="{'name': 'Rooms'}"/>
   </function>
 </odoo>

--- a/booking_engine/demo/website_menu.xml
+++ b/booking_engine/demo/website_menu.xml
@@ -2,6 +2,6 @@
 <odoo noupdate="1">
   <function model="website.menu" name="unlink">
     <value model="website.menu"
-      eval="obj().search([('website_id', '=', ref('website.default_website')), ('url', 'in', ['/appointment', '/contactus'])]).ids" />
+      eval="obj().search([('website_id', '=', ref('base.default_website')), ('url', 'in', ['/appointment', '/contactus'])]).ids" />
   </function>
 </odoo>

--- a/bowling/demo/website.xml
+++ b/bowling/demo/website.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-  <record id="website.default_website" model="website" forcecreate="1">
+  <record id="base.default_website" model="website" forcecreate="1">
     <field name="name">The Bowling Company</field>
     <field name="configurator_done" eval="True"/>
     <field name="logo" type="bytes" file="bowling/static/description/icon.png"/>

--- a/bowling/demo/website_theme_apply.xml
+++ b/bowling/demo/website_theme_apply.xml
@@ -3,7 +3,7 @@
   <function name="button_choose_theme" model="ir.module.module" eval="[ref('base.module_theme_beauty', raise_if_not_found=False) or ref('base.module_theme_default')]"/>
 
   <function model="ir.ui.view" name="write">
-    <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('website.default_website').id).viewref('website.homepage').id"/>
+    <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('base.default_website').id).viewref('website.homepage').id"/>
     <value model="ir.ui.view" eval="{'arch': obj().env.ref('bowling.ir_ui_view_1880').arch}"/>
   </function>
 

--- a/bowling/demo/website_view.xml
+++ b/bowling/demo/website_view.xml
@@ -21,7 +21,7 @@
     <field name="mode">extension</field>
     <field name="name">Header Call to Action</field>
     <field name="type">qweb</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
   </record>
   <record id="ir_ui_view_1880" model="ir.ui.view">
     <field name="arch" type="xml">
@@ -198,6 +198,6 @@
     <field name="key">bowling.homepage</field>
     <field name="name">Home</field>
     <field name="type">qweb</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
   </record>
 </odoo>

--- a/campsite/data/web_views.xml
+++ b/campsite/data/web_views.xml
@@ -3,7 +3,7 @@
   <data noupdate="1">
     <function model="website.menu" name="write">
       <value model="website.menu"
-      eval="obj().search([('website_id', '=', ref('website.default_website')), ('url', '=', '/shop')], limit=1).id" />
+      eval="obj().search([('website_id', '=', ref('base.default_website')), ('url', '=', '/shop')], limit=1).id" />
       <value eval="{'name': 'Stay Offers'}"/>
     </function>
   </data>

--- a/campsite/demo/website.xml
+++ b/campsite/demo/website.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-  <record id="website.default_website" model="website" forcecreate="1">
+  <record id="base.default_website" model="website" forcecreate="1">
     <field name="name">campsite</field>
     <field name="configurator_done" eval="True"/>
     <field name="favicon" type="bytes" file="campsite/static/description/icon.png"/>

--- a/campsite/demo/website_theme_apply.xml
+++ b/campsite/demo/website_theme_apply.xml
@@ -2,12 +2,12 @@
 <odoo>
   <function name="button_choose_theme" model="ir.module.module" eval="[ref('base.module_theme_real_estate', raise_if_not_found=False) or ref('base.module_theme_default')]"/>
     
-  <function name="make_scss_customization" model="website.assets" context="{'website_id': ref('website.default_website')}">
+  <function name="make_scss_customization" model="website.assets" context="{'website_id': ref('base.default_website')}">
     <value eval="'/website/static/src/scss/options/colors/user_color_palette.scss'"/>
     <value eval="{'o-color-1': '#005134','o-color-2': '#A58F99','o-color-3': '#FBFBFB','o-color-4': '#FFFFFF','o-color-5': '#43594F', 'menu': 1}"/>
   </function>
   <function name="write" model="ir.ui.view">
-    <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=ref('website.default_website')).viewref('website.homepage').id"/>
+    <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=ref('base.default_website')).viewref('website.homepage').id"/>
     <value model="ir.ui.view" eval="{'arch': obj().env.ref('campsite.homepage').arch.replace(
       '*filter_newest_products_campsite*', str(obj().env.ref('website_sale.dynamic_filter_newest_products').id)
     )}"/>

--- a/campsite/demo/website_view.xml
+++ b/campsite/demo/website_view.xml
@@ -188,6 +188,6 @@
     <field name="key">campsite.homepage</field>
     <field name="name">Home</field>
     <field name="type">qweb</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
   </record>
 </odoo>

--- a/candy_shop/demo/website.xml
+++ b/candy_shop/demo/website.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-  <record id="website.default_website" model="website" forcecreate="1">
+  <record id="base.default_website" model="website" forcecreate="1">
     <field name="name">Candy Shop</field>
     <field name="configurator_done" eval="True"/>
     <field name="logo" type="bytes" file="candy_shop/static/description/icon.png"/>

--- a/candy_shop/demo/website_menu.xml
+++ b/candy_shop/demo/website_menu.xml
@@ -3,22 +3,22 @@
   <record id="website_menu_14" model="website.menu">
     <field name="name">Candy</field>
     <field name="url" eval="'/shop/category/%s' % ref('product_public_category_4')"/>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
     <field name="sequence">21</field>
-    <field name="parent_id" search="[('website_id', '=', ref('website.default_website')), ('url', '=', '#')]"/>
+    <field name="parent_id" search="[('website_id', '=', ref('base.default_website')), ('url', '=', '#')]"/>
   </record>
   <record id="website_menu_17" model="website.menu">
     <field name="name">Drinks</field>
     <field name="url" eval="'/shop/category/%s' % ref('product_public_category_1')"/>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
     <field name="sequence">22</field>
-    <field name="parent_id" search="[('website_id', '=', ref('website.default_website')), ('url', '=', '#')]"/>
+    <field name="parent_id" search="[('website_id', '=', ref('base.default_website')), ('url', '=', '#')]"/>
   </record>
   <record id="website_menu_16" model="website.menu">
     <field name="name">Snacks</field>
     <field name="url" eval="'/shop/category/%s' % ref('product_public_category_3')"/>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
     <field name="sequence">23</field>
-    <field name="parent_id" search="[('website_id', '=', ref('website.default_website')), ('url', '=', '#')]"/>
+    <field name="parent_id" search="[('website_id', '=', ref('base.default_website')), ('url', '=', '#')]"/>
   </record>
 </odoo>

--- a/candy_shop/demo/website_theme_apply.xml
+++ b/candy_shop/demo/website_theme_apply.xml
@@ -57,7 +57,7 @@
     </function>
 
     <function model="ir.ui.view" name="write">
-      <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('website.default_website').id).viewref('website.homepage').id"/>
+      <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('base.default_website').id).viewref('website.homepage').id"/>
       <value model="ir.ui.view" eval="{'arch': obj().env.ref('candy_shop.homepage').arch.replace(
         '*drinks_product_public_category*', str(obj().env.ref('candy_shop.product_public_category_1').id)).replace(
         '*snacks_product_public_category*', str(obj().env.ref('candy_shop.product_public_category_3').id)).replace(
@@ -72,7 +72,7 @@
     </function>
 
     <function model="ir.ui.view" name="write">
-        <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('website.default_website').id).viewref('website.template_footer_minimalist').id"/>
+        <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('base.default_website').id).viewref('website.template_footer_minimalist').id"/>
         <value model="ir.ui.view" eval="{
             'arch': obj().env.ref('candy_shop.ir_ui_view_3453').arch,
             'active': True
@@ -81,7 +81,7 @@
 
     <data noupdate="1">
       <function model="website.menu" name="unlink">
-          <value model="website.menu" eval="obj().search([('website_id', '=', ref('website.default_website')), ('url', '=', '/contactus')]).ids"/>
+          <value model="website.menu" eval="obj().search([('website_id', '=', ref('base.default_website')), ('url', '=', '/contactus')]).ids"/>
       </function>
     </data>
 </odoo>

--- a/candy_shop/demo/website_view.xml
+++ b/candy_shop/demo/website_view.xml
@@ -5,7 +5,7 @@
       <field name="key">candy_shop.homepage</field>
       <field name="type">qweb</field>
       <field name="active" eval="True"/>
-      <field name="website_id" ref="website.default_website"/>
+      <field name="website_id" ref="base.default_website"/>
       <field name="arch" type="xml">
           <t name="Homepage" t-name="website.homepage">
               <t t-call="website.layout" pageName.f="homepage">
@@ -163,7 +163,7 @@
         <field name="key">candy_shop.contactus</field>
         <field name="type">qweb</field>
         <field name="active" eval="True"/>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="arch" type="xml">
             <t name="Contact Us" t-name="website.contactus">
                 <t t-call="website.layout"
@@ -336,7 +336,7 @@
     <field name="mode">extension</field>
     <field name="name">Header Call to Action</field>
     <field name="type">qweb</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
   </record>
   <record id="ir_ui_view_3454" model="ir.ui.view">
     <field name="name">Header Text element</field>
@@ -344,7 +344,7 @@
     <field name="key">website.header_text_element</field>
     <field name="mode">extension</field>
     <field name="type">qweb</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
     <field name="arch" type="xml">
       <xpath expr="//t[@t-if=&quot;_txt_elt_content == 'sentence'&quot;]/div/small" position="replace">
           <small>🚛 Free Shipping for Orders over 100<b>€</b> 🚛</small>
@@ -357,7 +357,7 @@
     <field name="key">website.template_footer_minimalist</field>
     <field name="mode">extension</field>
     <field name="inherit_id" ref="website.layout"/>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
     <field name="arch" type="xml">
       <data inherit_id="website.layout" name="Minimalist" active="False">
         <xpath expr="//div[@id='footer']" position="replace">
@@ -420,7 +420,7 @@
     <field name="inherit_id" ref="website.layout"/>
     <field name="mode">extension</field>
     <field name="type">qweb</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
     <field name="arch" type="xml">
         <xpath expr="//footer//span[hasclass('o_footer_copyright_name')]" position="replace">
             <span class="o_footer_copyright_name me-2">​</span>

--- a/catering/demo/website.xml
+++ b/catering/demo/website.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-  <record id="website.default_website" model="website" forcecreate="1">
+  <record id="base.default_website" model="website" forcecreate="1">
     <field name="name">Catering</field>
     <field name="configurator_done" eval="True"/>
     <field name="logo" type="bytes" file="catering/static/description/icon.png"/>

--- a/catering/demo/website_theme_apply.xml
+++ b/catering/demo/website_theme_apply.xml
@@ -38,7 +38,7 @@
     </function>
 
     <function model="ir.ui.view" name="write">
-      <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('website.default_website').id).viewref('website.homepage').id"/>
+      <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('base.default_website').id).viewref('website.homepage').id"/>
       <value model="ir.ui.view" eval="{'arch': obj().env.ref('catering.homepage').arch}"/>
     </function>
 

--- a/catering/demo/website_view.xml
+++ b/catering/demo/website_view.xml
@@ -222,6 +222,6 @@
     <field name="key">catering.homepage</field>
     <field name="name">Home</field>
     <field name="type">qweb</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
   </record>
 </odoo>

--- a/certification_organism/data/ir_attachment_post.xml
+++ b/certification_organism/data/ir_attachment_post.xml
@@ -4,14 +4,14 @@
         <field name="name">20230824140623-ce4327.png</field>
         <field name="res_id" ref="welcome_article" />
         <field name="res_model">knowledge.article</field>
-        <field name="website_id" ref="website.default_website" />
+        <field name="website_id" ref="base.default_website" />
         <field name="raw" type="bytes" file="certification_organism/static/src/binary/ir_attachment/410-20230824140623-ce4327.png" />
     </record>
     <record id="ir_attachment_411" model="ir.attachment">
         <field name="name">20230824142855-26332a.png</field>
         <field name="res_id" ref="welcome_article" />
         <field name="res_model">knowledge.article</field>
-        <field name="website_id" ref="website.default_website" />
+        <field name="website_id" ref="base.default_website" />
         <field name="raw" type="bytes" file="certification_organism/static/src/binary/ir_attachment/411-20230824142855-26332a.png" />
     </record>
     <record id="ir_attachment_513" model="ir.attachment">
@@ -19,195 +19,195 @@
         <field name="raw" type="bytes" file="certification_organism/static/src/binary/ir_attachment/513-picture3.png"/>
         <field name="res_id" ref="welcome_article"/>
         <field name="res_model">knowledge.article</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
     </record>
     <record id="ir_attachment_514" model="ir.attachment">
         <field name="name">picture4.png</field>
         <field name="raw" type="bytes" file="certification_organism/static/src/binary/ir_attachment/514-picture4.png"/>
         <field name="res_id" ref="welcome_article"/>
         <field name="res_model">knowledge.article</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
     </record>
     <record id="ir_attachment_515" model="ir.attachment">
         <field name="name">picture5.png</field>
         <field name="raw" type="bytes" file="certification_organism/static/src/binary/ir_attachment/515-picture5.png"/>
         <field name="res_id" ref="welcome_article"/>
         <field name="res_model">knowledge.article</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
     </record>
     <record id="ir_attachment_516" model="ir.attachment">
         <field name="name">picture6.png</field>
         <field name="raw" type="bytes" file="certification_organism/static/src/binary/ir_attachment/516-picture6.png"/>
         <field name="res_id" ref="welcome_article"/>
         <field name="res_model">knowledge.article</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
     </record>
     <record id="ir_attachment_517" model="ir.attachment">
         <field name="name">picture7.png</field>
         <field name="raw" type="bytes" file="certification_organism/static/src/binary/ir_attachment/517-picture7.png"/>
         <field name="res_id" ref="welcome_article"/>
         <field name="res_model">knowledge.article</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
     </record>
     <record id="ir_attachment_518" model="ir.attachment">
         <field name="name">picture8.png</field>
         <field name="raw" type="bytes" file="certification_organism/static/src/binary/ir_attachment/518-picture8.png"/>
         <field name="res_id" ref="welcome_article"/>
         <field name="res_model">knowledge.article</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
     </record>
     <record id="ir_attachment_519" model="ir.attachment">
         <field name="name">picture8.png</field>
         <field name="raw" type="bytes" file="certification_organism/static/src/binary/ir_attachment/519-picture8.png"/>
         <field name="res_id" ref="welcome_article"/>
         <field name="res_model">knowledge.article</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
     </record>
     <record id="ir_attachment_520" model="ir.attachment">
         <field name="name">picture9.png</field>
         <field name="raw" type="bytes" file="certification_organism/static/src/binary/ir_attachment/520-picture9.png"/>
         <field name="res_id" ref="welcome_article"/>
         <field name="res_model">knowledge.article</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
     </record>
     <record id="ir_attachment_521" model="ir.attachment">
         <field name="name">picture10.png</field>
         <field name="raw" type="bytes" file="certification_organism/static/src/binary/ir_attachment/521-picture10.png"/>
         <field name="res_id" ref="welcome_article"/>
         <field name="res_model">knowledge.article</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
     </record>
     <record id="ir_attachment_522" model="ir.attachment">
         <field name="name">picture11.png</field>
         <field name="raw" type="bytes" file="certification_organism/static/src/binary/ir_attachment/522-picture11.png"/>
         <field name="res_id" ref="welcome_article"/>
         <field name="res_model">knowledge.article</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
     </record>
     <record id="ir_attachment_523" model="ir.attachment">
         <field name="name">picture12.png</field>
         <field name="raw" type="bytes" file="certification_organism/static/src/binary/ir_attachment/523-picture12.png"/>
         <field name="res_id" ref="welcome_article"/>
         <field name="res_model">knowledge.article</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
     </record>
     <record id="ir_attachment_524" model="ir.attachment">
         <field name="name">picture13.png</field>
         <field name="raw" type="bytes" file="certification_organism/static/src/binary/ir_attachment/524-picture13.png"/>
         <field name="res_id" ref="welcome_article"/>
         <field name="res_model">knowledge.article</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
     </record>
     <record id="ir_attachment_525" model="ir.attachment">
         <field name="name">picture14.png</field>
         <field name="raw" type="bytes" file="certification_organism/static/src/binary/ir_attachment/525-picture14.png"/>
         <field name="res_id" ref="welcome_article"/>
         <field name="res_model">knowledge.article</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
     </record>
     <record id="ir_attachment_526" model="ir.attachment">
         <field name="name">picture15.png</field>
         <field name="raw" type="bytes" file="certification_organism/static/src/binary/ir_attachment/526-picture15.png"/>
         <field name="res_id" ref="welcome_article"/>
         <field name="res_model">knowledge.article</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
     </record>
     <record id="ir_attachment_527" model="ir.attachment">
         <field name="name">picture16.png</field>
         <field name="raw" type="bytes" file="certification_organism/static/src/binary/ir_attachment/527-picture16.png"/>
         <field name="res_id" ref="welcome_article"/>
         <field name="res_model">knowledge.article</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
     </record>
     <record id="ir_attachment_528" model="ir.attachment">
         <field name="name">picture17.png</field>
         <field name="raw" type="bytes" file="certification_organism/static/src/binary/ir_attachment/528-picture17.png"/>
         <field name="res_id" ref="welcome_article"/>
         <field name="res_model">knowledge.article</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
     </record>
     <record id="ir_attachment_529" model="ir.attachment">
         <field name="name">picture18.png</field>
         <field name="raw" type="bytes" file="certification_organism/static/src/binary/ir_attachment/529-picture18.png"/>
         <field name="res_id" ref="welcome_article"/>
         <field name="res_model">knowledge.article</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
     </record>
     <record id="ir_attachment_530" model="ir.attachment">
         <field name="name">picture19.png</field>
         <field name="raw" type="bytes" file="certification_organism/static/src/binary/ir_attachment/530-picture19.png"/>
         <field name="res_id" ref="welcome_article"/>
         <field name="res_model">knowledge.article</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
     </record>
     <record id="ir_attachment_531" model="ir.attachment">
         <field name="name">picture20.png</field>
         <field name="raw" type="bytes" file="certification_organism/static/src/binary/ir_attachment/531-picture20.png"/>
         <field name="res_id" ref="welcome_article"/>
         <field name="res_model">knowledge.article</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
     </record>
     <record id="ir_attachment_532" model="ir.attachment">
         <field name="name">picture21.png</field>
         <field name="raw" type="bytes" file="certification_organism/static/src/binary/ir_attachment/532-picture21.png"/>
         <field name="res_id" ref="welcome_article"/>
         <field name="res_model">knowledge.article</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
     </record>
     <record id="ir_attachment_533" model="ir.attachment">
         <field name="name">picture22.png</field>
         <field name="raw" type="bytes" file="certification_organism/static/src/binary/ir_attachment/533-picture22.png"/>
         <field name="res_id" ref="welcome_article"/>
         <field name="res_model">knowledge.article</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
     </record>
     <record id="ir_attachment_534" model="ir.attachment">
         <field name="name">picture23.png</field>
         <field name="raw" type="bytes" file="certification_organism/static/src/binary/ir_attachment/534-picture23.png"/>
         <field name="res_id" ref="welcome_article"/>
         <field name="res_model">knowledge.article</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
     </record>
     <record id="ir_attachment_535" model="ir.attachment">
         <field name="name">picture24.png</field>
         <field name="raw" type="bytes" file="certification_organism/static/src/binary/ir_attachment/535-picture24.png"/>
         <field name="res_id" ref="welcome_article"/>
         <field name="res_model">knowledge.article</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
     </record>
     <record id="ir_attachment_536" model="ir.attachment">
         <field name="name">picture26.png</field>
         <field name="raw" type="bytes" file="certification_organism/static/src/binary/ir_attachment/536-picture26.png"/>
         <field name="res_id" ref="welcome_article"/>
         <field name="res_model">knowledge.article</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
     </record>
     <record id="ir_attachment_537" model="ir.attachment">
         <field name="name">picture25.png</field>
         <field name="raw" type="bytes" file="certification_organism/static/src/binary/ir_attachment/537-picture25.png"/>
         <field name="res_id" ref="welcome_article"/>
         <field name="res_model">knowledge.article</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
     </record>
     <record id="ir_attachment_538" model="ir.attachment">
         <field name="name">picture27.png</field>
         <field name="raw" type="bytes" file="certification_organism/static/src/binary/ir_attachment/538-picture27.png"/>
         <field name="res_id" ref="welcome_article"/>
         <field name="res_model">knowledge.article</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
     </record>
     <record id="ir_attachment_539" model="ir.attachment">
         <field name="name">picture28.png</field>
         <field name="raw" type="bytes" file="certification_organism/static/src/binary/ir_attachment/539-picture28.png"/>
         <field name="res_id" ref="welcome_article"/>
         <field name="res_model">knowledge.article</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
     </record>
     <record id="ir_attachment_540" model="ir.attachment">
         <field name="name">picture29.png</field>
         <field name="raw" type="bytes" file="certification_organism/static/src/binary/ir_attachment/540-picture29.png"/>
         <field name="res_id" ref="welcome_article"/>
         <field name="res_model">knowledge.article</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
     </record>
 </odoo>

--- a/certification_organism/data/website_menu.xml
+++ b/certification_organism/data/website_menu.xml
@@ -4,13 +4,13 @@
         <field name="name">Top Menu for Website 1</field>
         <field name="sequence" eval="False"/>
         <field name="url">/default-main-menu</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
     </record>
     <record id="website_menu_6" model="website.menu">
         <field name="name">Contact us</field>
         <field name="sequence">2</field>
         <field name="url">/contactus</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="page_id" ref="website_page_5"/>
         <field name="parent_id" ref="website_menu_4"/>
     </record>

--- a/certification_organism/data/website_page.xml
+++ b/certification_organism/data/website_page.xml
@@ -3,7 +3,7 @@
     <record id="website_page_5" model="website.page">
         <field name="url">/contactus</field>
         <field name="is_published" eval="True"/>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="view_id" ref="contactus"/>
     </record>
 </odoo>

--- a/certification_organism/data/website_view.xml
+++ b/certification_organism/data/website_view.xml
@@ -5,7 +5,7 @@
         <field name="key">website.contactus</field>
         <field name="type">qweb</field>
         <field name="active" eval="True"/>
-        <field name="website_id" ref="website.default_website" />
+        <field name="website_id" ref="base.default_website" />
         <field name="arch" type="xml">
             <t name="Contact Us" t-name="website.contactus">
                 <t t-call="website.layout"

--- a/certification_organism/demo/website.xml
+++ b/certification_organism/demo/website.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-    <record id="website.default_website" model="website" forcecreate="1">
+    <record id="base.default_website" model="website" forcecreate="1">
         <field name="name">certification-auditors-industry</field>
     </record>
 </odoo>

--- a/climbing_gym/demo/ir_attachment_post.xml
+++ b/climbing_gym/demo/ir_attachment_post.xml
@@ -30,28 +30,28 @@
         <field name="name">website.s_wavy_grid_default_image_2</field>
         <field name="raw" type="bytes" file="climbing_gym/static/src/binary/ir_attachment/974-website.s_wavy_grid_default_image_2"/>
         <field name="key">website.s_wavy_grid_default_image_2</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
     </record>
     <record id="configurator_1_s_three_columns_default_image_3" model="ir.attachment" forcecreate="1">
         <field name="name">website.s_three_columns_default_image_3</field>
         <field name="raw" type="bytes" file="climbing_gym/static/src/binary/ir_attachment/929-website.s_three_columns_default_image_3"/>
         <field name="key">website.s_three_columns_default_image_3</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
     </record>
     <record id="configurator_1_s_three_columns_default_image_2" model="ir.attachment" forcecreate="1">
         <field name="name">website.s_three_columns_default_image_2</field>
         <field name="raw" type="bytes" file="climbing_gym/static/src/binary/ir_attachment/928-website.s_three_columns_default_image_2"/>
         <field name="key">website.s_three_columns_default_image_2</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
     </record>
     <record id="configurator_1_s_three_columns_default_image_1" model="ir.attachment" forcecreate="1">
         <field name="name">website.s_three_columns_default_image_1</field>
         <field name="raw" type="bytes" file="climbing_gym/static/src/binary/ir_attachment/927-website.s_three_columns_default_image_1"/>
         <field name="key">website.s_three_columns_default_image_1</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
     </record>
 </odoo>

--- a/climbing_gym/demo/website.xml
+++ b/climbing_gym/demo/website.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-    <record id="website.default_website" model="website" forcecreate="1">
+    <record id="base.default_website" model="website" forcecreate="1">
         <field name="name">A little place of adventure</field>
         <field name="theme_id" search="[('id', '=', ref('base.module_theme_kiddo', raise_if_not_found=False))]"/>
         <field name="logo" type="bytes" file="climbing_gym/static/description/icon.png"/>

--- a/climbing_gym/demo/website_theme_apply.xml
+++ b/climbing_gym/demo/website_theme_apply.xml
@@ -3,7 +3,7 @@
     <function name="button_choose_theme" model="ir.module.module" eval="[ref('base.module_theme_orchid', raise_if_not_found=False) or ref('base.module_theme_default')]"/>
     
     <function name="write" model="ir.ui.view">
-        <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('website.default_website').id).viewref('website.homepage').id"/>
+        <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('base.default_website').id).viewref('website.homepage').id"/>
         <value model="ir.ui.view" eval="{'arch': obj().env.ref('climbing_gym.homepage').arch}"/>
     </function>
 </odoo>

--- a/climbing_gym/demo/website_view.xml
+++ b/climbing_gym/demo/website_view.xml
@@ -4,7 +4,7 @@
     <field name="name">Home</field>
     <field name="key">climbing_gym.homepage</field>
     <field name="type">qweb</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
     <field name="arch" type="xml">
       <t name="Homepage" t-name="website.homepage">
         <t t-call="website.layout" pageName.f="homepage">
@@ -210,7 +210,7 @@
     <field name="name">record_cover</field>
     <field name="key">climbing_gym.record_cover</field>
     <field name="type">qweb</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
     <field name="arch" type="xml">
       <t t-name="website.record_cover">
         <t t-set="_cp" t-value="_cp or json.loads(_record.cover_properties)"/>
@@ -231,7 +231,7 @@
         <field name="key">climbing_gym.contactus</field>
         <field name="type">qweb</field>
         <field name="active" eval="True"/>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="arch" type="xml">
             <t name="Contact Us" t-name="website.contactus">
                 <t t-call="website.layout"

--- a/clothing_boutique/demo/website.xml
+++ b/clothing_boutique/demo/website.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-    <record id="website.default_website" model="website" forcecreate="1">
+    <record id="base.default_website" model="website" forcecreate="1">
         <field name="name">The Glam Boutique</field>
         <field name="theme_id" search="[('id', '=', ref('base.module_theme_orchid', raise_if_not_found=False))]"/>
         <field name="configurator_done" eval="True"/>

--- a/clothing_boutique/demo/website_attachments.xml
+++ b/clothing_boutique/demo/website_attachments.xml
@@ -4,42 +4,42 @@
         <field name="name">clothing_boutique.s_cover_default_image</field>
         <field name="raw" type="bytes" file="clothing_boutique/static/src/binary/ir_attachment/403-website.s_cover_default_image"/>
         <field name="key">clothing_boutique.s_cover_default_image</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
     </record>
     <record id="ir_attachment_578" model="ir.attachment">
          <field name="name">unsplash_KfqgYzoH3Vk_boutique.jpg</field>
          <field name="raw" type="bytes" file="clothing_boutique/static/src/binary/ir_attachment/578-unsplash_KfqgYzoH3Vk_boutique.jpg"/>
          <field name="key">clothing_boutique.clothing_hanger_1</field>
-         <field name="website_id" ref="website.default_website"/>
+         <field name="website_id" ref="base.default_website"/>
          <field name="public" eval="True"/>
     </record>
     <record id="ir_attachment_579" model="ir.attachment">
          <field name="name">unsplash_7F7kEHj72MQ_boutique.jpg</field>
          <field name="raw" type="bytes" file="clothing_boutique/static/src/binary/ir_attachment/579-unsplash_7F7kEHj72MQ_boutique.jpg"/>
          <field name="key">clothing_boutique.clothing_hanger_2</field>
-         <field name="website_id" ref="website.default_website"/>
+         <field name="website_id" ref="base.default_website"/>
          <field name="public" eval="True"/>
     </record>
     <record id="ir_attachment_581" model="ir.attachment">
         <field name="name">unsplash_Ysc3ra1Xvpw_boutique.jpg</field>
         <field name="raw" type="bytes" file="clothing_boutique/static/src/binary/ir_attachment/581-unsplash_Ysc3ra1Xvpw_boutique.jpg"/>
         <field name="key">clothing_boutique.sale_1</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
     </record>
     <record id="configurator_1_s_three_columns_default_image_3" model="ir.attachment">
         <field name="name">clothing_boutique.s_three_columns_default_image_3</field>
         <field name="raw" type="bytes" file="clothing_boutique/static/src/binary/ir_attachment/427-website.s_three_columns_default_image_3"/>
         <field name="key">clothing_boutique.s_three_columns_default_image_3</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
     </record>
     <record id="configurator_1_s_banner_default_image" model="ir.attachment">
         <field name="name">clothing_boutique.s_banner_default_image</field>
         <field name="raw" type="bytes" file="clothing_boutique/static/src/binary/ir_attachment/413-website.s_banner_default_image"/>
         <field name="key">clothing_boutique.s_banner_default_image</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
     </record>
 </odoo>

--- a/clothing_boutique/demo/website_theme_apply.xml
+++ b/clothing_boutique/demo/website_theme_apply.xml
@@ -3,7 +3,7 @@
     <function name="button_choose_theme" model="ir.module.module" eval="[ref('base.module_theme_orchid', raise_if_not_found=False) or ref('base.module_theme_default')]"/>
 
     <function model="ir.ui.view" name="write">
-        <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('website.default_website').id).viewref('website.homepage').id"/>
+        <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('base.default_website').id).viewref('website.homepage').id"/>
         <value model="ir.ui.view" eval="{'arch': obj().env.ref('clothing_boutique.homepage').arch}"/>
     </function>
     <function model="ir.ui.view" name="write">

--- a/concert_halls/data/website_menu.xml
+++ b/concert_halls/data/website_menu.xml
@@ -5,9 +5,9 @@
       <field name="page_id" ref="website_page_7"/>
       <field name="url">/business</field>
       <field name="sequence">50</field>
-      <field name="website_id" ref="website.default_website"/>
+      <field name="website_id" ref="base.default_website"/>
       <field name="parent_id" model="website.menu" eval="obj().search([
-                ('website_id', '=', ref('website.default_website')),
+                ('website_id', '=', ref('base.default_website')),
                 ('url', '=', '#'),
       ], limit=1).id"/>
     </record>

--- a/concert_halls/data/website_page.xml
+++ b/concert_halls/data/website_page.xml
@@ -2,7 +2,7 @@
 <odoo noupdate="1">
   <record id="website_page_7" model="website.page">
     <field name="view_id" ref="business_view"/>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
     <field name="is_published" eval="True"/>
     <field name="url">/business</field>
   </record>

--- a/concert_halls/data/website_view.xml
+++ b/concert_halls/data/website_view.xml
@@ -5,7 +5,7 @@
         <field name="key">concert_halls.business</field>
         <field name="type">qweb</field>
         <field name="active" eval="True"/>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="arch" type="xml">
             <t t-name="website.business">
                 <t t-call="website.layout">

--- a/concert_halls/demo/website.xml
+++ b/concert_halls/demo/website.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-  <record id="website.default_website" model="website" forcecreate="1">
+  <record id="base.default_website" model="website" forcecreate="1">
     <field name="name">Concert Halls</field>
     <field name="configurator_done" eval="True"/>
     <field name="user_id" ref="base.public_user"/>

--- a/concert_halls/demo/website_theme_apply.xml
+++ b/concert_halls/demo/website_theme_apply.xml
@@ -38,19 +38,19 @@
   </function>
 
   <function model="ir.ui.view" name="write">
-      <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('website.default_website').id).viewref('website.homepage').id"/>
+      <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('base.default_website').id).viewref('website.homepage').id"/>
       <value model="ir.ui.view" eval="{'arch': obj().env.ref('concert_halls.homepage').arch.replace(
         '*filter_upcoming_and_ongoing_event_concert_halls*', str(obj().env.ref('website_event.website_snippet_filter_event_list_unfinished').id)
       )}"/>
   </function>
 
   <function name="write" model="ir.ui.view">
-      <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=ref('website.default_website')).viewref('website.contactus').id"/>
+      <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=ref('base.default_website')).viewref('website.contactus').id"/>
       <value model="ir.ui.view" eval="{'arch': obj().env.ref('concert_halls.contactus').arch}"/>
   </function>
 
   <function model="ir.ui.view" name="write">
-        <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('website.default_website').id).viewref('website.template_footer_centered').id"/>
+        <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('base.default_website').id).viewref('website.template_footer_centered').id"/>
         <value model="ir.ui.view" eval="{
             'arch': obj().env.ref('concert_halls.customfooter_view').arch,
             'active': True
@@ -81,11 +81,11 @@
 
   <data noupdate="1">
       <function name="write" model="website.menu">
-          <value model="website.menu" eval="obj().search([('url', '=', '/contactus'), ('website_id', '=', ref('website.default_website'))], limit=1).id"/>
+          <value model="website.menu" eval="obj().search([('url', '=', '/contactus'), ('website_id', '=', ref('base.default_website'))], limit=1).id"/>
           <value eval="{'name': 'Contact'}"/>
       </function>
       <function model="website.menu" name="unlink">
-          <value model="website.menu" eval="obj().search([('website_id', '=', ref('website.default_website')), ('url', '=', '/shop')], limit=1).id"/>
+          <value model="website.menu" eval="obj().search([('website_id', '=', ref('base.default_website')), ('url', '=', '/shop')], limit=1).id"/>
       </function>
   </data>
 </odoo>

--- a/concert_halls/demo/website_view.xml
+++ b/concert_halls/demo/website_view.xml
@@ -65,7 +65,7 @@
     <field name="key">website_event.navbar</field>
     <field name="name">Event Navbar</field>
     <field name="type">qweb</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
   </record>
   <record id="ir_ui_view_3471" model="ir.ui.view">
     <field name="arch" type="xml">
@@ -88,13 +88,13 @@
     <field name="mode">extension</field>
     <field name="name">Header Call to Action</field>
     <field name="type">qweb</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
   </record>
   <record id="homepage" model="ir.ui.view">
     <field name="name">Home</field>
     <field name="key">concert_halls.homepage</field>
     <field name="type">qweb</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
     <field name="arch" type="xml">
       <t name="Homepage" t-name="website.homepage">
         <t t-call="website.layout" pageName.f="homepage">
@@ -287,7 +287,7 @@
     <field name="key">concert_halls.contactus</field>
     <field name="type">qweb</field>
     <field name="active" eval="True"/>
-    <field name="website_id" ref="website.default_website" />
+    <field name="website_id" ref="base.default_website" />
     <field name="arch" type="xml">
       <t name="Contact Us" t-name="website.contactus">
           <t t-call="website.layout"
@@ -532,7 +532,7 @@
     <field name="key">website_event.index_topbar</field>
     <field name="name">Topbar</field>
     <field name="type">qweb</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
   </record>
   <record id="ir_ui_view_3972" model="ir.ui.view">
     <field name="arch" type="xml">
@@ -552,7 +552,7 @@
     <field name="key">website.record_cover</field>
     <field name="name">record_cover</field>
     <field name="type">qweb</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
   </record>
   <record id="ir_ui_view_3978" model="ir.ui.view">
     <field name="arch" type="xml">
@@ -572,7 +572,7 @@
     <field name="name">About us</field>
     <field name="priority">20</field>
     <field name="type">qweb</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
   </record>
   <record id="ir_ui_view_3981" model="ir.ui.view">
     <field name="arch" type="xml">
@@ -600,7 +600,7 @@
     <field name="name">Quotes</field>
     <field name="priority">60</field>
     <field name="type">qweb</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
   </record>
   <record id="customfooter_view" model="ir.ui.view">
     <field name="name">Centered</field>
@@ -608,7 +608,7 @@
     <field name="inherit_id" ref="website.layout"/>
     <field name="mode">extension</field>
     <field name="type">qweb</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
     <field name="arch" type="xml">
         <data inherit_id="website.layout" name="Centered" active="False">
             <xpath expr="//div[@id='footer']" position="replace">

--- a/corporate_gifts/data/website_menu.xml
+++ b/corporate_gifts/data/website_menu.xml
@@ -2,7 +2,7 @@
 <odoo noupdate="1">
     <function model="website.menu" name="write">
         <value model="website.menu" eval="obj().search([
-            ('website_id', '=', ref('website.default_website')),
+            ('website_id', '=', ref('base.default_website')),
             ('url', '=', '/contactus'),
         ], limit=1).id"/>
         <value eval="{'name': 'Request a Quote'}"/>

--- a/corporate_gifts/data/website_view.xml
+++ b/corporate_gifts/data/website_view.xml
@@ -5,7 +5,7 @@
         <field name="key">corporate_gifts.contactus</field>
         <field name="type">qweb</field>
         <field name="active" eval="True"/>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="arch" type="xml">
             <t name="Contact Us" t-name="website.contactus">
                 <t t-call="website.layout"
@@ -228,7 +228,7 @@
         </field>
     </record>
     <function model="ir.ui.view" name="write">
-        <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('website.default_website').id).viewref('website.contactus').id"/>
+        <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('base.default_website').id).viewref('website.contactus').id"/>
         <value model="ir.ui.view" eval="{'arch': obj().env.ref('corporate_gifts.contactus').arch.replace(
         '*pocket_printing_tag*', str(obj().env.ref('corporate_gifts.crm_tag_2').id)).replace(
         '*back_printing_tag*', str(obj().env.ref('corporate_gifts.crm_tag_3').id)).replace(

--- a/corporate_gifts/demo/ir_attachment_post.xml
+++ b/corporate_gifts/demo/ir_attachment_post.xml
@@ -3,21 +3,21 @@
     <record id="ir_attachment_685" model="ir.attachment" >
         <field name="name">713hUVi4SYL.jpg</field>
         <field name="res_model">crm.lead</field>
-        <field name="website_id" ref="website.default_website" />
+        <field name="website_id" ref="base.default_website" />
         <field name="raw" type="bytes" file="corporate_gifts/static/src/binary/ir_attachment/685-713hUVi4SYL.jpg" />
         <field name="res_id" ref="crm_lead_2" />
     </record>
     <record id="ir_attachment_731" model="ir.attachment" >
         <field name="name">cle-usb.jpg</field>
         <field name="res_model">crm.lead</field>
-        <field name="website_id" ref="website.default_website" />
+        <field name="website_id" ref="base.default_website" />
         <field name="raw" type="bytes" file="corporate_gifts/static/src/binary/ir_attachment/731-cle-usb.jpg" />
         <field name="res_id" ref="crm_lead_3" />
     </record>
     <record id="ir_attachment_738" model="ir.attachment" >
         <field name="name">porte-cle.jpg</field>
         <field name="res_model">project.task</field>
-        <field name="website_id" ref="website.default_website" />
+        <field name="website_id" ref="base.default_website" />
         <field name="raw" type="bytes" file="corporate_gifts/static/src/binary/ir_attachment/738-porte-cle.jpg" />
         <field name="res_id" model="project.task" eval="obj().env.ref('corporate_gifts.sale_order_line_48').task_id.id"/>
     </record>

--- a/corporate_gifts/demo/sale_order.xml
+++ b/corporate_gifts/demo/sale_order.xml
@@ -9,7 +9,7 @@
     </record>
     <record id="sale_order_4" model="sale.order">
         <field name="partner_id" ref="base.partner_admin"/>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="user_id" ref="base.user_admin"/>
     </record>
 </odoo>

--- a/corporate_gifts/demo/website.xml
+++ b/corporate_gifts/demo/website.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-    <record id="website.default_website" model="website"  forcecreate="1">
+    <record id="base.default_website" model="website"  forcecreate="1">
         <field name="name">industry-marketing-swag</field>
         <field name="theme_id" search="[('id', '=', ref('base.module_theme_enark', raise_if_not_found=False))]"/>
         <field name="logo" type="bytes" file="corporate_gifts/static/description/icon.png"/>

--- a/corporate_gifts/demo/website_ir_attachment.xml
+++ b/corporate_gifts/demo/website_ir_attachment.xml
@@ -2,257 +2,257 @@
 <odoo noupdate="1">
     <record id="ir_attachment_427" model="ir.attachment" >
         <field name="name">unsplash_A77QfVfNA8Y_t-shirts.jpg</field>
-        <field name="website_id" ref="website.default_website" />
+        <field name="website_id" ref="base.default_website" />
         <field name="public" eval="True"/>
         <field name="raw" type="bytes" file="corporate_gifts/static/src/binary/ir_attachment/427-unsplash_A77QfVfNA8Y_t-shirts.jpg" />
     </record>
     <record id="ir_attachment_428" model="ir.attachment" >
         <field name="name">unsplash_A77QfVfNA8Y_t-shirts.jpg</field>
-        <field name="website_id" ref="website.default_website" />
+        <field name="website_id" ref="base.default_website" />
         <field name="public" eval="True"/>
         <field name="raw" type="bytes" file="corporate_gifts/static/src/binary/ir_attachment/428-unsplash_A77QfVfNA8Y_t-shirts.jpg" />
     </record>
     <record id="ir_attachment_542" model="ir.attachment" >
         <field name="name">TW043_I_BC_millenial-pink_04.jpg</field>
-        <field name="website_id" ref="website.default_website" />
+        <field name="website_id" ref="base.default_website" />
         <field name="public" eval="True"/>
         <field name="raw" type="bytes" file="corporate_gifts/static/src/binary/ir_attachment/542-TW043_I_BC_millenial-pink_04.jpg" />
     </record>
     <record id="configurator_1_library_image_02" model="ir.attachment" >
         <field name="name">website.library_image_02</field>
         <field name="key">website.library_image_02</field>
-        <field name="website_id" ref="website.default_website" />
+        <field name="website_id" ref="base.default_website" />
         <field name="public" eval="True"/>
         <field name="raw" type="bytes" file="corporate_gifts/static/src/binary/ir_attachment/411-website.library_image_02" />
     </record>
     <record id="configurator_1_library_image_03" model="ir.attachment" >
         <field name="name">website.library_image_03</field>
         <field name="key">website.library_image_03</field>
-        <field name="website_id" ref="website.default_website" />
+        <field name="website_id" ref="base.default_website" />
         <field name="public" eval="True"/>
         <field name="raw" type="bytes" file="corporate_gifts/static/src/binary/ir_attachment/404-website.library_image_03" />
     </record>
     <record id="configurator_1_library_image_05" model="ir.attachment" >
         <field name="name">website.library_image_05</field>
         <field name="key">website.library_image_05</field>
-        <field name="website_id" ref="website.default_website" />
+        <field name="website_id" ref="base.default_website" />
         <field name="public" eval="True"/>
         <field name="raw" type="bytes" file="corporate_gifts/static/src/binary/ir_attachment/407-website.library_image_05" />
     </record>
     <record id="configurator_1_library_image_08" model="ir.attachment" >
         <field name="name">website.library_image_08</field>
         <field name="key">website.library_image_08</field>
-        <field name="website_id" ref="website.default_website" />
+        <field name="website_id" ref="base.default_website" />
         <field name="public" eval="True"/>
         <field name="raw" type="bytes" file="corporate_gifts/static/src/binary/ir_attachment/410-website.library_image_08" />
     </record>
     <record id="configurator_1_library_image_10" model="ir.attachment" >
         <field name="name">website.library_image_10</field>
         <field name="key">website.library_image_10</field>
-        <field name="website_id" ref="website.default_website" />
+        <field name="website_id" ref="base.default_website" />
         <field name="public" eval="True"/>
         <field name="raw" type="bytes" file="corporate_gifts/static/src/binary/ir_attachment/405-website.library_image_10" />
     </record>
     <record id="configurator_1_library_image_13" model="ir.attachment" >
         <field name="name">website.library_image_13</field>
         <field name="key">website.library_image_13</field>
-        <field name="website_id" ref="website.default_website" />
+        <field name="website_id" ref="base.default_website" />
         <field name="public" eval="True"/>
         <field name="raw" type="bytes" file="corporate_gifts/static/src/binary/ir_attachment/406-website.library_image_13" />
     </record>
     <record id="configurator_1_library_image_14" model="ir.attachment" >
         <field name="name">website.library_image_14</field>
         <field name="key">website.library_image_14</field>
-        <field name="website_id" ref="website.default_website" />
+        <field name="website_id" ref="base.default_website" />
         <field name="public" eval="True"/>
         <field name="raw" type="bytes" file="corporate_gifts/static/src/binary/ir_attachment/408-website.library_image_14" />
     </record>
     <record id="configurator_1_library_image_16" model="ir.attachment" >
         <field name="name">website.library_image_16</field>
         <field name="key">website.library_image_16</field>
-        <field name="website_id" ref="website.default_website" />
+        <field name="website_id" ref="base.default_website" />
         <field name="public" eval="True"/>
         <field name="raw" type="bytes" file="corporate_gifts/static/src/binary/ir_attachment/409-website.library_image_16" />
     </record>
     <record id="configurator_1_s_banner_default_image" model="ir.attachment" >
         <field name="name">website.s_banner_default_image</field>
         <field name="key">website.s_banner_default_image</field>
-        <field name="website_id" ref="website.default_website" />
+        <field name="website_id" ref="base.default_website" />
         <field name="public" eval="True"/>
         <field name="raw" type="bytes" file="corporate_gifts/static/src/binary/ir_attachment/388-website.s_banner_default_image" />
     </record>
     <record id="configurator_1_s_carousel_default_image_1" model="ir.attachment" >
         <field name="name">website.s_carousel_default_image_1</field>
         <field name="key">website.s_carousel_default_image_1</field>
-        <field name="website_id" ref="website.default_website" />
+        <field name="website_id" ref="base.default_website" />
         <field name="public" eval="True"/>
         <field name="raw" type="bytes" file="corporate_gifts/static/src/binary/ir_attachment/385-website.s_carousel_default_image_1" />
     </record>
     <record id="configurator_1_s_carousel_default_image_2" model="ir.attachment" >
         <field name="name">website.s_carousel_default_image_2</field>
         <field name="key">website.s_carousel_default_image_2</field>
-        <field name="website_id" ref="website.default_website" />
+        <field name="website_id" ref="base.default_website" />
         <field name="public" eval="True"/>
         <field name="raw" type="bytes" file="corporate_gifts/static/src/binary/ir_attachment/386-website.s_carousel_default_image_2" />
     </record>
     <record id="configurator_1_s_carousel_default_image_3" model="ir.attachment" >
         <field name="name">website.s_carousel_default_image_3</field>
         <field name="key">website.s_carousel_default_image_3</field>
-        <field name="website_id" ref="website.default_website" />
+        <field name="website_id" ref="base.default_website" />
         <field name="public" eval="True"/>
         <field name="raw" type="bytes" file="corporate_gifts/static/src/binary/ir_attachment/387-website.s_carousel_default_image_3" />
     </record>
     <record id="configurator_1_s_cover_default_image" model="ir.attachment" >
         <field name="name">website.s_cover_default_image</field>
         <field name="key">website.s_cover_default_image</field>
-        <field name="website_id" ref="website.default_website" />
+        <field name="website_id" ref="base.default_website" />
         <field name="public" eval="True"/>
         <field name="raw" type="bytes" file="corporate_gifts/static/src/binary/ir_attachment/378-website.s_cover_default_image" />
     </record>
     <record id="configurator_1_s_image_text_default_image" model="ir.attachment" >
         <field name="name">website.s_image_text_default_image</field>
         <field name="key">website.s_image_text_default_image</field>
-        <field name="website_id" ref="website.default_website" />
+        <field name="website_id" ref="base.default_website" />
         <field name="public" eval="True"/>
         <field name="raw" type="bytes" file="corporate_gifts/static/src/binary/ir_attachment/398-website.s_image_text_default_image" />
     </record>
     <record id="configurator_1_s_masonry_block_default_image_1" model="ir.attachment" >
         <field name="name">website.s_masonry_block_default_image_1</field>
         <field name="key">website.s_masonry_block_default_image_1</field>
-        <field name="website_id" ref="website.default_website" />
+        <field name="website_id" ref="base.default_website" />
         <field name="public" eval="True"/>
         <field name="raw" type="bytes" file="corporate_gifts/static/src/binary/ir_attachment/379-website.s_masonry_block_default_image_1" />
     </record>
     <record id="configurator_1_s_media_list_default_image_1" model="ir.attachment" >
         <field name="name">website.s_media_list_default_image_1</field>
         <field name="key">website.s_media_list_default_image_1</field>
-        <field name="website_id" ref="website.default_website" />
+        <field name="website_id" ref="base.default_website" />
         <field name="public" eval="True"/>
         <field name="raw" type="bytes" file="corporate_gifts/static/src/binary/ir_attachment/380-website.s_media_list_default_image_1" />
     </record>
     <record id="configurator_1_s_media_list_default_image_2" model="ir.attachment" >
         <field name="name">website.s_media_list_default_image_2</field>
         <field name="key">website.s_media_list_default_image_2</field>
-        <field name="website_id" ref="website.default_website" />
+        <field name="website_id" ref="base.default_website" />
         <field name="public" eval="True"/>
         <field name="raw" type="bytes" file="corporate_gifts/static/src/binary/ir_attachment/381-website.s_media_list_default_image_2" />
     </record>
     <record id="configurator_1_s_media_list_default_image_3" model="ir.attachment" >
         <field name="name">website.s_media_list_default_image_3</field>
         <field name="key">website.s_media_list_default_image_3</field>
-        <field name="website_id" ref="website.default_website" />
+        <field name="website_id" ref="base.default_website" />
         <field name="public" eval="True"/>
         <field name="raw" type="bytes" file="corporate_gifts/static/src/binary/ir_attachment/382-website.s_media_list_default_image_3" />
     </record>
     <record id="configurator_1_s_parallax_default_image" model="ir.attachment" >
         <field name="name">website.s_parallax_default_image</field>
         <field name="key">website.s_parallax_default_image</field>
-        <field name="website_id" ref="website.default_website" />
+        <field name="website_id" ref="base.default_website" />
         <field name="public" eval="True"/>
         <field name="raw" type="bytes" file="corporate_gifts/static/src/binary/ir_attachment/389-website.s_parallax_default_image" />
     </record>
     <record id="configurator_1_s_picture_default_image" model="ir.attachment" >
         <field name="name">website.s_picture_default_image</field>
         <field name="key">website.s_picture_default_image</field>
-        <field name="website_id" ref="website.default_website" />
+        <field name="website_id" ref="base.default_website" />
         <field name="public" eval="True"/>
         <field name="raw" type="bytes" file="corporate_gifts/static/src/binary/ir_attachment/397-website.s_picture_default_image" />
     </record>
     <record id="configurator_1_s_product_catalog_default_image" model="ir.attachment" >
         <field name="name">website.s_product_catalog_default_image</field>
         <field name="key">website.s_product_catalog_default_image</field>
-        <field name="website_id" ref="website.default_website" />
+        <field name="website_id" ref="base.default_website" />
         <field name="public" eval="True"/>
         <field name="raw" type="bytes" file="corporate_gifts/static/src/binary/ir_attachment/390-website.s_product_catalog_default_image" />
     </record>
     <record id="configurator_1_s_product_list_default_image_1" model="ir.attachment" >
         <field name="name">website.s_product_list_default_image_1</field>
         <field name="key">website.s_product_list_default_image_1</field>
-        <field name="website_id" ref="website.default_website" />
+        <field name="website_id" ref="base.default_website" />
         <field name="public" eval="True"/>
         <field name="raw" type="bytes" file="corporate_gifts/static/src/binary/ir_attachment/391-website.s_product_list_default_image_1" />
     </record>
     <record id="configurator_1_s_product_list_default_image_2" model="ir.attachment" >
         <field name="name">website.s_product_list_default_image_2</field>
         <field name="key">website.s_product_list_default_image_2</field>
-        <field name="website_id" ref="website.default_website" />
+        <field name="website_id" ref="base.default_website" />
         <field name="public" eval="True"/>
         <field name="raw" type="bytes" file="corporate_gifts/static/src/binary/ir_attachment/392-website.s_product_list_default_image_2" />
     </record>
     <record id="configurator_1_s_product_list_default_image_3" model="ir.attachment" >
         <field name="name">website.s_product_list_default_image_3</field>
         <field name="key">website.s_product_list_default_image_3</field>
-        <field name="website_id" ref="website.default_website" />
+        <field name="website_id" ref="base.default_website" />
         <field name="public" eval="True"/>
         <field name="raw" type="bytes" file="corporate_gifts/static/src/binary/ir_attachment/393-website.s_product_list_default_image_3" />
     </record>
     <record id="configurator_1_s_product_list_default_image_4" model="ir.attachment" >
         <field name="name">website.s_product_list_default_image_4</field>
         <field name="key">website.s_product_list_default_image_4</field>
-        <field name="website_id" ref="website.default_website" />
+        <field name="website_id" ref="base.default_website" />
         <field name="public" eval="True"/>
         <field name="raw" type="bytes" file="corporate_gifts/static/src/binary/ir_attachment/394-website.s_product_list_default_image_4" />
     </record>
     <record id="configurator_1_s_product_list_default_image_5" model="ir.attachment" >
         <field name="name">website.s_product_list_default_image_5</field>
         <field name="key">website.s_product_list_default_image_5</field>
-        <field name="website_id" ref="website.default_website" />
+        <field name="website_id" ref="base.default_website" />
         <field name="public" eval="True"/>
         <field name="raw" type="bytes" file="corporate_gifts/static/src/binary/ir_attachment/395-website.s_product_list_default_image_5" />
     </record>
     <record id="configurator_1_s_product_list_default_image_6" model="ir.attachment" >
         <field name="name">website.s_product_list_default_image_6</field>
         <field name="key">website.s_product_list_default_image_6</field>
-        <field name="website_id" ref="website.default_website" />
+        <field name="website_id" ref="base.default_website" />
         <field name="public" eval="True"/>
         <field name="raw" type="bytes" file="corporate_gifts/static/src/binary/ir_attachment/396-website.s_product_list_default_image_6" />
     </record>
     <record id="configurator_1_s_quotes_carousel_demo_image_0" model="ir.attachment" >
         <field name="name">website.s_quotes_carousel_demo_image_0</field>
         <field name="key">website.s_quotes_carousel_demo_image_0</field>
-        <field name="website_id" ref="website.default_website" />
+        <field name="website_id" ref="base.default_website" />
         <field name="public" eval="True"/>
         <field name="raw" type="bytes" file="corporate_gifts/static/src/binary/ir_attachment/403-website.s_quotes_carousel_demo_image_0" />
     </record>
     <record id="configurator_1_s_quotes_carousel_demo_image_1" model="ir.attachment" >
         <field name="name">website.s_quotes_carousel_demo_image_1</field>
         <field name="key">website.s_quotes_carousel_demo_image_1</field>
-        <field name="website_id" ref="website.default_website" />
+        <field name="website_id" ref="base.default_website" />
         <field name="public" eval="True"/>
         <field name="raw" type="bytes" file="corporate_gifts/static/src/binary/ir_attachment/383-website.s_quotes_carousel_demo_image_1" />
     </record>
     <record id="configurator_1_s_quotes_carousel_demo_image_2" model="ir.attachment" >
         <field name="name">website.s_quotes_carousel_demo_image_2</field>
         <field name="key">website.s_quotes_carousel_demo_image_2</field>
-        <field name="website_id" ref="website.default_website" />
+        <field name="website_id" ref="base.default_website" />
         <field name="public" eval="True"/>
         <field name="raw" type="bytes" file="corporate_gifts/static/src/binary/ir_attachment/384-website.s_quotes_carousel_demo_image_2" />
     </record>
     <record id="configurator_1_s_text_image_default_image" model="ir.attachment" >
         <field name="name">website.s_text_image_default_image</field>
         <field name="key">website.s_text_image_default_image</field>
-        <field name="website_id" ref="website.default_website" />
+        <field name="website_id" ref="base.default_website" />
         <field name="public" eval="True"/>
         <field name="raw" type="bytes" file="corporate_gifts/static/src/binary/ir_attachment/399-website.s_text_image_default_image" />
     </record>
     <record id="configurator_1_s_three_columns_default_image_1" model="ir.attachment" >
         <field name="name">website.s_three_columns_default_image_1</field>
         <field name="key">website.s_three_columns_default_image_1</field>
-        <field name="website_id" ref="website.default_website" />
+        <field name="website_id" ref="base.default_website" />
         <field name="public" eval="True"/>
         <field name="raw" type="bytes" file="corporate_gifts/static/src/binary/ir_attachment/400-website.s_three_columns_default_image_1" />
     </record>
     <record id="configurator_1_s_three_columns_default_image_2" model="ir.attachment" >
         <field name="name">website.s_three_columns_default_image_2</field>
         <field name="key">website.s_three_columns_default_image_2</field>
-        <field name="website_id" ref="website.default_website" />
+        <field name="website_id" ref="base.default_website" />
         <field name="public" eval="True"/>
         <field name="raw" type="bytes" file="corporate_gifts/static/src/binary/ir_attachment/401-website.s_three_columns_default_image_2" />
     </record>
     <record id="configurator_1_s_three_columns_default_image_3" model="ir.attachment" >
         <field name="name">website.s_three_columns_default_image_3</field>
         <field name="key">website.s_three_columns_default_image_3</field>
-        <field name="website_id" ref="website.default_website" />
+        <field name="website_id" ref="base.default_website" />
         <field name="public" eval="True"/>
         <field name="raw" type="bytes" file="corporate_gifts/static/src/binary/ir_attachment/402-website.s_three_columns_default_image_3" />
     </record>

--- a/corporate_gifts/demo/website_menu.xml
+++ b/corporate_gifts/demo/website_menu.xml
@@ -3,11 +3,11 @@
     <record id="website_menu_11" model="website.menu" >
         <field name="name">Services</field>
         <field name="sequence">30</field>
-        <field name="website_id" ref="website.default_website" />
+        <field name="website_id" ref="base.default_website" />
         <field name="url">/our-services</field>
         <field name="page_id" ref="website_page_5" />
         <field name="parent_id" model="website.menu" eval="obj().search([
-                ('website_id', '=', ref('website.default_website')),
+                ('website_id', '=', ref('base.default_website')),
                 ('url', '=', '#'),
         ], limit=1).id"/>
     </record>

--- a/corporate_gifts/demo/website_page.xml
+++ b/corporate_gifts/demo/website_page.xml
@@ -2,7 +2,7 @@
 <odoo noupdate="1">
     <record id="website_page_5" model="website.page" >
         <field name="view_id" ref="services"/>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="url">/our-services</field>
         <field name="is_published" eval="True"/>
     </record>

--- a/corporate_gifts/demo/website_theme_apply.xml
+++ b/corporate_gifts/demo/website_theme_apply.xml
@@ -2,7 +2,7 @@
 <odoo>
     <function name="button_choose_theme" model="ir.module.module" eval="[ref('base.module_theme_enark', raise_if_not_found=False) or ref('base.module_theme_default')]"/>
 
-    <function model="website.assets" name="make_scss_customization" context="{'website_id': ref('website.default_website')}">
+    <function model="website.assets" name="make_scss_customization" context="{'website_id': ref('base.default_website')}">
         <value eval="'/website/static/src/scss/options/colors/user_color_palette.scss'"/>
         <value eval="{
                 'o-color-1': '#0A58CA',
@@ -20,7 +20,7 @@
     </function>
 
     <function model="ir.ui.view" name="write">
-        <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('website.default_website').id).viewref('website.homepage').ids"/>
+        <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('base.default_website').id).viewref('website.homepage').ids"/>
         <value model="ir.ui.view" eval="{'arch': obj().env.ref('corporate_gifts.homepage').arch.replace(
             '*filter_newest_products_corporate_gifts*', str(obj().env.ref('website_sale.dynamic_filter_newest_products').id)
         )}"/>

--- a/corporate_gifts/demo/website_view.xml
+++ b/corporate_gifts/demo/website_view.xml
@@ -4,7 +4,7 @@
         <field name="name">Home</field>
         <field name="key">corporate_gifts.homepage</field>
         <field name="type">qweb</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="arch" type="xml">
             <t name="Homepage" t-name="website.homepage">
                 <t t-call="website.layout" pageName.f="homepage">
@@ -91,7 +91,7 @@
         <field name="name">Services</field>
         <field name="key">corporate_gifts.services</field>
         <field name="type">qweb</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="arch" type="xml">
             <t name="Services" t-name="website.services">
                 <t t-call="website.layout">

--- a/cosmetics_store/data/product_pricelist.xml
+++ b/cosmetics_store/data/product_pricelist.xml
@@ -2,7 +2,7 @@
 <odoo noupdate="1">
   <record id="product_pricelist_1" model="product.pricelist">
     <field name="name">Website Default Pricelist</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
   </record>
   <record id="product_pricelist_2" model="product.pricelist">
     <field name="name">Reseller</field>

--- a/cosmetics_store/demo/sale_order.xml
+++ b/cosmetics_store/demo/sale_order.xml
@@ -5,23 +5,23 @@
     <field name="user_id" ref="base.user_admin"/>
     <field name="partner_shipping_id" ref="base.main_partner"/>
     <field name="carrier_id" ref="website_sale_collect.carrier_pick_up_in_store"/>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
   </record>
   <record id="sale_order_4" model="sale.order">
     <field name="partner_id" ref="res_partner_20"/>
     <field name="user_id" ref="base.user_admin"/>
     <field name="carrier_id" ref="delivery.free_delivery_carrier"/>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
   </record>
   <record id="sale_order_2" model="sale.order">
     <field name="partner_id" ref="base.partner_admin"/>
     <field name="user_id" ref="base.user_admin"/>
     <field name="carrier_id" ref="delivery.free_delivery_carrier"/>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
   </record>
   <record id="sale_order_1" model="sale.order">
     <field name="partner_id" ref="base.partner_admin"/>
     <field name="user_id" ref="base.user_admin"/>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
   </record>
 </odoo>

--- a/cosmetics_store/demo/website.xml
+++ b/cosmetics_store/demo/website.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-  <record id="website.default_website" model="website" forcecreate="1">
+  <record id="base.default_website" model="website" forcecreate="1">
     <field name="name">Cosmetics Store</field>
     <field name="configurator_done" eval="True"/>
     <field name="logo" type="bytes" file="cosmetics_store/static/src/binary/website/1-logo"/>

--- a/cosmetics_store/demo/website_theme_apply.xml
+++ b/cosmetics_store/demo/website_theme_apply.xml
@@ -4,14 +4,14 @@
   <function name="button_choose_theme" model="ir.module.module" eval="[ref('base.module_theme_treehouse', raise_if_not_found=False) or ref('base.module_theme_default')]"/>
 
   <function model="ir.ui.view" name="write">
-    <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('website.default_website').id).viewref('website.homepage').id"/>
+    <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('base.default_website').id).viewref('website.homepage').id"/>
     <value model="ir.ui.view" eval="{'arch': obj().env.ref('cosmetics_store.ir_ui_view_2258').arch.replace(
       '*filter_newest_products_cosmetics_store*', str(obj().env.ref('website_sale.dynamic_filter_newest_products').id)
     )}"/>
   </function>
 
   <function model="ir.ui.view" name="write">
-    <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=ref('website.default_website')).viewref('website.footer_custom').id"/>
+    <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=ref('base.default_website')).viewref('website.footer_custom').id"/>
     <value eval="{'active': False}"/>
   </function>
 

--- a/cosmetics_store/demo/website_view.xml
+++ b/cosmetics_store/demo/website_view.xml
@@ -146,6 +146,6 @@
     <field name="key">cosmetics_store.homepage</field>
     <field name="name">Home</field>
     <field name="type">qweb</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
   </record>
 </odoo>

--- a/coworking/demo/sale_order.xml
+++ b/coworking/demo/sale_order.xml
@@ -5,7 +5,7 @@
     <field name="partner_id" ref="base_industry_data.res_partner_29"/>
     <field name="carrier_id" ref="delivery.free_delivery_carrier"/>
     <field name="starred_user_ids" eval="[(6, 0, [ref('base.user_admin')])]"/>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
   </record>
   <record id="sale_order_11" model="sale.order">
     <field name="user_id" ref="base.user_admin"/>
@@ -18,7 +18,7 @@
     <field name="user_id" ref="base.user_admin"/>
     <field name="partner_id" ref="base_industry_data.res_partner_29"/>
     <field name="starred_user_ids" eval="[(6, 0, [ref('base.user_admin')])]"/>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
   </record>
   <record id="sale_order_8" model="sale.order">
     <field name="user_id" ref="base.user_admin"/>

--- a/coworking/demo/website.xml
+++ b/coworking/demo/website.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-  <record id="website.default_website" model="website" forcecreate="1">
+  <record id="base.default_website" model="website" forcecreate="1">
     <field name="name">Coworking Spaces </field>
     <field name="configurator_done" eval="True"/>
     <field name="user_id" ref="base.public_user"/>

--- a/coworking/demo/website_menu.xml
+++ b/coworking/demo/website_menu.xml
@@ -1,22 +1,22 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo auto_sequence="1" noupdate="1">
   <function model="website.menu" name="unlink">
-      <value model="website.menu" eval="obj().search([('website_id', '=', ref('website.default_website')), ('url', '=', '#')]).ids" />
+      <value model="website.menu" eval="obj().search([('website_id', '=', ref('base.default_website')), ('url', '=', '#')]).ids" />
   </function>
   <record id="website_menu_4" model="website.menu">
     <field name="name">Top Menu for Website 1</field>
-    <field name="website_id" ref="website.default_website" />
+    <field name="website_id" ref="base.default_website" />
   </record>
   <record id="website_menu_5" model="website.menu">
     <field name="name">Home</field>
     <field name="page_id" ref="website_page_4"/>
     <field name="url">/</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
     <field name="parent_id" ref="website_menu_4"/>
   </record>
   <record id="website_menu_16" model="website.menu">
     <field name="name">My Coworking</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
     <field name="parent_id" ref="website_menu_4" />
     <field name="group_ids" eval="[(6, 0, [ref('website.group_website_restricted_editor'), ref('website.group_website_designer'), ref('base.group_portal')])]"/>
   </record>
@@ -24,14 +24,14 @@
     <field name="name">My Coworking</field>
     <field name="page_id" ref="website_page_8"/>
     <field name="url">/my-cowork</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
     <field name="parent_id" ref="website_menu_16"/>
     <field name="group_ids" eval="[(6, 0, [ref('website.group_website_restricted_editor'), ref('website.group_website_designer'), ref('base.group_portal')])]"/>
   </record>
   <record id="website_menu_7" model="website.menu">
     <field name="name">Book a meeting room</field>
     <field name="url" eval="'/appointment/%s' % ref('coworking.appointment_type_3')"/>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
     <field name="parent_id" ref="website_menu_16"/>
     <field name="group_ids" eval="[(6, 0, [ref('website.group_website_restricted_editor'), ref('website.group_website_designer'), ref('base.group_portal')])]"/>
   </record>
@@ -39,33 +39,33 @@
     <field name="name">Community</field>
     <field name="page_id" ref="website_page_6"/>
     <field name="url">/about-us</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
     <field name="parent_id" ref="website_menu_4" />
   </record>
   <record id="website_menu_13" model="website.menu">
     <field name="name">Coworking Events</field>
     <field name="url">/event</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
     <field name="parent_id" ref="website_menu_16"/>
     <field name="group_ids" eval="[(6, 0, [ref('website.group_website_restricted_editor'), ref('website.group_website_designer'), ref('base.group_portal')])]"/>
   </record>
   <record id="website_menu_12" model="website.menu">
     <field name="name">Issue at the Coworking?</field>
     <field name="url" eval="'/helpdesk/%s' % ref('helpdesk.helpdesk_team1')"/>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
     <field name="parent_id" ref="website_menu_16"/>
     <field name="group_ids" eval="[(6, 0, [ref('website.group_website_restricted_editor'), ref('website.group_website_designer'), ref('base.group_portal')])]"/>
   </record>
   <record id="website_menu_15" model="website.menu">
     <field name="name">Book a free tour</field>
     <field name="url" eval="'/appointment/%s' % ref('coworking.appointment_type_2')"/>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
     <field name="parent_id" ref="website_menu_4" />
   </record>
   <record id="website_menu_6" model="website.menu">
     <field name="name">Contact us</field>
     <field name="url">/become-a-member</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
     <field name="parent_id" ref="website_menu_4"/>
   </record>
 </odoo>

--- a/coworking/demo/website_page.xml
+++ b/coworking/demo/website_page.xml
@@ -2,25 +2,25 @@
 <odoo noupdate="1">
   <record id="website_page_4" model="website.page">
     <field name="view_id" ref="homepage"/>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
     <field name="is_published" eval="True"/>
     <field name="url">/</field>
   </record>
   <record id="website_page_10" model="website.page">
     <field name="view_id" ref="ir_ui_view_4210"/>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
     <field name="is_published" eval="True"/>
     <field name="url">/become-a-member</field>
   </record>
   <record id="website_page_6" model="website.page">
     <field name="view_id" ref="ir_ui_view_3304"/>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
     <field name="is_published" eval="True"/>
     <field name="url">/about-us</field>
   </record>
   <record id="website_page_8" model="website.page">
     <field name="view_id" ref="ir_ui_view_4092"/>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
     <field name="is_published" eval="True"/>
     <field name="url">/my-cowork</field>
   </record>

--- a/coworking/demo/website_theme_apply.xml
+++ b/coworking/demo/website_theme_apply.xml
@@ -2,7 +2,7 @@
 <odoo>
   <function name="button_choose_theme" model="ir.module.module" eval="[ref('base.module_theme_artists', raise_if_not_found=False) or ref('base.module_theme_default')]"/>
 
-  <function model="website.assets" name="make_scss_customization" context="{'website_id': ref('website.default_website')}">
+  <function model="website.assets" name="make_scss_customization" context="{'website_id': ref('base.default_website')}">
     <value eval="'/website/static/src/scss/options/colors/user_color_palette.scss'"/>
     <value eval="{'menu': 2}"/>
   </function>
@@ -51,7 +51,7 @@
   </function>
 
   <function model="ir.ui.view" name="write">
-    <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('website.default_website').id).viewref('website.homepage').id"/>
+    <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('base.default_website').id).viewref('website.homepage').id"/>
     <value model="ir.ui.view" eval="{'arch': obj().env.ref('coworking.homepage').arch.replace(
         '*free_tour_appointment_type*', str(obj().env.ref('coworking.appointment_type_2').id)).replace(
         '*one_day_pass_product*', str(obj().env.ref('coworking.product_product_11').website_url)).replace(
@@ -60,12 +60,12 @@
   </function>
 
   <function name="write" model="ir.ui.view">
-    <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=ref('website.default_website')).viewref('website.contactus').id"/>
+    <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=ref('base.default_website')).viewref('website.contactus').id"/>
     <value model="ir.ui.view" eval="{'arch': obj().env.ref('coworking.ir_ui_view_4210').arch}"/>
   </function>
 
   <function model="ir.ui.view" name="write">
-    <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('website.default_website').id).viewref('website.template_footer_centered').id"/>
+    <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('base.default_website').id).viewref('website.template_footer_centered').id"/>
     <value model="ir.ui.view" eval="{'arch': obj().env.ref('coworking.ir_ui_view_3303').arch}"/>
   </function>
 

--- a/coworking/demo/website_view.xml
+++ b/coworking/demo/website_view.xml
@@ -143,7 +143,7 @@
     <field name="key">website.about-us</field>
     <field name="name">About Us</field>
     <field name="type">qweb</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
   </record>
   <record id="ir_ui_view_3303" model="ir.ui.view">
     <field name="arch" type="xml">
@@ -197,13 +197,13 @@
     <field name="mode">extension</field>
     <field name="name">Centered</field>
     <field name="type">qweb</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
   </record>
   <record id="homepage" model="ir.ui.view">
     <field name="name">Home</field>
     <field name="key">coworking.homepage</field>
     <field name="type">qweb</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
     <field name="arch" type="xml">
       <t name="Homepage" t-name="website.homepage">
         <t t-call="website.layout" pageName.f="homepage">
@@ -498,7 +498,7 @@
     <field name="key">website.contactus_433adc</field>
     <field name="name">Member/Business Address</field>
     <field name="type">qweb</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
   </record>
   <record id="ir_ui_view_4092" model="ir.ui.view">
     <field name="arch" type="xml">
@@ -625,6 +625,6 @@
     <field name="key">website.my-cowork</field>
     <field name="name">My CoWork</field>
     <field name="type">qweb</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
   </record>
 </odoo>

--- a/custom_industrial_equipment/demo/website.xml
+++ b/custom_industrial_equipment/demo/website.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-  <record id="website.default_website" model="website" forcecreate="1">
+  <record id="base.default_website" model="website" forcecreate="1">
     <field name="name">Custom Industrial Equipment</field>
     <field name="configurator_done" eval="True"/>
     <field name="logo" type="bytes" file="custom_industrial_equipment/static/description/icon.png"/>

--- a/custom_industrial_equipment/demo/website_theme_apply.xml
+++ b/custom_industrial_equipment/demo/website_theme_apply.xml
@@ -55,15 +55,15 @@
   </function>
 
   <function model="ir.ui.view" name="write">
-    <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('website.default_website').id).viewref('website.homepage').id"/>
+    <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('base.default_website').id).viewref('website.homepage').id"/>
     <value model="ir.ui.view" eval="{'arch': obj().env.ref('custom_industrial_equipment.homepage').arch}"/>
   </function>
   <function model="ir.ui.view" name="write">
-    <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('website.default_website').id).viewref('website.contactus').id"/>
+    <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('base.default_website').id).viewref('website.contactus').id"/>
     <value model="ir.ui.view" eval="{'arch': obj().env.ref('custom_industrial_equipment.contactus').arch}"/>
   </function>
   <function model="ir.ui.view" name="write">
-    <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('website.default_website').id).viewref('website.footer_custom').id" />
+    <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('base.default_website').id).viewref('website.footer_custom').id" />
     <value model="ir.ui.view" eval="{'arch': obj().env.ref('custom_industrial_equipment.customfooter_view').arch}" />
   </function>
 </odoo>

--- a/custom_industrial_equipment/demo/website_view.xml
+++ b/custom_industrial_equipment/demo/website_view.xml
@@ -218,7 +218,7 @@
     <field name="key">custom_industrial_equipment.contactus</field>
     <field name="name">Contact Us</field>
     <field name="type">qweb</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
   </record>
   <record id="homepage" model="ir.ui.view">
     <field name="arch" type="xml">
@@ -418,7 +418,7 @@
     <field name="key">custom_industrial_equipment.homepage</field>
     <field name="name">Home</field>
     <field name="type">qweb</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
   </record>
   <record id="customfooter_view" model="ir.ui.view">
       <field name="name">Contact</field>
@@ -426,7 +426,7 @@
       <field name="inherit_id" ref="website.layout"/>
       <field name="mode">extension</field>
       <field name="type">qweb</field>
-      <field name="website_id" ref="website.default_website"/>
+      <field name="website_id" ref="base.default_website"/>
       <field name="arch" type="xml">
         <data inherit_id="website.layout" name="Contact" active="True">
           <xpath expr="//div[@id='footer']" position="replace">

--- a/diy_workshops/data/website_menu.xml
+++ b/diy_workshops/data/website_menu.xml
@@ -2,7 +2,7 @@
 <odoo>
     <data noupdate="1">
         <function model="website.menu" name="write">
-        <value model="website.menu" eval="obj().search([ ('website_id', '=', ref('website.default_website')),('url', '=', '/event')], limit=1).id" />
+        <value model="website.menu" eval="obj().search([ ('website_id', '=', ref('base.default_website')),('url', '=', '/event')], limit=1).id" />
         <value eval="{'name': 'Workshops'}" />
         </function>
   </data>

--- a/diy_workshops/demo/product_pricelist.xml
+++ b/diy_workshops/demo/product_pricelist.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
   <record id="product_pricelist_1" model="product.pricelist">
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
   </record>
 </odoo>

--- a/diy_workshops/demo/website.xml
+++ b/diy_workshops/demo/website.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-  <record id="website.default_website" model="website" forcecreate="1">
+  <record id="base.default_website" model="website" forcecreate="1">
     <field name="name">My Website</field>
     <field name="configurator_done" eval="True"/>
     <field name="logo" type="bytes" file="diy_workshops/static/description/icon.png"/>

--- a/diy_workshops/demo/website_theme_apply.xml
+++ b/diy_workshops/demo/website_theme_apply.xml
@@ -5,7 +5,7 @@
   <!-- <function model="theme.utils" name="enable_view" eval="['website.template_header_vertical']"/> -->
 
   <function model="ir.ui.view" name="write">
-    <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('website.default_website').id).viewref('website.homepage').id" />
+    <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('base.default_website').id).viewref('website.homepage').id" />
     <value model="ir.ui.view" eval="{'arch': obj().env.ref('diy_workshops.homepage').arch.replace(
         '*sew_your_first_tote_bag_event*', str(obj().env.ref('diy_workshops.event_event_1').website_url)).replace(
         '*sewing_for_kids_event*', str(obj().env.ref('diy_workshops.event_event_2').website_url)).replace(
@@ -16,11 +16,11 @@
     }" />
   </function>
   <function model="ir.ui.view" name="write">
-    <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('website.default_website').id).viewref('website.template_footer_descriptive').id" />
+    <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('base.default_website').id).viewref('website.template_footer_descriptive').id" />
     <value model="ir.ui.view" eval="{'arch': obj().env.ref('diy_workshops.ir_ui_view_3984').arch}" />
   </function>
   <function name="write" model="ir.ui.view">
-    <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=ref('website.default_website')).viewref('website.contactus').id"/>
+    <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=ref('base.default_website')).viewref('website.contactus').id"/>
     <value model="ir.ui.view" eval="{'arch': obj().env.ref('diy_workshops.contactus').arch}"/>
   </function>
 
@@ -64,7 +64,7 @@
     <function model="website.menu" name="unlink">
       <value model="website.menu"
         eval="obj().search([
-        ('website_id', '=', ref('website.default_website')),
+        ('website_id', '=', ref('base.default_website')),
         ('url', '=', '/shop'),
         ]).ids" />
     </function>

--- a/diy_workshops/demo/website_view.xml
+++ b/diy_workshops/demo/website_view.xml
@@ -4,7 +4,7 @@
     <field name="key">diy_workshops.contactus</field>
     <field name="name">Contact Us</field>
     <field name="type">qweb</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
     <field name="arch" type="xml">
       <t name="Contact Us" t-name="website.contactus">
         <t t-call="website.layout"
@@ -125,7 +125,7 @@
     <field name="mode">extension</field>
     <field name="name">Descriptive</field>
     <field name="type">qweb</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
     <field name="arch" type="xml">
       <data inherit_id="website.layout" name="Descriptive" active="False">
         <xpath expr="//div[@id='footer']" position="replace">
@@ -187,7 +187,7 @@
     <field name="mode">extension</field>
     <field name="name">Header Call to Action</field>
     <field name="type">qweb</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
     <field name="arch" type="xml">
       <data inherit_id="website.placeholder_header_call_to_action" name="Header Call to Action" active="True">
         <xpath expr="." position="inside">
@@ -210,7 +210,7 @@
     <field name="mode">extension</field>
     <field name="name">Header Text element</field>
     <field name="type">qweb</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
     <field name="arch" type="xml">
       <data inherit_id="website.placeholder_header_text_element" name="Header Text element" active="True">
         <xpath expr="." position="inside">
@@ -283,7 +283,7 @@
     <field name="key">diy_workshops.homepage</field>
     <field name="name">Home</field>
     <field name="type">qweb</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
     <field name="arch" type="xml">
       <t name="Homepage" t-name="website.homepage">
         <t t-call="website.layout" pageName.f="homepage">

--- a/driving_school/demo/website.xml
+++ b/driving_school/demo/website.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-  <record id="website.default_website" model="website" forcecreate="1">
+  <record id="base.default_website" model="website" forcecreate="1">
     <field name="name">Driving-School</field>
     <field name="configurator_done" eval="True"/>
     <field name="logo" type="bytes" file="driving_school/static/description/icon.png"/>

--- a/driving_school/demo/website_page.xml
+++ b/driving_school/demo/website_page.xml
@@ -2,7 +2,7 @@
 <odoo noupdate="1">
   <record id="website_page_4" model="website.page">
     <field name="view_id" ref="homepage"/>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
     <field name="is_published" eval="True"/>
     <field name="url">/</field>
   </record>

--- a/driving_school/demo/website_theme_apply.xml
+++ b/driving_school/demo/website_theme_apply.xml
@@ -39,12 +39,12 @@
   </function>
 
   <function model="ir.ui.view" name="write">
-    <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('website.default_website').id).viewref('website.homepage').id"/>
+    <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('base.default_website').id).viewref('website.homepage').id"/>
     <value model="ir.ui.view" eval="{'arch': obj().env.ref('driving_school.homepage').arch}"/>
   </function>
 
   <function name="write" model="ir.ui.view">
-    <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=ref('website.default_website')).viewref('website.contactus').id"/>
+    <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=ref('base.default_website')).viewref('website.contactus').id"/>
     <value model="ir.ui.view" eval="{'arch': obj().env.ref('driving_school.contactus').arch}"/>
   </function>
 
@@ -55,7 +55,7 @@
 
   <data noupdate="1">
     <function model="website.menu" name="unlink">
-      <value model="website.menu" search="[('website_id', '=', ref('website.default_website')), ('url', '=', '/appointment')]"/>
+      <value model="website.menu" search="[('website_id', '=', ref('base.default_website')), ('url', '=', '/appointment')]"/>
     </function>
   </data>
 

--- a/driving_school/demo/website_view.xml
+++ b/driving_school/demo/website_view.xml
@@ -21,13 +21,13 @@
     <field name="mode">extension</field>
     <field name="name">Header Call to Action</field>
     <field name="type">qweb</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
   </record>
   <record id="homepage" model="ir.ui.view">
     <field name="name">Home</field>
     <field name="key">driving_school.homepage</field>
     <field name="type">qweb</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
     <field name="arch" type="xml">
       <t name="Homepage" t-name="website.homepage">
         <t t-call="website.layout" pageName.f="homepage">
@@ -327,7 +327,7 @@
         <field name="key">driving_school.contactus</field>
         <field name="type">qweb</field>
         <field name="active" eval="True"/>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="arch" type="xml">
             <t name="Contact Us" t-name="website.contactus">
                 <t t-call="website.layout"

--- a/dropshipping/demo/sale_order.xml
+++ b/dropshipping/demo/sale_order.xml
@@ -4,18 +4,18 @@
     <field name="partner_id" ref="base.partner_admin"/>
     <field name="user_id" ref="base.user_admin"/>
     <field name="carrier_id" ref="delivery.free_delivery_carrier"/>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
   </record>
   <record id="sale_order_2" model="sale.order">
     <field name="partner_id" ref="base_industry_data.res_users_7_res_partner"/>
     <field name="user_id" ref="base.user_admin"/>
     <field name="carrier_id" ref="delivery.free_delivery_carrier"/>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
   </record>
   <record id="sale_order_1" model="sale.order">
     <field name="partner_id" ref="base_industry_data.res_users_7_res_partner"/>
     <field name="user_id" ref="base.user_admin"/>
     <field name="carrier_id" ref="delivery.free_delivery_carrier"/>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
   </record>
 </odoo>

--- a/dropshipping/demo/website.xml
+++ b/dropshipping/demo/website.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-  <record id="website.default_website" model="website" forcecreate="1">
+  <record id="base.default_website" model="website" forcecreate="1">
     <field name="name">Phone Cases</field>
     <field name="configurator_done" eval="True"/>
     <field name="logo" type="bytes" file="dropshipping/static/description/icon.png"/>

--- a/dropshipping/demo/website_menu.xml
+++ b/dropshipping/demo/website_menu.xml
@@ -3,28 +3,28 @@
   <record id="website_menu_4" model="website.menu">
     <field name="name">Top Menu for Website 1</field>
     <field name="sequence" eval="False"/>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
   </record>
   <record id="website_menu_5" model="website.menu">
     <field name="name">Home</field>
     <field name="page_id" ref="website_page_4"/>
     <field name="url">/</field>
     <field name="sequence">10</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
     <field name="parent_id" ref="website_menu_4"/>
   </record>
   <record id="website_menu_9" model="website.menu">
     <field name="name">Shop</field>
     <field name="url">/shop</field>
     <field name="sequence">15</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
     <field name="parent_id" ref="website_menu_4"/>
   </record>
   <record id="website_menu_6" model="website.menu">
     <field name="name">Contact us</field>
     <field name="page_id" ref="website.contactus_page"/>
     <field name="url">/contactus</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
     <field name="parent_id" ref="website_menu_4"/>
   </record>
 </odoo>

--- a/dropshipping/demo/website_page.xml
+++ b/dropshipping/demo/website_page.xml
@@ -2,7 +2,7 @@
 <odoo noupdate="1">
   <record id="website_page_4" model="website.page">
     <field name="view_id" ref="ir_ui_view_1661"/>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
     <field name="is_published" eval="True"/>
     <field name="url">/</field>
   </record>

--- a/dropshipping/demo/website_theme_apply.xml
+++ b/dropshipping/demo/website_theme_apply.xml
@@ -3,11 +3,11 @@
   <function name="button_choose_theme" model="ir.module.module" eval="[ref('base.module_theme_buzzy', raise_if_not_found=False) or ref('base.module_theme_default')]"/>
 
   <function model="ir.ui.view" name="write">
-    <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('website.default_website').id).viewref('website.homepage').id"/>
+    <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('base.default_website').id).viewref('website.homepage').id"/>
     <value model="ir.ui.view" eval="{'arch': obj().env.ref('dropshipping.ir_ui_view_1661').arch}"/>
   </function>
   <function model="ir.ui.view" name="write">
-    <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('website.default_website').id).viewref('website.template_footer_headline').id"/>
+    <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('base.default_website').id).viewref('website.template_footer_headline').id"/>
     <value model="ir.ui.view" eval="{'arch': obj().env.ref('dropshipping.ir_ui_view_3467').arch}"/>
   </function>
   <function model="website.assets" name="make_scss_customization">

--- a/dropshipping/demo/website_view.xml
+++ b/dropshipping/demo/website_view.xml
@@ -87,7 +87,7 @@ Our services are designed for small to medium size companies.</p>
     <field name="mode">extension</field>
     <field name="name">Headline</field>
     <field name="type">qweb</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
   </record>
   <!-- Homepage -->
   <record id="ir_ui_view_1661" model="ir.ui.view">
@@ -409,6 +409,6 @@ Durability meets design—our cases provide the ultimate protection without sacr
     <field name="key">dropshipping.homepage</field>
     <field name="name">Home</field>
     <field name="type">qweb</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
   </record>
 </odoo>

--- a/elearning_platform/demo/sale_order.xml
+++ b/elearning_platform/demo/sale_order.xml
@@ -3,6 +3,6 @@
   <record id="sale_order_40" model="sale.order">
     <field name="partner_id" ref="res_partner_88"/>
     <field name="user_id" ref="base.user_admin"/>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
   </record>
 </odoo>

--- a/elearning_platform/demo/website.xml
+++ b/elearning_platform/demo/website.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-  <record id="website.default_website" model="website" forcecreate="1">
+  <record id="base.default_website" model="website" forcecreate="1">
     <field name="name">elearning-platform</field>
     <field name="configurator_done" eval="True"/>
     <field name="logo" type="bytes" file="elearning_platform/static/description/icon.png"/>

--- a/elearning_platform/demo/website_page.xml
+++ b/elearning_platform/demo/website_page.xml
@@ -5,7 +5,7 @@
     <field name="header_color">#</field>
     <field name="header_text_color">#</field>
     <field name="view_id" ref="homepage"/>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
     <field name="is_published" eval="True"/>
     <field name="url">/</field>
   </record>

--- a/elearning_platform/demo/website_theme_apply.xml
+++ b/elearning_platform/demo/website_theme_apply.xml
@@ -45,7 +45,7 @@
   </function>
 
   <function model="ir.ui.view" name="write">
-    <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('website.default_website').id).viewref('website.homepage').id"/>
+    <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('base.default_website').id).viewref('website.homepage').id"/>
     <value model="ir.ui.view" eval="{'arch': obj().env.ref('elearning_platform.homepage').arch}"/>
   </function>
 
@@ -76,7 +76,7 @@
 
   <data noupdate="1">
     <function model="website.menu" name="unlink">
-        <value model="website.menu" eval="obj().search([('website_id', '=', ref('website.default_website')), ('url', '=', '/shop')]).ids"/>
+        <value model="website.menu" eval="obj().search([('website_id', '=', ref('base.default_website')), ('url', '=', '/shop')]).ids"/>
     </function>
   </data>
 

--- a/elearning_platform/demo/website_view.xml
+++ b/elearning_platform/demo/website_view.xml
@@ -148,13 +148,13 @@
     <field name="key">elearning_platform.homepage</field>
     <field name="name">Home</field>
     <field name="type">qweb</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
   </record>
   <record id="ir_ui_view_3213" model="ir.ui.view">
     <field name="name">Courses Homepage</field>
     <field name="key">website_slides.courses_home</field>
     <field name="type">qweb</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
     <field name="arch" type="xml">
       <t name="Odoo Courses Homepage" t-name="website_slides.courses_home">
         <t t-call="website.layout" body_classname="o_wslides_body">

--- a/electrician/data/res_config_settings.xml
+++ b/electrician/data/res_config_settings.xml
@@ -4,7 +4,6 @@
         <field name="group_product_pricelist" eval="1"/>
         <field name="group_analytic_accounting" eval="1"/>
         <field name="group_sale_order_template" eval="1"/>
-        <field name="company_so_template_id" ref="sale_order_template_1"/>
     </record>
 
     <function name="execute" model="res.config.settings">

--- a/electronic_store/demo/sale_order.xml
+++ b/electronic_store/demo/sale_order.xml
@@ -21,12 +21,12 @@
     </record>
     <record id="sale_order_6" model="sale.order">
         <field name="partner_id" ref="res_partner_25"/>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="user_id" ref="base.user_admin"/>
     </record>
     <record id="sale_order_7" model="sale.order">
         <field name="partner_id" ref="base.public_partner"/>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="user_id" ref="base.user_admin"/>
     </record>
     <record id="sale_order_8" model="sale.order">

--- a/electronic_store/demo/website.xml
+++ b/electronic_store/demo/website.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-    <record id="website.default_website" model="website" forcecreate="1">
+    <record id="base.default_website" model="website" forcecreate="1">
         <field name="name">kb-electronics</field>
         <field name="theme_id" search="[('id', '=', ref('base.module_theme_buzzy', raise_if_not_found=False))]"/>
         <field name="configurator_done" eval="True"/>

--- a/electronic_store/demo/website_ir_attachment.xml
+++ b/electronic_store/demo/website_ir_attachment.xml
@@ -10,7 +10,7 @@
         <field name="name">image.jpg</field>
         <field name="raw" type="bytes" file="electronic_store/static/src/binary/ir_attachment/1524-image.jpg"/>
         <field name="res_model">ir.ui.view</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
     </record>
     <record id="configurator_1_s_banner_default_image" model="ir.attachment">

--- a/electronic_store/demo/website_menu.xml
+++ b/electronic_store/demo/website_menu.xml
@@ -3,20 +3,20 @@
     <record id="website_menu_10" model="website.menu">
         <field name="name">About Us</field>
         <field name="url">/about-us</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="page_id" ref="website_page_6"/>
         <field name="parent_id" model="website.menu" eval="obj().search([
-            ('website_id', '=', ref('website.default_website')),
+            ('website_id', '=', ref('base.default_website')),
             ('url', '=', '#'),
         ], limit=1).id"/>
     </record>
     <record id="website_menu_11" model="website.menu">
         <field name="name">Services</field>
         <field name="url">/our-services</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="page_id" ref="website_page_7"/>
         <field name="parent_id" model="website.menu" eval="obj().search([
-            ('website_id', '=', ref('website.default_website')),
+            ('website_id', '=', ref('base.default_website')),
             ('url', '=', '#'),
         ], limit=1).id"/>
     </record>

--- a/electronic_store/demo/website_page.xml
+++ b/electronic_store/demo/website_page.xml
@@ -4,12 +4,12 @@
         <field name="url">/about-us</field>
         <field name="is_published" eval="True"/>
         <field name="view_id" ref="website_page_about_us_view"/>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
     </record>
     <record id="website_page_7" model="website.page">
         <field name="url">/our-services</field>
         <field name="is_published" eval="True"/>
         <field name="view_id" ref="services"/>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
     </record>
 </odoo>

--- a/electronic_store/demo/website_theme_apply.xml
+++ b/electronic_store/demo/website_theme_apply.xml
@@ -3,11 +3,11 @@
     <function name="button_choose_theme" model="ir.module.module" eval="[ref('base.module_theme_buzzy', raise_if_not_found=False) or ref('base.module_theme_default')]"/>
 
     <function name="write" model="ir.ui.view">
-        <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=ref('website.default_website')).viewref('website.homepage').id"/>
+        <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=ref('base.default_website')).viewref('website.homepage').id"/>
         <value model="ir.ui.view" eval="{'arch': obj().env.ref('electronic_store.homepage').arch}"/>
     </function>
     <function name="write" model="ir.ui.view">
-        <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=ref('website.default_website')).viewref('website.contactus').id"/>
+        <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=ref('base.default_website')).viewref('website.contactus').id"/>
         <value model="ir.ui.view" eval="{'arch': obj().env.ref('electronic_store.contactus').arch.replace(
         '*base_user_admin*', str(obj().env.ref('base.user_admin').id)
         )}"/>
@@ -25,7 +25,7 @@
     
     <data noupdate="1">
         <function name="write" model="website.menu">
-            <value model="website.menu" eval="obj().search([('url', '=', '/helpdesk/customer-care-1'), ('website_id', '=', ref('website.default_website'))], limit=1).id"/>
+            <value model="website.menu" eval="obj().search([('url', '=', '/helpdesk/customer-care-1'), ('website_id', '=', ref('base.default_website'))], limit=1).id"/>
             <value eval="{'sequence': 90}"/>
         </function>
     </data>

--- a/electronic_store/demo/website_view.xml
+++ b/electronic_store/demo/website_view.xml
@@ -30,7 +30,7 @@
         <field name="name">About Us</field>
         <field name="key">website.about-us</field>
         <field name="type">qweb</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="arch" type="xml">
             <t name="About Us" t-name="website.about-us">
                 <t t-call="website.layout">
@@ -71,7 +71,7 @@
         <field name="name">Services</field>
         <field name="type">qweb</field>
         <field name="key">website.services</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="arch" type="xml">
             <t name="Services" t-name="website.services">
                 <t t-call="website.layout">
@@ -236,7 +236,7 @@
         <field name="name">Contact Us</field>
         <field name="key">electronic_store.contactus</field>
         <field name="type">qweb</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="arch" type="xml">
             <t name="Contact Us" t-name="website.contactus">
                 <t t-call="website.layout"
@@ -456,7 +456,7 @@
         <field name="key">website.footer_copyright_company_name</field>
         <field name="mode">extension</field>
         <field name="inherit_id" ref="website.layout"/>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="arch" type="xml">
             <data inherit_id="website.layout">
                 <xpath expr="//footer//span[hasclass('o_footer_copyright_name')]" position="replace">
@@ -469,7 +469,7 @@
         <field name="name">website_helpdesk.team_form_1</field>
         <field name="type">qweb</field>
         <field name="key">website_helpdesk.team_form_1</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="arch" type="xml">
             <t name="Helpdesk: Submit a Ticket Form" t-name="website_helpdesk.ticket_submit_form">
                 <div class="container">
@@ -580,7 +580,7 @@
         <field name="key">website_helpdesk.team_oe_structure_website_helpdesk_team_3</field>
         <field name="mode">extension</field>
         <field name="inherit_id" ref="website_helpdesk.team"/>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="arch" type="xml">
             <data>
                 <xpath expr="//*[hasclass('oe_structure')][@id='oe_structure_website_helpdesk_team_3']" position="replace">

--- a/environmental_agency/data/res_config_settings.xml
+++ b/environmental_agency/data/res_config_settings.xml
@@ -4,7 +4,6 @@
         <field name="group_discount_per_so_line" eval="1"/>
         <field name="group_project_stages" eval="1"/>
         <field name="group_sale_order_template" eval="1"/>
-        <field name="module_sale_pdf_quote_builder" eval="1"/>
     </record>
     <function name="execute" model="res.config.settings" eval="[ref('res_config_settings')]"/>
 </odoo>

--- a/environmental_agency/demo/website.xml
+++ b/environmental_agency/demo/website.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-    <record id="website.default_website" model="website" forcecreate="1">
+    <record id="base.default_website" model="website" forcecreate="1">
         <field name="name">Environmental Agency</field>
         <field name="configurator_done" eval="True"/>
         <field name="logo" type="bytes" file="environmental_agency/static/description/icon.png"/>

--- a/environmental_agency/demo/website_theme_apply.xml
+++ b/environmental_agency/demo/website_theme_apply.xml
@@ -2,20 +2,20 @@
 <odoo>
     <function name="button_choose_theme" model="ir.module.module" eval="[ref('base.module_theme_treehouse', raise_if_not_found=False) or ref('base.module_theme_default')]"/>
 
-    <function name="make_scss_customization" model="website.assets" context="{'website_id': ref('website.default_website')}">
+    <function name="make_scss_customization" model="website.assets" context="{'website_id': ref('base.default_website')}">
         <value eval="'/website/static/src/scss/options/colors/user_color_palette.scss'"/>
         <value eval="{'o-color-1': '#8CB89F','o-color-2': '#ECE4DF','o-color-3': '#FBF8F2','o-color-4': '#FFFFFF','o-color-5': '#43594F','menu': 5}"/>
     </function>
     <function model="ir.ui.view" name="write">
-        <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=ref('website.default_website')).viewref('website.homepage').id"/>
+        <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=ref('base.default_website')).viewref('website.homepage').id"/>
         <value model="ir.ui.view" eval="{'arch': obj().env.ref('environmental_agency.ir_ui_view_3007').arch}"/>
     </function>
     <function model="ir.ui.view" name="write">
-        <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=ref('website.default_website')).viewref('website.template_footer_descriptive').id"/>
+        <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=ref('base.default_website')).viewref('website.template_footer_descriptive').id"/>
         <value model="ir.ui.view" eval="{'arch': obj().env.ref('environmental_agency.ir_ui_view_3082').arch}"/>
     </function>
     <function model="ir.ui.view" name="write">
-        <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=ref('website.default_website')).viewref('website.contactus').id"/>
+        <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=ref('base.default_website')).viewref('website.contactus').id"/>
         <value model="ir.ui.view" eval="{'arch': obj().env.ref('environmental_agency.ir_ui_view_3085').arch}"/>
     </function>
 </odoo>

--- a/escape_rooms/data/website_theme_apply.xml
+++ b/escape_rooms/data/website_theme_apply.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo>
     <function name="write" model="ir.ui.view">
-        <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=ref('website.default_website')).viewref('website.contactus').id"/>
+        <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=ref('base.default_website')).viewref('website.contactus').id"/>
         <value model="ir.ui.view" eval="{'arch': obj().env.ref('escape_rooms.contactus').arch.replace(
         '*reservation_tag*', str(obj().env.ref('escape_rooms.crm_tag_10').id)).replace(
         '*corporate_tag*', str(obj().env.ref('escape_rooms.crm_tag_12').id)).replace(

--- a/escape_rooms/data/website_view.xml
+++ b/escape_rooms/data/website_view.xml
@@ -5,7 +5,7 @@
         <field name="key">escape_rooms.contactus</field>
         <field name="type">qweb</field>
         <field name="active" eval="True"/>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="arch" type="xml">
             <t name="Contact Us" t-name="website.contactus">
                 <t t-call="website.layout"

--- a/escape_rooms/demo/website.xml
+++ b/escape_rooms/demo/website.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-  <record id="website.default_website" model="website" forcecreate="1">
+  <record id="base.default_website" model="website" forcecreate="1">
     <field name="name">Escape Rooms</field>
     <field name="configurator_done" eval="True"/>
     <field name="user_id" ref="base.public_user"/>

--- a/escape_rooms/demo/website_menu.xml
+++ b/escape_rooms/demo/website_menu.xml
@@ -2,21 +2,21 @@
 <odoo auto_sequence="1" noupdate="1">
     <function model="website.menu" name="write">
         <value model="website.menu" eval="obj().search([
-            ('website_id', '=', ref('website.default_website')),
+            ('website_id', '=', ref('base.default_website')),
             ('url', '=', '/contactus'),
         ], limit=1).id"/>
         <value eval="{'name': 'Questions &amp; inquiries'}"/>
     </function>
     <function model="website.menu" name="write">
         <value model="website.menu" eval="obj().search([
-            ('website_id', '=', ref('website.default_website')),
+            ('website_id', '=', ref('base.default_website')),
             ('url', '=', '/shop'),
         ], limit=1).id"/>
         <value eval="{'name': 'Gift Cards'}"/>
     </function>
     <function model="website.menu" name="write">
         <value model="website.menu" eval="obj().search([
-            ('website_id', '=', ref('website.default_website')),
+            ('website_id', '=', ref('base.default_website')),
             ('url', '=', '/appointment'),
         ], limit=1).id"/>
         <value eval="{'name': 'Escape Rooms'}"/>

--- a/escape_rooms/demo/website_page.xml
+++ b/escape_rooms/demo/website_page.xml
@@ -2,13 +2,13 @@
 <odoo noupdate="1">
     <record id="website_page_4" model="website.page">
         <field name="view_id" ref="homepage"/>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="is_published" eval="True"/>
         <field name="url">/</field>
     </record>
     <record id="website_page_6" model="website.page">
         <field name="view_id" ref="contactus"/>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="is_published" eval="True"/>
         <field name="url">/contactus</field>
     </record>

--- a/escape_rooms/demo/website_theme_apply.xml
+++ b/escape_rooms/demo/website_theme_apply.xml
@@ -48,7 +48,7 @@
   </function>
 
   <function model="ir.ui.view" name="write">
-      <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('website.default_website').id).viewref('website.homepage').id"/>
+      <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('base.default_website').id).viewref('website.homepage').id"/>
       <value model="ir.ui.view" eval="{'arch': obj().env.ref('escape_rooms.homepage').arch.replace(
         '*filter_newest_products_escape_rooms*', str(obj().env.ref('website_sale.dynamic_filter_newest_products').id)
       )}"/>

--- a/escape_rooms/demo/website_view.xml
+++ b/escape_rooms/demo/website_view.xml
@@ -75,7 +75,7 @@
     <field name="key">website_appointment.appointments_cards_layout</field>
     <field name="name">Appointment Types</field>
     <field name="type">qweb</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
   </record>
   <record id="ir_ui_view_3723" model="ir.ui.view">
     <field name="arch" type="xml">
@@ -99,7 +99,7 @@
     <field name="mode">extension</field>
     <field name="name">Appointment: Appointment Info</field>
     <field name="type">qweb</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
   </record>
   <record id="ir_ui_view_3247" model="ir.ui.view">
     <field name="arch" type="xml">
@@ -170,7 +170,7 @@
     <field name="mode">extension</field>
     <field name="name">Default</field>
     <field name="type">qweb</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
   </record>
   <record id="ir_ui_view_3755" model="ir.ui.view">
     <field name="arch" type="xml">
@@ -193,7 +193,7 @@
     <field name="mode">extension</field>
     <field name="name">Header Call to Action</field>
     <field name="type">qweb</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
   </record>
   <record id="ir_ui_view_3724" model="ir.ui.view">
     <field name="arch" type="xml">
@@ -218,7 +218,7 @@
     <field name="key">website_sale.header_cart_link</field>
     <field name="name">Header Cart Link</field>
     <field name="type">qweb</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
   </record>
   <record id="ir_ui_view_3754" model="ir.ui.view">
     <field name="arch" type="xml">
@@ -293,13 +293,13 @@
     <field name="mode">extension</field>
     <field name="name">Header Text element</field>
     <field name="type">qweb</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
   </record>
   <record id="homepage" model="ir.ui.view">
     <field name="name">Home</field>
     <field name="key">escape_rooms.homepage</field>
     <field name="type">qweb</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
     <field name="arch" type="xml">
       <t name="Homepage" t-name="website.homepage">
         <t t-call="website.layout" pageName.f="homepage">
@@ -417,6 +417,6 @@
     <field name="key">website_appointment.website_calendar_index_topbar</field>
     <field name="name">Topbar</field>
     <field name="type">qweb</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
   </record>
 </odoo>

--- a/event_management/data/website_theme_apply.xml
+++ b/event_management/data/website_theme_apply.xml
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo>
     <function name="write" model="ir.ui.view">
-        <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=ref('website.default_website')).viewref('website.contactus').id"/>
+        <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=ref('base.default_website')).viewref('website.contactus').id"/>
         <value model="ir.ui.view" eval="{'arch': obj().env.ref('event_management.contactus').arch}"/>
     </function>
     <data noupdate="1">
         <function model="website.menu" name="write">
             <value model="website.menu" eval="obj().search([
-                ('website_id', '=', ref('website.default_website')),
+                ('website_id', '=', ref('base.default_website')),
                 ('url', '=', '/contactus'),
             ], limit=1).id"/>
             <value eval="{'name': 'Get a Quote'}"/>

--- a/event_management/data/website_view.xml
+++ b/event_management/data/website_view.xml
@@ -5,7 +5,7 @@
     <field name="key">event_management.contactus</field>
     <field name="type">qweb</field>
     <field name="active" eval="True"/>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
     <field name="arch" type="xml">
       <t name="Contact Us" t-name="website.contactus">
         <t t-call="website.layout"

--- a/event_management/demo/website.xml
+++ b/event_management/demo/website.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-    <record id="website.default_website" model="website" forcecreate="1">
+    <record id="base.default_website" model="website" forcecreate="1">
         <field name="name">Event Management</field>
         <field name="configurator_done" eval="True"/>
         <field name="logo" type="bytes" file="event_management/static/description/icon.png"/>

--- a/event_management/demo/website_menu.xml
+++ b/event_management/demo/website_menu.xml
@@ -2,11 +2,11 @@
 <odoo noupdate="1">
   <record id="website_menu_4" model="website.menu">
     <field name="name">Top Menu for Website 1</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
   </record>
   <record id="website_menu_9" model="website.menu">
     <field name="name">Jobs</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
     <field name="parent_id" ref="website_menu_4"/>
   </record>
 </odoo>

--- a/event_management/demo/website_theme_apply.xml
+++ b/event_management/demo/website_theme_apply.xml
@@ -3,7 +3,7 @@
 	<function name="button_choose_theme" model="ir.module.module" eval="[ref('base.module_theme_enark', raise_if_not_found=False) or ref('base.module_theme_default')]"/>
 
   <function model="ir.ui.view" name="write">
-    <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('website.default_website').id).viewref('website.homepage').id"/>
+    <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('base.default_website').id).viewref('website.homepage').id"/>
     <value model="ir.ui.view" eval="{'arch': obj().env.ref('event_management.homepage').arch}"/>
   </function>
 
@@ -66,10 +66,10 @@
 
   <data noupdate="1">
     <function model="website.menu" name="unlink">
-      <value model="website.menu" search="[('website_id', '=', ref('website.default_website')), ('url', '=', '/appointment')]"/>
+      <value model="website.menu" search="[('website_id', '=', ref('base.default_website')), ('url', '=', '/appointment')]"/>
     </function>
     <function model="website.menu" name="unlink">
-      <value model="website.menu" search="[('website_id', '=', ref('website.default_website')), ('url', '=', '/shop')]"/>
+      <value model="website.menu" search="[('website_id', '=', ref('base.default_website')), ('url', '=', '/shop')]"/>
     </function>
   </data>
 

--- a/event_management/demo/website_view.xml
+++ b/event_management/demo/website_view.xml
@@ -4,7 +4,7 @@
     <field name="name">Home</field>
     <field name="key">event_management.homepage</field>
     <field name="type">qweb</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
     <field name="arch" type="xml">
       <t name="Homepage" t-name="website.homepage">
         <t t-call="website.layout" pageName.f="homepage">
@@ -217,7 +217,7 @@
     <field name="key">website_hr_recruitment.job_right_side_bar</field>
     <field name="mode">extension</field>
     <field name="type">qweb</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
     <field name="arch" type="xml">
       <data inherit_id="website_hr_recruitment.index" active="True" name="Right Side Bar">
         <xpath expr="//div[@id='jobs_grid']" position="after">

--- a/eyewear_shop/demo/ir_attachment_post.xml
+++ b/eyewear_shop/demo/ir_attachment_post.xml
@@ -4,42 +4,42 @@
     <field name="name">eyewear_shop.s_accordion_image_default_image</field>
     <field name="raw" type="bytes" file="eyewear_shop/static/src/binary/ir_attachment/907-website.s_accordion_image_default_image"/>
     <field name="key">eyewear_shop.s_accordion_image_default_image</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
     <field name="public" eval="True"/>
   </record>
   <record id="configurator_1_s_banner_default_image_2" model="ir.attachment">
     <field name="name">eyewear_shop.s_banner_default_image_2</field>
     <field name="raw" type="bytes" file="eyewear_shop/static/src/binary/ir_attachment/907-website.s_accordion_image_default_image"/>
     <field name="key">eyewear_shop.s_banner_default_image_2</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
     <field name="public" eval="True"/>
   </record>
   <record id="configurator_1_s_image_text_default_image" model="ir.attachment">
     <field name="name">eyewear_shop.s_image_text_default_image</field>
     <field name="raw" type="bytes" file="eyewear_shop/static/src/binary/ir_attachment/907-website.s_accordion_image_default_image"/>
     <field name="key">eyewear_shop.s_image_text_default_image</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
     <field name="public" eval="True"/>
   </record>
   <record id="configurator_1_s_text_image_default_image" model="ir.attachment">
     <field name="name">eyewear_shop.s_text_image_default_image</field>
     <field name="raw" type="bytes" file="eyewear_shop/static/src/binary/ir_attachment/886-website.s_text_image_default_image"/>
     <field name="key">eyewear_shop.s_text_image_default_image</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
     <field name="public" eval="True"/>
   </record>
   <record id="configurator_1_s_parallax_default_image" model="ir.attachment">
     <field name="name">eyewear_shop.s_parallax_default_image</field>
     <field name="raw" type="bytes" file="eyewear_shop/static/src/binary/ir_attachment/876-website.s_parallax_default_image"/>
     <field name="key">eyewear_shop.s_parallax_default_image</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
     <field name="public" eval="True"/>
   </record>
   <record id="ir_attachment_807" model="ir.attachment">
     <field name="name">eyewear_shop.s_color_blocks_2_default_image_2</field>
     <field name="key">eyewear_shop.s_color_blocks_2_default_image_2</field>
     <field name="raw" type="bytes" file="eyewear_shop/static/src/binary/ir_attachment/s_color_blocks_2_default_image_2.jpg"/>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
     <field name="public" eval="True"/>
   </record>
 </odoo>

--- a/eyewear_shop/demo/website.xml
+++ b/eyewear_shop/demo/website.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-  <record id="website.default_website" model="website" forcecreate="1">
+  <record id="base.default_website" model="website" forcecreate="1">
     <field name="name">Eyewear Shop</field>
     <field name="configurator_done" eval="True"/>
     <field name="user_id" ref="base.public_user"/>

--- a/eyewear_shop/demo/website_theme_apply.xml
+++ b/eyewear_shop/demo/website_theme_apply.xml
@@ -2,12 +2,12 @@
 <odoo>
     <function name="button_choose_theme" model="ir.module.module" eval="[ref('base.module_theme_clean', raise_if_not_found=False) or ref('base.module_theme_default')]"/>
 
-    <function name="make_scss_customization" model="website.assets" context="{'website_id': ref('website.default_website')}">
+    <function name="make_scss_customization" model="website.assets" context="{'website_id': ref('base.default_website')}">
         <value eval="'/website/static/src/scss/options/colors/user_color_palette.scss'"/>
         <value eval="{'o-color-1': '#10c3a5','o-color-2': '#40CFB7','o-color-3': '#ECFAF8','o-color-4': '#FFFFFF','o-color-5': '#021815', 'footer': 5, 'copyright': 5}"/>
     </function>
     <function model="ir.ui.view" name="write">
-        <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('website.default_website').id).viewref('website.homepage').id"/>
+        <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('base.default_website').id).viewref('website.homepage').id"/>
         <value model="ir.ui.view" eval="{'arch': obj().env.ref('eyewear_shop.homepage').arch}"/>
     </function>
     <function model="ir.ui.view" name="write">
@@ -18,13 +18,13 @@
         <function model="website.checkout.step" name="write">
             <value model="website.checkout.step" eval="obj().search([
                 ('step_href', '=', '/shop/extra_info'),
-                ('website_id', '=', ref('website.default_website')),
+                ('website_id', '=', ref('base.default_website')),
             ]).ids"/>
             <value eval="{'is_published': True}"/>
         </function>
     </data>
     <function model="ir.ui.view" name="write">
-        <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('website.default_website').id).viewref('website_sale.extra_info').id"/>
+        <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('base.default_website').id).viewref('website_sale.extra_info').id"/>
         <value model="ir.ui.view" eval="{'arch': obj().env.ref('eyewear_shop.ir_ui_view_3549').arch}"/>
     </function>
 </odoo>

--- a/eyewear_shop/demo/website_view.xml
+++ b/eyewear_shop/demo/website_view.xml
@@ -4,7 +4,7 @@
     <field name="name">Contact Us</field>
     <field name="key">eyewear_shop.contactus</field>
     <field name="type">qweb</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
     <field name="arch" type="xml">
       <t name="Contact Us" t-name="website.contactus">
         <t t-call="website.layout"
@@ -132,7 +132,7 @@
     <field name="name">Home</field>
     <field name="key">eyewear_shop.homepage</field>
     <field name="type">qweb</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
     <field name="arch" type="xml">
       <t name="Homepage" t-name="website.homepage">
         <t t-call="website.layout" pageName.f="homepage">
@@ -397,7 +397,7 @@
     <field name="name">Checkout Extra Info</field>
     <field name="key">eyewear_shop.extra_info</field>
     <field name="type">qweb</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
     <field name="arch" type="xml">
       <t name="Checkout Extra Info" active="False" t-name="website_sale.extra_info">
         <t t-set="oe_structure">

--- a/fitness/demo/product_pricelist.xml
+++ b/fitness/demo/product_pricelist.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
     <record id="product_pricelist_1" model="product.pricelist">
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
     </record>
 </odoo>

--- a/fitness/demo/website.xml
+++ b/fitness/demo/website.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-    <record id="website.default_website" model="website" forcecreate="1">
+    <record id="base.default_website" model="website" forcecreate="1">
         <field name="name">Fitness</field>
         <field name="configurator_done" eval="True"/>
         <field name="theme_id" search="[('id', '=', ref('base.module_theme_nano', raise_if_not_found=False))]"/>

--- a/fitness/demo/website_ir_attachment.xml
+++ b/fitness/demo/website_ir_attachment.xml
@@ -4,63 +4,63 @@
         <field name="name">website.library_image_03</field>
         <field name="raw" type="bytes" file="fitness/static/src/binary/ir_attachment/816-website.library_image_03"/>
         <field name="key">website.library_image_03</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
     </record>
     <record id="configurator_1_library_image_05" model="ir.attachment">
         <field name="name">website.library_image_05</field>
         <field name="raw" type="bytes" file="fitness/static/src/binary/ir_attachment/819-website.library_image_05"/>
         <field name="key">website.library_image_05</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
     </record>
     <record id="configurator_1_library_image_10" model="ir.attachment">
         <field name="name">website.library_image_10</field>
         <field name="raw" type="bytes" file="fitness/static/src/binary/ir_attachment/817-website.library_image_10"/>
         <field name="key">website.library_image_10</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
     </record>
     <record id="configurator_1_library_image_13" model="ir.attachment">
         <field name="name">website.library_image_13</field>
         <field name="raw" type="bytes" file="fitness/static/src/binary/ir_attachment/818-website.library_image_13"/>
         <field name="key">website.library_image_13</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
     </record>
     <record id="configurator_1_library_image_14" model="ir.attachment">
         <field name="name">website.library_image_14</field>
         <field name="raw" type="bytes" file="fitness/static/src/binary/ir_attachment/820-website.library_image_14"/>
         <field name="key">website.library_image_14</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
     </record>
     <record id="configurator_1_library_image_16" model="ir.attachment">
         <field name="name">website.library_image_16</field>
         <field name="raw" type="bytes" file="fitness/static/src/binary/ir_attachment/821-website.library_image_16"/>
         <field name="key">website.library_image_16</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
     </record>
     <record id="configurator_1_s_cover_default_image" model="ir.attachment">
         <field name="name">website.s_cover_default_image</field>
         <field name="raw" type="bytes" file="fitness/static/src/binary/ir_attachment/790-website.s_cover_default_image"/>
         <field name="key">website.s_cover_default_image</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
     </record>
     <record id="configurator_1_s_parallax_default_image" model="ir.attachment">
         <field name="name">website.s_parallax_default_image</field>
         <field name="raw" type="bytes" file="fitness/static/src/binary/ir_attachment/801-website.s_parallax_default_image"/>
         <field name="key">website.s_parallax_default_image</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
     </record>
     <record id="configurator_1_s_image_text_default_image" model="ir.attachment">
         <field name="name">website.s_image_text_default_image</field>
         <field name="raw" type="bytes" file="fitness/static/src/binary/ir_attachment/810-website.s_image_text_default_image"/>
         <field name="key">website.s_image_text_default_image</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
     </record>
     <record id="ir_attachment_780" model="ir.attachment">
@@ -69,7 +69,7 @@
         <field name="url">/theme_nano/static/src/img/snippets/s_reference_06.png</field>
         <field name="res_model">ir.ui.view</field>
         <field name="key">website.s_reference_default_image_6</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
     </record>
     <record id="ir_attachment_781" model="ir.attachment">
@@ -78,7 +78,7 @@
         <field name="url">/theme_nano/static/src/img/snippets/s_reference_01.png</field>
         <field name="res_model">ir.ui.view</field>
         <field name="key">website.s_reference_demo_image_1</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
     </record>
     <record id="ir_attachment_782" model="ir.attachment">
@@ -87,7 +87,7 @@
         <field name="url">/theme_nano/static/src/img/snippets/s_reference_02.png</field>
         <field name="res_model">ir.ui.view</field>
         <field name="key">website.s_reference_demo_image_2</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
     </record>
     <record id="ir_attachment_783" model="ir.attachment">
@@ -96,7 +96,7 @@
         <field name="url">/theme_nano/static/src/img/snippets/s_reference_03.png</field>
         <field name="res_model">ir.ui.view</field>
         <field name="key">website.s_reference_demo_image_3</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
     </record>
     <record id="ir_attachment_784" model="ir.attachment">
@@ -105,7 +105,7 @@
         <field name="url">/theme_nano/static/src/img/snippets/s_reference_04.png</field>
         <field name="res_model">ir.ui.view</field>
         <field name="key">website.s_reference_demo_image_4</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
     </record>
     <record id="ir_attachment_785" model="ir.attachment">
@@ -114,7 +114,7 @@
         <field name="url">/theme_nano/static/src/img/snippets/s_reference_05.png</field>
         <field name="res_model">ir.ui.view</field>
         <field name="key">website.s_reference_demo_image_5</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
     </record>
 </odoo>

--- a/fitness/demo/website_menu.xml
+++ b/fitness/demo/website_menu.xml
@@ -3,22 +3,22 @@
     <record id="website_menu_11" model="website.menu">
         <field name="name">About Us</field>
         <field name="url">/about-us</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="sequence">50</field>
         <field name="page_id" ref="website_page_5"/>
         <field name="parent_id" model="website.menu" eval="obj().search([
-                ('website_id', '=', ref('website.default_website')),
+                ('website_id', '=', ref('base.default_website')),
                 ('url', '=', '#'),
         ], limit=1).id"/>
     </record>
     <record id="website_menu_12" model="website.menu">
         <field name="name">Pricing</field>
         <field name="url">/pricing</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="sequence">35</field>
         <field name="page_id" ref="website_page_6"/>
         <field name="parent_id" model="website.menu" eval="obj().search([
-                ('website_id', '=', ref('website.default_website')),
+                ('website_id', '=', ref('base.default_website')),
                 ('url', '=', '#'),
         ], limit=1).id"/>
     </record>

--- a/fitness/demo/website_page.xml
+++ b/fitness/demo/website_page.xml
@@ -3,19 +3,19 @@
     <record id="website_page_4" model="website.page">
         <field name="view_id" ref="homepage"/>
         <field name="is_published" eval="True"/>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="url">/</field>
     </record>
     <record id="website_page_5" model="website.page">
         <field name="view_id" ref="aboutus"/>
         <field name="is_published" eval="True"/>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="url">/about-us</field>
     </record>
     <record id="website_page_6" model="website.page">
         <field name="view_id" ref="pricing"/>
         <field name="is_published" eval="True"/>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="url">/pricing</field>
     </record>
 </odoo>

--- a/fitness/demo/website_theme_apply.xml
+++ b/fitness/demo/website_theme_apply.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo>
     <function name="write" model="ir.ui.view">
-        <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('website.default_website').id).viewref('website.homepage').id"/>
+        <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('base.default_website').id).viewref('website.homepage').id"/>
         <value model="ir.ui.view" eval="{'arch': obj().env.ref('fitness.homepage').arch}"/>
     </function>
     <function model="ir.ui.view" name="write">

--- a/fitness/demo/website_view.xml
+++ b/fitness/demo/website_view.xml
@@ -3,7 +3,7 @@
     <record id="homepage" model="ir.ui.view">
         <field name="name">Home</field>
         <field name="key">fitness.homepage</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="type">qweb</field>
         <field name="arch" type="xml">
             <t name="Homepage" t-name="website.homepage">
@@ -112,7 +112,7 @@
     <record id="aboutus" model="ir.ui.view">
         <field name="name">About Us</field>
         <field name="key">fitness.about-us</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="type">qweb</field>
         <field name="arch" type="xml">
             <t name="About Us" t-name="website.about-us">
@@ -227,7 +227,7 @@
     <record id="pricing" model="ir.ui.view">
         <field name="name">Pricing</field>
         <field name="key">fitness.pricing-1</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="type">qweb</field>
         <field name="arch" type="xml">
             <t name="Pricing" t-name="website.pricing-1">

--- a/florist/data/website_theme_apply.xml
+++ b/florist/data/website_theme_apply.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo>
     <function model="ir.ui.view" name="write">
-        <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('website.default_website').id).viewref('website.contactus').id"/>
+        <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('base.default_website').id).viewref('website.contactus').id"/>
         <value model="ir.ui.view" eval="{'arch': obj().env.ref('florist.contactus').arch}"/>
     </function>
 </odoo>

--- a/florist/data/website_view.xml
+++ b/florist/data/website_view.xml
@@ -113,6 +113,6 @@
     <field name="name">Contact Us</field>
     <field name="type">qweb</field>
     <field name="active" eval="True"/>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
   </record>
 </odoo>

--- a/florist/demo/website.xml
+++ b/florist/demo/website.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-  <record id="website.default_website" model="website" forcecreate="1">
+  <record id="base.default_website" model="website" forcecreate="1">
     <field name="name">Florist</field>
     <field name="theme_id" search="[('id', '=', ref('base.module_theme_orchid', raise_if_not_found=False))]"/>
     <field name="configurator_done" eval="True"/>

--- a/florist/demo/website_theme_apply.xml
+++ b/florist/demo/website_theme_apply.xml
@@ -2,7 +2,7 @@
 <odoo>
   <function name="button_choose_theme" model="ir.module.module" eval="[ref('base.module_theme_orchid', raise_if_not_found=False) or ref('base.module_theme_default')]"/>
 
-  <function model="website.assets" name="make_scss_customization" context="{'website_id': ref('website.default_website')}">
+  <function model="website.assets" name="make_scss_customization" context="{'website_id': ref('base.default_website')}">
     <value eval="'/website/static/src/scss/options/user_values.scss'"/>
     <value eval="{
       'menu-gradient': 'null',
@@ -38,7 +38,7 @@
   </function>
 
   <function model="ir.ui.view" name="write">
-    <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('website.default_website').id).viewref('website.homepage').id"/>
+    <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('base.default_website').id).viewref('website.homepage').id"/>
     <value model="ir.ui.view" eval="{'arch': obj().env.ref('florist.homepage').arch}"/>
   </function>
 </odoo>

--- a/florist/demo/website_view.xml
+++ b/florist/demo/website_view.xml
@@ -60,7 +60,7 @@
     <field name="mode">extension</field>
     <field name="name">Descriptive</field>
     <field name="type">qweb</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
   </record>
   <record id="ir_ui_view_3596" model="ir.ui.view">
     <field name="arch" type="xml">
@@ -133,13 +133,13 @@
     <field name="mode">extension</field>
     <field name="name">Header Text element</field>
     <field name="type">qweb</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
   </record>
   <record id="homepage" model="ir.ui.view">
     <field name="name">Home</field>
     <field name="key">florist.homepage</field>
     <field name="type">qweb</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
     <field name="arch" type="xml">
       <t name="Homepage" t-name="website.homepage">
         <t t-call="website.layout" pageName.f="homepage">
@@ -293,7 +293,7 @@
     </field>
   </record>
   <function model="ir.ui.view" name="write">
-    <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('website.default_website').id).viewref('website.template_footer_descriptive').id"/>
+    <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('base.default_website').id).viewref('website.template_footer_descriptive').id"/>
     <value model="ir.ui.view" eval="{'arch': obj().env.ref('florist.ir_ui_view_3407').arch}"/>
   </function>
 </odoo>

--- a/furniture_store/demo/sale_order.xml
+++ b/furniture_store/demo/sale_order.xml
@@ -3,11 +3,11 @@
   <record id="sale_order_3" model="sale.order">
     <field name="partner_id" ref="base_industry_data.res_partner_28"/>
     <field name="user_id" ref="base.user_admin"/>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
   </record>
   <record id="sale_order_2" model="sale.order">
     <field name="partner_id" ref="base.partner_admin"/>
     <field name="user_id" ref="base.user_admin"/>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
   </record>
 </odoo>

--- a/furniture_store/demo/website.xml
+++ b/furniture_store/demo/website.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-    <record id="website.default_website" model="website" forcecreate="1">
+    <record id="base.default_website" model="website" forcecreate="1">
         <field name="name">Furniture Store</field>
         <field name="configurator_done" eval="True" />
         <field name="logo" type="bytes" file="furniture_store/static/description/icon.png" />

--- a/furniture_store/demo/website_view.xml
+++ b/furniture_store/demo/website_view.xml
@@ -286,7 +286,7 @@
         <field name="key">furniture_store.contactus</field>
         <field name="name">Contact Us</field>
         <field name="type">qweb</field>
-        <field name="website_id" ref="website.default_website" />
+        <field name="website_id" ref="base.default_website" />
     </record>
     <record id="ir_ui_view_3955" model="ir.ui.view">
         <field name="arch" type="xml">
@@ -371,7 +371,7 @@
         <field name="mode">extension</field>
         <field name="name">Header Text element</field>
         <field name="type">qweb</field>
-        <field name="website_id" ref="website.default_website" />
+        <field name="website_id" ref="base.default_website" />
     </record>
     <record id="ir_ui_view_2244" model="ir.ui.view">
         <field name="arch" type="xml">
@@ -715,14 +715,14 @@
         <field name="key">website.homepage</field>
         <field name="name">Home</field>
         <field name="type">qweb</field>
-        <field name="website_id" ref="website.default_website" />
+        <field name="website_id" ref="base.default_website" />
     </record>
     <record id="ir_ui_view_thumbnails_design" model="ir.ui.view">
         <field name="name">Thumbnails Design</field>
         <field name="key">website_sale.products_design_thumbs</field>
         <field name="inherit_id" ref="website_sale.products"/>
         <field name="mode">extension</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="type">qweb</field>
         <field name="arch" type="xml">
         <xpath expr="//section[@id='o_wsale_products_grid']" position="attributes">
@@ -735,7 +735,7 @@
         <field name="key">website_sale.products_thumb_4_5</field>
         <field name="inherit_id" ref="website_sale.products"/>
         <field name="mode">extension</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="type">qweb</field>
         <field name="arch" type="xml">
         <xpath expr="//section[@id='o_wsale_products_grid']" position="attributes">
@@ -745,7 +745,7 @@
     </record>
     <function model="ir.ui.view" name="write">
         <value model="ir.ui.view"
-            eval="obj().env['website'].with_context(website_id=obj().env.ref('website.default_website').id).viewref('website.homepage').id" />
+            eval="obj().env['website'].with_context(website_id=obj().env.ref('base.default_website').id).viewref('website.homepage').id" />
         <value model="ir.ui.view"
             eval="{'arch': obj().env.ref('furniture_store.ir_ui_view_2244').arch.replace(
                 '*filter_newest_products_furniture_store*', str(obj().env.ref('website_sale.dynamic_filter_newest_products').id)
@@ -753,7 +753,7 @@
     </function>
     <function model="ir.ui.view" name="write">
         <value model="ir.ui.view"
-            eval="obj().env['website'].with_context(website_id=obj().env.ref('website.default_website').id).viewref('website.contactus').id" />
+            eval="obj().env['website'].with_context(website_id=obj().env.ref('base.default_website').id).viewref('website.contactus').id" />
         <value model="ir.ui.view"
             eval="{'arch': obj().env.ref('furniture_store.ir_ui_view_3972').arch}" />
     </function>

--- a/gallery/__manifest__.py
+++ b/gallery/__manifest__.py
@@ -10,7 +10,7 @@
         'pos_stock',
         'sale_purchase_project',
         'sign',
-        'website_event_sale'
+        'website_event_sale',
     ],
     'data': [
         'data/crm_stage.xml',

--- a/gallery/demo/website.xml
+++ b/gallery/demo/website.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-  <record id="website.default_website" model="website" forcecreate="1">
+  <record id="base.default_website" model="website" forcecreate="1">
     <field name="name">My Gallery</field>
     <field name="configurator_done" eval="True"/>
     <field name="logo" type="bytes" file="gallery/static/description/icon.png"/>

--- a/gallery/demo/website_menu.xml
+++ b/gallery/demo/website_menu.xml
@@ -3,13 +3,13 @@
   <record id="website_menu_4" model="website.menu">
     <field name="name">Top Menu for Website 1</field>
     <field name="sequence" eval="False"/>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
   </record>
   <record id="website_menu_13" model="website.menu">
     <field name="name">Contact Us</field>
     <field name="page_id" ref="website_page_6"/>
     <field name="url">/contactus</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
     <field name="parent_id" ref="website_menu_4"/>
   </record>
 </odoo>

--- a/gallery/demo/website_page.xml
+++ b/gallery/demo/website_page.xml
@@ -2,7 +2,7 @@
 <odoo noupdate="1">
   <record id="website_page_6" model="website.page">
     <field name="view_id" ref="ir_ui_view_3577"/>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
     <field name="is_published" eval="True"/>
     <field name="url">/contactus</field>
   </record>

--- a/gallery/demo/website_theme_apply.xml
+++ b/gallery/demo/website_theme_apply.xml
@@ -3,7 +3,7 @@
   <function name="button_choose_theme" model="ir.module.module" eval="[ref('base.module_theme_nano', raise_if_not_found=False) or ref('base.module_theme_default')]"/>
 
   <function model="ir.ui.view" name="write">
-    <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('website.default_website').id).viewref('website.homepage').id"/>
+    <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('base.default_website').id).viewref('website.homepage').id"/>
     <value model="ir.ui.view" eval="{'arch': obj().env.ref('gallery.ir_ui_view_1680').arch.replace(
         '*salvation_product*', str(obj().env.ref('gallery.product_template_10').website_url)).replace(
         '*mountain_view_product*', str(obj().env.ref('gallery.product_template_14').website_url)).replace(
@@ -12,31 +12,31 @@
     }"/>
   </function>
   <function model="ir.ui.view" name="write">
-    <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('website.default_website').id).viewref('website.template_footer_descriptive').id"/>
+    <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('base.default_website').id).viewref('website.template_footer_descriptive').id"/>
     <value model="ir.ui.view" eval="{'arch': obj().env.ref('gallery.ir_ui_view_3549').arch}"/>
   </function>
   <function name="write" model="ir.ui.view">
-    <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=ref('website.default_website')).viewref('website_sale.search').id"/>
+    <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=ref('base.default_website')).viewref('website_sale.search').id"/>
     <value model="ir.ui.view" eval="{'active': False}"/>
   </function>
   <function name="write" model="ir.ui.view">
-    <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=ref('website.default_website')).viewref('website_sale.products_categories').id"/>
+    <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=ref('base.default_website')).viewref('website_sale.products_categories').id"/>
     <value model="ir.ui.view" eval="{'active': False}"/>
   </function>
   <function name="write" model="ir.ui.view">
-    <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=ref('website.default_website')).viewref('website_sale.products_categories_top').id"/>
+    <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=ref('base.default_website')).viewref('website_sale.products_categories_top').id"/>
     <value model="ir.ui.view" eval="{'active': True}"/>
   </function>
   <function name="write" model="ir.ui.view">
-    <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=ref('website.default_website')).viewref('website_sale.products_attributes').id"/>
+    <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=ref('base.default_website')).viewref('website_sale.products_attributes').id"/>
     <value model="ir.ui.view" eval="{'active': False}"/>
   </function>
   <function name="write" model="ir.ui.view">
-    <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=ref('website.default_website')).viewref('website_sale.products_attributes_top').id"/>
+    <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=ref('base.default_website')).viewref('website_sale.products_attributes_top').id"/>
     <value model="ir.ui.view" eval="{'active': True}"/>
   </function>
   <function name="write" model="ir.ui.view">
-    <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=ref('website.default_website')).viewref('website_sale.sort').id"/>
+    <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=ref('base.default_website')).viewref('website_sale.sort').id"/>
     <value model="ir.ui.view" eval="{'active': False}"/>
   </function>
   <function model="website.assets" name="make_scss_customization">
@@ -83,7 +83,7 @@
   <data noupdate="1">
     <function model="website.menu" name="write">
       <value model="website.menu" eval="obj().search([
-              ('website_id', '=', ref('website.default_website')),
+              ('website_id', '=', ref('base.default_website')),
               ('url', '=', '/shop'),
           ], limit=1).id"/>
       <value eval="{'name': 'Collections'}"/>

--- a/gallery/demo/website_view.xml
+++ b/gallery/demo/website_view.xml
@@ -170,7 +170,7 @@
     <field name="key">gallery.contactus</field>
     <field name="name">Contact Us</field>
     <field name="type">qweb</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
   </record>
   <record id="ir_ui_view_3549" model="ir.ui.view">
     <field name="arch" type="xml">
@@ -185,7 +185,7 @@
     <field name="mode">extension</field>
     <field name="name">Descriptive</field>
     <field name="type">qweb</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
   </record>
   <record id="ir_ui_view_1680" model="ir.ui.view">
     <field name="arch" type="xml">
@@ -367,7 +367,7 @@
     <field name="key">gallery.homepage</field>
     <field name="name">Home</field>
     <field name="type">qweb</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
   </record>
   <record id="ir_ui_view_4086" model="ir.ui.view">
     <field name="arch" type="xml">
@@ -382,7 +382,7 @@
     <field name="name">Topbar</field>
     <field name="mode">extension</field>
     <field name="type">qweb</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
   </record>
   <record id="ir_ui_view_3576" model="ir.ui.view">
     <field name="arch" type="xml">
@@ -397,7 +397,7 @@
     <field name="mode">extension</field>
     <field name="name">footer_copyright_company_name</field>
     <field name="type">qweb</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
   </record>
   <record id="ir_ui_view_4085" model="ir.ui.view">
     <field name="arch" type="xml">
@@ -417,7 +417,7 @@
     <field name="key">gallery.record_cover</field>
     <field name="name">record_cover</field>
     <field name="type">qweb</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
   </record>
   <record id="ir_ui_view_3574" model="ir.ui.view">
     <field name="arch" type="xml">
@@ -437,7 +437,7 @@
     <field name="name">Share Buttons</field>
     <field name="priority">22</field>
     <field name="type">qweb</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
   </record>
   <function model="ir.model.fields" name="formbuilder_whitelist">
       <value eval="'crm.lead'" />

--- a/guest_house/demo/website.xml
+++ b/guest_house/demo/website.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-  <record id="website.default_website" model="website" forcecreate="1">
+  <record id="base.default_website" model="website" forcecreate="1">
     <field name="name">guest_house</field>
     <field name="configurator_done" eval="True"/>
     <field name="favicon" type="bytes" file="guest_house/static/description/icon.png"/>

--- a/guest_house/demo/website_theme_apply.xml
+++ b/guest_house/demo/website_theme_apply.xml
@@ -2,12 +2,12 @@
 <odoo>
   <function name="button_choose_theme" model="ir.module.module" eval="[ref('base.module_theme_notes', raise_if_not_found=False) or ref('base.module_theme_default')]"/>
     
-  <function name="make_scss_customization" model="website.assets" context="{'website_id': ref('website.default_website')}">
+  <function name="make_scss_customization" model="website.assets" context="{'website_id': ref('base.default_website')}">
     <value eval="'/website/static/src/scss/options/colors/user_color_palette.scss'"/>
     <value eval="{'o-color-1': '#F7CB74','o-color-2': '#629A7C','o-color-3': '#FBFBFB','o-color-4': '#FFFFFF','o-color-5': '#43594F', 'menu': 1}"/>
   </function>
   <function name="write" model="ir.ui.view">
-    <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=ref('website.default_website')).viewref('website.homepage').id"/>
+    <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=ref('base.default_website')).viewref('website.homepage').id"/>
     <value model="ir.ui.view" eval="{'arch': obj().env.ref('guest_house.homepage').arch.replace(
       '*filter_newest_products_guest_house*', str(obj().env.ref('website_sale.dynamic_filter_newest_products').id)
     )}"/>

--- a/guest_house/demo/website_view.xml
+++ b/guest_house/demo/website_view.xml
@@ -151,11 +151,11 @@
     <field name="key">guest_house.homepage</field>
     <field name="name">Home</field>
     <field name="type">qweb</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
     <field name="active" eval="True"/>
   </record>
   <function model="ir.ui.view" name="write">
-    <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('website.default_website').id).viewref('website.homepage').id"/>
+    <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('base.default_website').id).viewref('website.homepage').id"/>
     <value model="ir.ui.view" eval="{'arch': obj().env.ref('guest_house.homepage').arch}"/>
   </function>
 </odoo>

--- a/guided_tours/data/website_menu.xml
+++ b/guided_tours/data/website_menu.xml
@@ -2,7 +2,7 @@
 <odoo noupdate="1">
   <function model="website.menu" name="write">
         <value model="website.menu" eval="obj().search([
-            ('website_id', '=', ref('website.default_website')),
+            ('website_id', '=', ref('base.default_website')),
             ('url', '=', '/event'),
         ], limit=1).id"/>
         <value eval="{'name': 'Guided Tours'}"/>
@@ -10,7 +10,7 @@
 
     <function model="website.menu" name="write">
         <value model="website.menu" eval="obj().search([
-            ('website_id', '=', ref('website.default_website')),
+            ('website_id', '=', ref('base.default_website')),
             ('url', '=', '/appointment'),
         ], limit=1).id"/>
         <value eval="{'name': 'Book a Guide'}"/>

--- a/guided_tours/demo/website.xml
+++ b/guided_tours/demo/website.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-  <record id="website.default_website" model="website" forcecreate="1">
+  <record id="base.default_website" model="website" forcecreate="1">
     <field name="name">tourguide</field>
     <field name="configurator_done" eval="True"/>
     <field name="logo" type="bytes" file="guided_tours/static/description/icon.png"/>

--- a/guided_tours/demo/website_theme_apply.xml
+++ b/guided_tours/demo/website_theme_apply.xml
@@ -8,7 +8,7 @@
     <data noupdate="1">
         <function model="website.menu" name="unlink">
             <value model="website.menu" eval="obj().search([
-                ('website_id', '=', ref('website.default_website')),
+                ('website_id', '=', ref('base.default_website')),
                 ('url', '=', '/shop'),
             ]).ids"/>
         </function>

--- a/guided_tours/demo/website_view.xml
+++ b/guided_tours/demo/website_view.xml
@@ -60,7 +60,7 @@
     <field name="mode">extension</field>
     <field name="name">Descriptive</field>
     <field name="type">qweb</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
   </record>
   <record id="ir_ui_view_3837" model="ir.ui.view">
     <field name="arch" type="xml">
@@ -71,7 +71,7 @@
     <field name="key">guided_tours.navbar</field>
     <field name="name">Event Navbar</field>
     <field name="type">qweb</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
     <field name="inherit_id" ref="website_event.navbar"/>
   </record>
   <record id="ir_ui_view_3398" model="ir.ui.view">
@@ -95,7 +95,7 @@
     <field name="mode">extension</field>
     <field name="name">Header Call to Action</field>
     <field name="type">qweb</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
   </record>
   <record id="homepage" model="ir.ui.view">
     <field name="arch" type="xml">
@@ -210,7 +210,7 @@
     <field name="key">guided_tours.homepage</field>
     <field name="name">Home</field>
     <field name="type">qweb</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
   </record>
   <record id="ir_ui_view_3720" model="ir.ui.view">
     <field name="arch" type="xml">
@@ -220,7 +220,7 @@
     </field>
     <field name="name">Topbar</field>
     <field name="type">qweb</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
     <field name="inherit_id" ref="website_event.index_topbar"/>
   </record>
   <record id="ir_ui_view_3844" model="ir.ui.view">
@@ -234,7 +234,7 @@
     <field name="key">guided_tours.website_calendar_index_topbar</field>
     <field name="name">Topbar</field>
     <field name="type">qweb</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
     <field name="inherit_id" ref="website_appointment.website_calendar_index_topbar"/>
   </record>
   <record id="ir_ui_view_3719" model="ir.ui.view">
@@ -255,7 +255,7 @@
     <field name="key">guided_tours.record_cover</field>
     <field name="name">record_cover</field>
     <field name="type">qweb</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
   </record>
   <record id="ir_ui_view_3841" model="ir.ui.view">
     <field name="arch" type="xml">
@@ -289,15 +289,15 @@
     <field name="key">guided_tours.index</field>
     <field name="name">Guided Tours</field>
     <field name="type">qweb</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
     <field name="inherit_id" ref="website_event.index"/>
   </record>
   <function model="ir.ui.view" name="write">
-    <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('website.default_website').id).viewref('website.template_footer_descriptive').id"/>
+    <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('base.default_website').id).viewref('website.template_footer_descriptive').id"/>
     <value model="ir.ui.view" eval="{'arch': obj().env.ref('guided_tours.ir_ui_view_3836').arch}"/>
   </function>
   <function model="ir.ui.view" name="write">
-    <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('website.default_website').id).viewref('website.homepage').id"/>
+    <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('base.default_website').id).viewref('website.homepage').id"/>
     <value model="ir.ui.view" eval="{'arch': obj().env.ref('guided_tours.homepage').arch}"/>
   </function>
 </odoo>

--- a/hair_salon/demo/website.xml
+++ b/hair_salon/demo/website.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-    <record id="website.default_website" model="website" forcecreate="1">
+    <record id="base.default_website" model="website" forcecreate="1">
         <field name="name">Hair Salon Industry</field>
         <field name="theme_id" search="[('id', '=', ref('base.module_theme_orchid', raise_if_not_found=False))]"/>
         <field name="configurator_done" eval="True"/>

--- a/hair_salon/demo/website_builder.xml
+++ b/hair_salon/demo/website_builder.xml
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo>
     <function name="write" model="ir.ui.view">
-        <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('website.default_website').id).viewref('website.homepage').id"/>
+        <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('base.default_website').id).viewref('website.homepage').id"/>
         <value model="ir.ui.view" eval="{'arch': obj().env.ref('hair_salon.homepage').arch}"/>
     </function>
     <function name="write" model="ir.ui.view">
-        <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('website.default_website').id).viewref('website.header_call_to_action').id"/>
+        <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('base.default_website').id).viewref('website.header_call_to_action').id"/>
         <value model="ir.ui.view" eval="{'arch': obj().env.ref('hair_salon.header_call_to_action').arch}"/>
     </function>
-    <function name="make_scss_customization" model="website.assets" context="{'website_id': ref('website.default_website')}">
+    <function name="make_scss_customization" model="website.assets" context="{'website_id': ref('base.default_website')}">
         <value eval="'/website/static/src/scss/options/colors/user_color_palette.scss'"/>
         <value eval="{'o-color-1': '#876A3B','o-color-2': '#6c757d','o-color-3': '#ced4da','o-color-4': '#FFFFFF','o-color-5': '#2E2414'}"/>
     </function>
@@ -16,7 +16,7 @@
     <data noupdate="1">
         <function model="website.menu" name="unlink">
             <value model="website.menu" eval="obj().search([
-                ('website_id', '=', ref('website.default_website')),
+                ('website_id', '=', ref('base.default_website')),
                 ('url', '=', '/contactus'),
             ]).ids"/>
         </function>

--- a/hair_salon/demo/website_ir_attachment.xml
+++ b/hair_salon/demo/website_ir_attachment.xml
@@ -2,37 +2,37 @@
 <odoo noupdate="1">
     <record id="ir_attachment_527" model="ir.attachment">
         <field name="name">image_1</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="raw" type="bytes" file="hair_salon/static/src/binary/website/adam-winger-fI-TKWjKYls-unsplash.jpg"/>
         <field name="public" eval="True"/>
     </record>
     <record id="ir_attachment_528" model="ir.attachment">
         <field name="name">image_2</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="raw" type="bytes" file="hair_salon/static/src/binary/website/adam-winger-WDmvpGs2060-unsplash.jpg"/>
         <field name="public" eval="True"/>
     </record>
     <record id="ir_attachment_531" model="ir.attachment">
         <field name="name">images11.png</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="raw" type="bytes" file="hair_salon/static/src/binary/website/delfina-pan-wJoB8D3hnzc-unsplash.jpg"/>
         <field name="public" eval="True"/>
     </record>
     <record id="ir_attachment_536" model="ir.attachment">
         <field name="name">image_3</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="raw" type="bytes" file="hair_salon/static/src/binary/website/kareya-saleh-tLKOj6cNwe0-unsplash.jpg"/>
         <field name="public" eval="True"/>
     </record>
     <record id="ir_attachment_537" model="ir.attachment">
         <field name="name">image_4</field>        
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="raw" type="bytes" file="hair_salon/static/src/binary/website/mostafa-meraji-5npGPG0sSVk-unsplash.jpg"/>
         <field name="public" eval="True"/>
     </record>
     <record id="ir_attachment_541" model="ir.attachment">
         <field name="name">image_5</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="raw" type="bytes" file="hair_salon/static/src/binary/website/obi-pixel9propics-_llKj6qOuZw-unsplash.jpg"/>
         <field name="public" eval="True"/>
     </record>

--- a/hair_salon/demo/website_view.xml
+++ b/hair_salon/demo/website_view.xml
@@ -22,7 +22,7 @@
 
     <record id="homepage" model="ir.ui.view">
         <field name="name">Home</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="key">hair_salon.homepage</field>
         <field name="type">qweb</field>
         <field name="arch" type="xml">        

--- a/headhunter/data/website_view.xml
+++ b/headhunter/data/website_view.xml
@@ -4,7 +4,7 @@
         <field name="name">Contact Us</field>
         <field name="type">qweb</field>
         <field name="key">headhunter.contact_us</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="active" eval="True"/>
         <field name="arch" type="xml">
             <t name="Contact Us" t-name="website.contactus">
@@ -160,7 +160,7 @@
         </field>
     </record>
     <function model="ir.ui.view" name="write">
-        <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('website.default_website').id).viewref('website.contactus').id"/>
+        <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('base.default_website').id).viewref('website.contactus').id"/>
         <value model="ir.ui.view" eval="{'arch': obj().env.ref('headhunter.contact_us').arch.replace(
         '*sales_team_team_sales_department*', str(obj().env.ref('sales_team.team_sales_department').id)).replace(
         '*base_user_admin*', str(obj().env.ref('base.user_admin').id))

--- a/headhunter/demo/website.xml
+++ b/headhunter/demo/website.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-    <record id="website.default_website" model="website" forcecreate="1">
+    <record id="base.default_website" model="website" forcecreate="1">
         <field name="name">Headhunter</field>
         <field name="configurator_done" eval="True"/>
         <field name="theme_id" search="[('id', '=', ref('base.module_theme_buzzy', raise_if_not_found=False))]"/>

--- a/headhunter/demo/website_ir_attachment.xml
+++ b/headhunter/demo/website_ir_attachment.xml
@@ -3,14 +3,14 @@
     <record id="ir_attachment_contact" model="ir.attachment">
         <field name="name">contact_us_image</field>
         <field name="raw" type="bytes" file="headhunter/static/src/binary/ir_attachment/contact.jpg" />
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="key">headhunter.contact</field>
         <field name="public" eval="True"/>
     </record>
     <record id="ir_attachment_services" model="ir.attachment">
         <field name="name">services_image</field>
         <field name="raw" type="bytes" file="headhunter/static/src/binary/ir_attachment/services.jpg" />
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="key">headhunter.services</field>
         <field name="public" eval="True"/>
     </record>

--- a/headhunter/demo/website_menu.xml
+++ b/headhunter/demo/website_menu.xml
@@ -7,10 +7,10 @@
         <field name="page_id" ref="website_page_6"/>
         <field name="parent_id" model="website.menu"
             eval="obj().search([
-                ('website_id', '=', ref('website.default_website')),
+                ('website_id', '=', ref('base.default_website')),
                 ('url', '=', '#'),
             ], limit=1).id"
         />
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
     </record>
 </odoo>

--- a/headhunter/demo/website_page.xml
+++ b/headhunter/demo/website_page.xml
@@ -4,6 +4,6 @@
         <field name="view_id" ref="services"/>
         <field name="is_published" eval="True"/>
         <field name="url">/our-services</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
     </record>
 </odoo>

--- a/headhunter/demo/website_theme_apply.xml
+++ b/headhunter/demo/website_theme_apply.xml
@@ -3,14 +3,14 @@
     <function name="button_choose_theme" model="ir.module.module" eval="[ref('base.module_theme_buzzy', raise_if_not_found=False) or ref('base.module_theme_default')]"/>
     
     <function model="ir.ui.view" name="write">
-        <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('website.default_website').id).viewref('website.homepage').id"/>
+        <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('base.default_website').id).viewref('website.homepage').id"/>
         <value model="ir.ui.view" eval="{'arch': obj().env.ref('headhunter.homepage').arch}"/>
     </function>
 
     <data noupdate="1">
         <function model="website.menu" name="unlink">
             <value model="website.menu" eval="obj().search([
-                ('website_id', '=', ref('website.default_website')),
+                ('website_id', '=', ref('base.default_website')),
                 ('url', '=', '/appointment'),
             ]).ids"/>
         </function>

--- a/headhunter/demo/website_view.xml
+++ b/headhunter/demo/website_view.xml
@@ -4,7 +4,7 @@
         <field name="name">Home</field>
         <field name="type">qweb</field>
         <field name="key">headhunter.homepage</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="arch" type="xml">
             <t name="Homepage" t-name="website.homepage">
                 <t t-call="website.layout" pageName.f="homepage">
@@ -143,7 +143,7 @@
         <field name="name">Services</field>
         <field name="type">qweb</field>
         <field name="key">headhunter.services</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="arch" type="xml">
             <t name="Services" t-name="website.services">
                 <t t-call="website.layout">

--- a/holiday_house/data/web_views.xml
+++ b/holiday_house/data/web_views.xml
@@ -7,7 +7,7 @@
   <data noupdate="1">
     <function model="website.menu" name="write">
       <value model="website.menu" 
-        eval="obj().search([('website_id', '=', ref('website.default_website')), ('url', '=', '/shop')], limit=1).id" />
+        eval="obj().search([('website_id', '=', ref('base.default_website')), ('url', '=', '/shop')], limit=1).id" />
       <value eval="{'name': 'Houses'}"/>
     </function>
   </data>

--- a/holiday_house/demo/website.xml
+++ b/holiday_house/demo/website.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-  <record id="website.default_website" model="website" forcecreate="1">
+  <record id="base.default_website" model="website" forcecreate="1">
     <field name="name">holiday_house</field>
     <field name="configurator_done" eval="True"/>
     <field name="favicon" type="bytes" file="holiday_house/static/description/icon.png"/>

--- a/holiday_house/demo/website_theme_apply.xml
+++ b/holiday_house/demo/website_theme_apply.xml
@@ -2,12 +2,12 @@
 <odoo>
   <function name="button_choose_theme" model="ir.module.module" eval="[ref('base.module_theme_real_estate', raise_if_not_found=False) or ref('base.module_theme_default')]"/>
     
-  <function name="make_scss_customization" model="website.assets" context="{'website_id': ref('website.default_website')}">
+  <function name="make_scss_customization" model="website.assets" context="{'website_id': ref('base.default_website')}">
     <value eval="'/website/static/src/scss/options/colors/user_color_palette.scss'"/>
     <value eval="{'o-color-1': '#8CB89F','o-color-2': '#ECE4DF','o-color-3': '#FBFBFB','o-color-4': '#FFFFFF','o-color-5': '#43594F', 'menu': 1}"/>
   </function>
   <function name="write" model="ir.ui.view">
-    <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=ref('website.default_website')).viewref('website.homepage').id"/>
+    <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=ref('base.default_website')).viewref('website.homepage').id"/>
     <value model="ir.ui.view" eval="{'arch': obj().env.ref('holiday_house.homepage').arch.replace(
       '*filter_newest_products_holiday_house*', str(obj().env.ref('website_sale.dynamic_filter_newest_products').id)
     )}"/>

--- a/holiday_house/demo/website_view.xml
+++ b/holiday_house/demo/website_view.xml
@@ -170,6 +170,6 @@
     <field name="key">holiday_house.homepage</field>
     <field name="name">Home</field>
     <field name="type">qweb</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
   </record>
 </odoo>

--- a/hotel/demo/website.xml
+++ b/hotel/demo/website.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-  <record id="website.default_website" model="website" forcecreate="1">
+  <record id="base.default_website" model="website" forcecreate="1">
     <field name="name">hotel</field>
     <field name="configurator_done" eval="True"/>
     <field name="favicon" type="bytes" file="hotel/static/description/icon.png"/>

--- a/hotel/demo/website_theme_apply.xml
+++ b/hotel/demo/website_theme_apply.xml
@@ -2,12 +2,12 @@
 <odoo>
   <function name="button_choose_theme" model="ir.module.module" eval="[ref('base.module_theme_bistro', raise_if_not_found=False) or ref('base.module_theme_default')]"/>
     
-  <function name="make_scss_customization" model="website.assets" context="{'website_id': ref('website.default_website')}">
+  <function name="make_scss_customization" model="website.assets" context="{'website_id': ref('base.default_website')}">
     <value eval="'/website/static/src/scss/options/colors/user_color_palette.scss'"/>
     <value eval="{'o-color-1': '#8CB89F','o-color-2': '#ECE4DF','o-color-3': '#FBFBFB','o-color-4': '#FFFFFF','o-color-5': '#43594F', 'menu': 1}"/>
   </function>
   <function name="write" model="ir.ui.view">
-    <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=ref('website.default_website')).viewref('website.homepage').id"/>
+    <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=ref('base.default_website')).viewref('website.homepage').id"/>
     <value model="ir.ui.view" eval="{'arch': obj().env.ref('hotel.homepage').arch}"/>
   </function>
 </odoo>

--- a/hotel/demo/website_view.xml
+++ b/hotel/demo/website_view.xml
@@ -259,6 +259,6 @@
     <field name="key">hotel.homepage</field>
     <field name="name">Home</field>
     <field name="type">qweb</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
   </record>
 </odoo>

--- a/industry_lawyer/data/website_page.xml
+++ b/industry_lawyer/data/website_page.xml
@@ -2,7 +2,7 @@
 <odoo noupdate="1">
     <record id="website_page_8" model="website.page">
         <field name="view_id" ref="contactus"/>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="is_published" eval="True"/>
         <field name="url">/contactus</field>
     </record>

--- a/industry_lawyer/data/website_theme_apply.xml
+++ b/industry_lawyer/data/website_theme_apply.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo>
     <function name="write" model="ir.ui.view">
-        <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=ref('website.default_website')).viewref('website.contactus').id"/>
+        <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=ref('base.default_website')).viewref('website.contactus').id"/>
         <value model="ir.ui.view" eval="{'arch': obj().env.ref('industry_lawyer.contactus').arch}"/>
     </function>
 </odoo>

--- a/industry_lawyer/data/website_view.xml
+++ b/industry_lawyer/data/website_view.xml
@@ -5,7 +5,7 @@
         <field name="key">industry_lawyer.contactus</field>
         <field name="active" eval="True"/>
         <field name="type">qweb</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="arch" type="xml">
           <t name="Contact Us" t-name="website.contactus">
             <t t-call="website.layout"

--- a/industry_lawyer/demo/website.xml
+++ b/industry_lawyer/demo/website.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-    <record id="website.default_website" model="website" forcecreate="1">
+    <record id="base.default_website" model="website" forcecreate="1">
         <field name="name">Law Firm</field>
         <field name="configurator_done" eval="True"/>
         <field name="logo" type="bytes" file="industry_lawyer/static/description/icon.png"/>

--- a/industry_lawyer/demo/website_menu.xml
+++ b/industry_lawyer/demo/website_menu.xml
@@ -4,9 +4,9 @@
     <field name="name">Services</field>
     <field name="page_id" ref="website_page_7"/>
     <field name="url">/our-services</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
     <field name="parent_id" model="website.menu" eval="obj().search([
-                ('website_id', '=', ref('website.default_website')),
+                ('website_id', '=', ref('base.default_website')),
                 ('url', '=', '#'),
     ], limit=1).id"/>
   </record>
@@ -14,9 +14,9 @@
     <field name="name">About Us</field>
     <field name="page_id" ref="website_page_6"/>
     <field name="url">/about-us</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
     <field name="parent_id" model="website.menu" eval="obj().search([
-                ('website_id', '=', ref('website.default_website')),
+                ('website_id', '=', ref('base.default_website')),
                 ('url', '=', '#'),
     ], limit=1).id"/>
   </record>

--- a/industry_lawyer/demo/website_page.xml
+++ b/industry_lawyer/demo/website_page.xml
@@ -2,19 +2,19 @@
 <odoo noupdate="1">
   <record id="website_page_4" model="website.page">
     <field name="view_id" ref="homepage"/>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
     <field name="is_published" eval="True"/>
     <field name="url">/</field>
   </record>
   <record id="website_page_6" model="website.page">
     <field name="view_id" ref="aboutus"/>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
     <field name="is_published" eval="True"/>
     <field name="url">/about-us</field>
   </record>
   <record id="website_page_7" model="website.page">
     <field name="view_id" ref="services"/>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
     <field name="is_published" eval="True"/>
     <field name="url">/our-services</field>
   </record>

--- a/industry_lawyer/demo/website_theme_apply.xml
+++ b/industry_lawyer/demo/website_theme_apply.xml
@@ -38,7 +38,7 @@
     </function>
 
     <function model="ir.ui.view" name="write">
-        <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('website.default_website').id).viewref('website.homepage').id"/>
+        <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('base.default_website').id).viewref('website.homepage').id"/>
         <value model="ir.ui.view" eval="{'arch': obj().env.ref('industry_lawyer.homepage').arch}"/>
     </function>
 </odoo>

--- a/industry_lawyer/demo/website_view.xml
+++ b/industry_lawyer/demo/website_view.xml
@@ -152,13 +152,13 @@
     <field name="key">industry_lawyer.about-us</field>
     <field name="name">About Us</field>
     <field name="type">qweb</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
   </record>
   <record id="homepage" model="ir.ui.view">
     <field name="name">Home</field>
     <field name="key">industry_lawyer.homepage</field>
     <field name="type">qweb</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
     <field name="arch" type="xml">
       <t name="Homepage" t-name="website.homepage">
         <t t-call="website.layout" pageName.f="homepage">
@@ -327,7 +327,7 @@
     <field name="name">Services</field>
     <field name="key">industry_lawyer.services</field>
     <field name="type">qweb</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
     <field name="arch" type="xml">
       <t name="Services" t-name="website.services">
         <t t-call="website.layout">

--- a/industry_real_estate/data/ir_attachment_post.xml
+++ b/industry_real_estate/data/ir_attachment_post.xml
@@ -5,26 +5,26 @@
         <field name="raw" type="bytes" file="industry_real_estate/static/src/binary/ir_attachment/664-home.png"/>
         <field name="res_id" ref="base.user_admin"/>
         <field name="res_model">res.users</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
     </record>
     <record id="ir_attachment_669" model="ir.attachment">
         <field name="name">ParkLine-apartment-in-Miami-FL.jpg.jpg</field>
         <field name="raw" type="bytes" file="industry_real_estate/static/src/binary/ir_attachment/669-ParkLine-apartment-in-Miami-FL.jpg.jpg"/>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
     </record>
     <record id="ir_attachment_671" model="ir.attachment">
         <field name="name">ParkLine-apartment-in-Miami-FL.jpg.jpg</field>
         <field name="raw" type="bytes" file="industry_real_estate/static/src/binary/ir_attachment/671-ParkLine-apartment-in-Miami-FL.jpg.jpg"/>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
     </record>
     <record id="ir_attachment_673" model="ir.attachment">
         <field name="name">ParkLine-apartment-in-Miami-FL.jpg.jpg</field>
         <field name="raw" type="bytes" file="industry_real_estate/static/src/binary/ir_attachment/673-ParkLine-apartment-in-Miami-FL.jpg.jpg"/>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
     </record>
     <record id="ir_attachment_675" model="ir.attachment">
         <field name="name">ParkLine-apartment-in-Miami-FL.jpg.jpg</field>
         <field name="raw" type="bytes" file="industry_real_estate/static/src/binary/ir_attachment/675-ParkLine-apartment-in-Miami-FL.jpg.jpg"/>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
     </record>
 </odoo>

--- a/industry_real_estate/data/ir_attachment_pre.xml
+++ b/industry_real_estate/data/ir_attachment_pre.xml
@@ -8,31 +8,31 @@
     <record id="ir_attachment_699" model="ir.attachment">
         <field name="name">Office-M-1.jpg</field>
         <field name="res_model">account.analytic.account</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="raw" type="bytes" file="industry_real_estate/static/src/binary/ir_attachment/699-Office-M-1.jpg"/>
     </record>
     <record id="ir_attachment_700" model="ir.attachment">
         <field name="name">Office-M-2.jpg</field>
         <field name="res_model">account.analytic.account</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="raw" type="bytes" file="industry_real_estate/static/src/binary/ir_attachment/700-Office-M-2.jpg"/>
     </record>
     <record id="ir_attachment_701" model="ir.attachment">
         <field name="name">Office-M-3.jpg</field>
         <field name="res_model">account.analytic.account</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="raw" type="bytes" file="industry_real_estate/static/src/binary/ir_attachment/701-Office-M-3.jpg"/>
     </record>
     <record id="ir_attachment_702" model="ir.attachment">
         <field name="name">Office-M-4.jpg</field>
         <field name="res_model">account.analytic.account</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="raw" type="bytes" file="industry_real_estate/static/src/binary/ir_attachment/702-Office-M-4.jpg"/>
     </record>
     <record id="ir_attachment_703" model="ir.attachment">
         <field name="name">Office-M-5.jpg</field>
         <field name="res_model">account.analytic.account</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="raw" type="bytes" file="industry_real_estate/static/src/binary/ir_attachment/703-Office-M-5.jpg"/>
     </record>
 </odoo>

--- a/industry_real_estate/data/website_theme_apply.xml
+++ b/industry_real_estate/data/website_theme_apply.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo>
     <function model="ir.ui.view" name="write">
-        <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('website.default_website').id).viewref('website.contactus').id"/>
+        <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('base.default_website').id).viewref('website.contactus').id"/>
         <value model="ir.ui.view" eval="{'arch': obj().env.ref('industry_real_estate.contactus').arch}"/>
     </function>
 </odoo>

--- a/industry_real_estate/data/website_view.xml
+++ b/industry_real_estate/data/website_view.xml
@@ -3,7 +3,7 @@
     <record id="contactus" model="ir.ui.view">
         <field name="name">Contact Us</field>
         <field name="key">industry_real_estate.contactus</field>
-        <field name="website_id" ref="website.default_website" />
+        <field name="website_id" ref="base.default_website" />
         <field name="type">qweb</field>
         <field name="active" eval="True"/>
         <field name="arch" type="xml">
@@ -175,7 +175,7 @@
         <field name="mode">extension</field>
         <field name="active" eval="True"/>
         <field name="type">qweb</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="arch" type="xml">
             <xpath expr="//*[hasclass('oe_structure')][@id='oe_structure_website_sale_product_2']" position="replace">
                 <div class="oe_structure oe_empty oe_structure_not_nearest mt16" id="oe_structure_website_sale_product_2" data-editor-message="DROP BUILDING BLOCKS HERE TO MAKE THEM AVAILABLE ACROSS ALL PRODUCTS">

--- a/industry_real_estate/demo/ir_attachment.xml
+++ b/industry_real_estate/demo/ir_attachment.xml
@@ -5,35 +5,35 @@
         <field name="raw" type="bytes" file="industry_real_estate/static/src/binary/ir_attachment/694-The-Garage-II-1936-scaled-1.jpg"/>
         <field name="res_id" ref="x_property_23"/>
         <field name="res_model">x_property</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
     </record>
     <record id="ir_attachment_695" model="ir.attachment">
         <field name="name">Ferrari-Meetingroom-scaled-1.jpg</field>
         <field name="raw" type="bytes" file="industry_real_estate/static/src/binary/ir_attachment/695-Ferrari-Meetingroom-scaled-1.jpg"/>
         <field name="res_id" ref="x_property_23"/>
         <field name="res_model">x_property</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
     </record>
     <record id="ir_attachment_696" model="ir.attachment">
         <field name="name">Kantoor-foto-20m2-1-scaled-1.jpg</field>
         <field name="raw" type="bytes" file="industry_real_estate/static/src/binary/ir_attachment/696-Kantoor-foto-20m2-1-scaled-1.jpg"/>
         <field name="res_id" ref="x_property_23"/>
         <field name="res_model">x_property</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
     </record>
     <record id="ir_attachment_697" model="ir.attachment">
         <field name="name">The-Garage-II-1995-scaled-1.jpg</field>
         <field name="raw" type="bytes" file="industry_real_estate/static/src/binary/ir_attachment/697-The-Garage-II-1995-scaled-1.jpg"/>
         <field name="res_id" ref="x_property_23"/>
         <field name="res_model">x_property</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
     </record>
     <record id="ir_attachment_698" model="ir.attachment">
         <field name="name">Cucina-Caffe-scaled-1.jpg</field>
         <field name="raw" type="bytes" file="industry_real_estate/static/src/binary/ir_attachment/698-Cucina-Caffe-scaled-1.jpg"/>
         <field name="res_id" ref="x_property_23"/>
         <field name="res_model">x_property</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
     </record>
     <record id="ir_attachment_699" model="ir.attachment">
         <field name="res_model">x_property</field>
@@ -60,90 +60,90 @@
         <field name="raw" type="bytes" file="industry_real_estate/static/src/binary/ir_attachment/704-The-Garage-II-1995-scaled-1.jpg"/>
         <field name="res_id" ref="x_property_23"/>
         <field name="res_model">x_property</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
     </record>
     <record id="ir_attachment_705" model="ir.attachment">
         <field name="name">The-Garage-II-1936-scaled-1.jpg</field>
         <field name="raw" type="bytes" file="industry_real_estate/static/src/binary/ir_attachment/705-The-Garage-II-1936-scaled-1.jpg"/>
         <field name="res_id" ref="x_property_23"/>
         <field name="res_model">x_property</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
     </record>
     <record id="ir_attachment_706" model="ir.attachment">
         <field name="name">Kantoor-foto-20m2-1-scaled-1.jpg</field>
         <field name="raw" type="bytes" file="industry_real_estate/static/src/binary/ir_attachment/706-Kantoor-foto-20m2-1-scaled-1.jpg"/>
         <field name="res_id" ref="x_property_23"/>
         <field name="res_model">x_property</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
     </record>
     <record id="ir_attachment_738" model="ir.attachment">
         <field name="name">The-Garage-II-1995-scaled-1.jpg</field>
         <field name="raw" type="bytes" file="industry_real_estate/static/src/binary/ir_attachment/738-The-Garage-II-1995-scaled-1.jpg"/>
         <field name="res_id" ref="x_property_23"/>
         <field name="res_model">x_property</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
     </record>
     <record id="ir_attachment_739" model="ir.attachment">
         <field name="name">The-Garage-II-1936-scaled-1.jpg</field>
         <field name="raw" type="bytes" file="industry_real_estate/static/src/binary/ir_attachment/739-The-Garage-II-1936-scaled-1.jpg"/>
         <field name="res_id" ref="x_property_23"/>
         <field name="res_model">x_property</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
     </record>
     <record id="ir_attachment_740" model="ir.attachment">
         <field name="name">Kantoor-foto-20m2-1-scaled-1.jpg</field>
         <field name="raw" type="bytes" file="industry_real_estate/static/src/binary/ir_attachment/740-Kantoor-foto-20m2-1-scaled-1.jpg"/>
         <field name="res_id" ref="x_property_23"/>
         <field name="res_model">x_property</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
     </record>
     <record id="ir_attachment_741" model="ir.attachment">
         <field name="name">Ferrari-Meetingroom-scaled-1.jpg</field>
         <field name="raw" type="bytes" file="industry_real_estate/static/src/binary/ir_attachment/741-Ferrari-Meetingroom-scaled-1.jpg"/>
         <field name="res_id" ref="x_property_23"/>
         <field name="res_model">x_property</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
     </record>
     <record id="ir_attachment_742" model="ir.attachment">
         <field name="name">Cucina-Caffe-scaled-1.jpg</field>
         <field name="raw" type="bytes" file="industry_real_estate/static/src/binary/ir_attachment/742-Cucina-Caffe-scaled-1.jpg"/>
         <field name="res_id" ref="x_property_23"/>
         <field name="res_model">x_property</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
     </record>
     <record id="ir_attachment_743" model="ir.attachment">
         <field name="name">IMAGE-10.jpg</field>
         <field name="raw" type="bytes" file="industry_real_estate/static/src/binary/ir_attachment/743-IMAGE-10.jpg"/>
         <field name="res_id" ref="x_property_23"/>
         <field name="res_model">x_property</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
     </record>
     <record id="ir_attachment_744" model="ir.attachment">
         <field name="name">9636680-leuvensesteenweg-643-zaventem.webp</field>
         <field name="raw" type="bytes" file="industry_real_estate/static/src/binary/ir_attachment/744-9636680-leuvensesteenweg-643-zaventem.webp"/>
         <field name="res_id" ref="x_property_23"/>
         <field name="res_model">x_property</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
     </record>
     <record id="ir_attachment_745" model="ir.attachment">
         <field name="name">4588158-leuvensesteenweg-643.webp</field>
         <field name="raw" type="bytes" file="industry_real_estate/static/src/binary/ir_attachment/745-4588158-leuvensesteenweg-643.webp"/>
         <field name="res_id" ref="x_property_23"/>
         <field name="res_model">x_property</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
     </record>
     <record id="ir_attachment_746" model="ir.attachment">
         <field name="name">download (3).jpeg</field>
         <field name="raw" type="bytes" file="industry_real_estate/static/src/binary/ir_attachment/746-download(3).jpeg"/>
         <field name="res_id" ref="x_property_23"/>
         <field name="res_model">x_property</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
     </record>
     <record id="ir_attachment_747" model="ir.attachment">
         <field name="name">the-huntley-atlanta-ga-luxury-apartment-view.jpg</field>
         <field name="raw" type="bytes" file="industry_real_estate/static/src/binary/ir_attachment/747-the-huntley-atlanta-ga-luxury-apartment-view.jpg"/>
         <field name="res_id" ref="x_property_23"/>
         <field name="res_model">x_property</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
     </record>
 </odoo>

--- a/industry_real_estate/demo/website.xml
+++ b/industry_real_estate/demo/website.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-    <record id="website.default_website" model="website" forcecreate="1">
+    <record id="base.default_website" model="website" forcecreate="1">
         <field name="name">Brokerage</field>
         <field name="configurator_done" eval="True"/>
         <field name="theme_id" search="[('id', '=', ref('base.module_theme_treehouse', raise_if_not_found=False))]"/>

--- a/industry_real_estate/demo/website_attachment.xml
+++ b/industry_real_estate/demo/website_attachment.xml
@@ -5,266 +5,266 @@
         <field name="name">website.library_image_02</field>
         <field name="raw" type="bytes" file="industry_real_estate/static/src/binary/ir_attachment/642-website.library_image_02"/>
         <field name="key">industry_real_estate.library_image_02</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
     </record>
     <record id="configurator_1_library_image_03" model="ir.attachment">
         <field name="name">website.library_image_03</field>
         <field name="raw" type="bytes" file="industry_real_estate/static/src/binary/ir_attachment/635-website.library_image_03"/>
         <field name="key">industry_real_estate.library_image_03</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
     </record>
     <record id="configurator_1_library_image_05" model="ir.attachment">
         <field name="name">website.library_image_05</field>
         <field name="raw" type="bytes" file="industry_real_estate/static/src/binary/ir_attachment/638-website.library_image_05"/>
         <field name="key">industry_real_estate.library_image_05</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
     </record>
     <record id="configurator_1_library_image_08" model="ir.attachment">
         <field name="name">website.library_image_08</field>
         <field name="raw" type="bytes" file="industry_real_estate/static/src/binary/ir_attachment/641-website.library_image_08"/>
         <field name="key">industry_real_estate.library_image_08</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
     </record>
     <record id="configurator_1_library_image_10" model="ir.attachment">
         <field name="name">website.library_image_10</field>
         <field name="raw" type="bytes" file="industry_real_estate/static/src/binary/ir_attachment/636-website.library_image_10"/>
         <field name="key">industry_real_estate.library_image_10</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
     </record>
     <record id="configurator_1_library_image_13" model="ir.attachment">
         <field name="name">website.library_image_13</field>
         <field name="raw" type="bytes" file="industry_real_estate/static/src/binary/ir_attachment/637-website.library_image_13"/>
         <field name="key">industry_real_estate.library_image_13</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
     </record>
     <record id="configurator_1_library_image_14" model="ir.attachment">
         <field name="name">website.library_image_14</field>
         <field name="raw" type="bytes" file="industry_real_estate/static/src/binary/ir_attachment/639-website.library_image_14"/>
         <field name="key">industry_real_estate.library_image_14</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
     </record>
     <record id="configurator_1_library_image_16" model="ir.attachment">
         <field name="name">website.library_image_16</field>
         <field name="raw" type="bytes" file="industry_real_estate/static/src/binary/ir_attachment/640-website.library_image_16"/>
         <field name="key">industry_real_estate.library_image_16</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
     </record>
     <record id="configurator_1_s_banner_default_image" model="ir.attachment">
         <field name="name">website.s_banner_default_image</field>
         <field name="raw" type="bytes" file="industry_real_estate/static/src/binary/ir_attachment/619-website.s_banner_default_image"/>
         <field name="key">industry_real_estate.s_banner_default_image</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
     </record>
     <record id="configurator_1_s_carousel_default_image_1" model="ir.attachment">
         <field name="name">website.s_carousel_default_image_1</field>
         <field name="raw" type="bytes" file="industry_real_estate/static/src/binary/ir_attachment/616-website.s_carousel_default_image_1"/>
         <field name="key">industry_real_estate.s_carousel_default_image_1</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
     </record>
     <record id="configurator_1_s_carousel_default_image_2" model="ir.attachment">
         <field name="name">website.s_carousel_default_image_2</field>
         <field name="raw" type="bytes" file="industry_real_estate/static/src/binary/ir_attachment/617-website.s_carousel_default_image_2"/>
         <field name="key">industry_real_estate.s_carousel_default_image_2</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
     </record>
     <record id="configurator_1_s_carousel_default_image_3" model="ir.attachment">
         <field name="name">website.s_carousel_default_image_3</field>
         <field name="raw" type="bytes" file="industry_real_estate/static/src/binary/ir_attachment/618-website.s_carousel_default_image_3"/>
         <field name="key">industry_real_estate.s_carousel_default_image_3</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
     </record>
     <record id="configurator_1_s_cover_default_image" model="ir.attachment">
         <field name="name">website.s_cover_default_image</field>
         <field name="raw" type="bytes" file="industry_real_estate/static/src/binary/ir_attachment/609-website.s_cover_default_image"/>
         <field name="key">industry_real_estate.s_cover_default_image</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
     </record>
     <record id="configurator_1_s_image_text_default_image" model="ir.attachment">
         <field name="name">website.s_image_text_default_image</field>
         <field name="raw" type="bytes" file="industry_real_estate/static/src/binary/ir_attachment/629-website.s_image_text_default_image"/>
         <field name="key">industry_real_estate.s_image_text_default_image</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
     </record>
     <record id="configurator_1_s_masonry_block_default_image_1" model="ir.attachment">
         <field name="name">website.s_masonry_block_default_image_1</field>
         <field name="raw" type="bytes" file="industry_real_estate/static/src/binary/ir_attachment/610-website.s_masonry_block_default_image_1"/>
         <field name="key">industry_real_estate.s_masonry_block_default_image_1</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
     </record>
     <record id="configurator_1_s_media_list_default_image_1" model="ir.attachment">
         <field name="name">website.s_media_list_default_image_1</field>
         <field name="raw" type="bytes" file="industry_real_estate/static/src/binary/ir_attachment/611-website.s_media_list_default_image_1"/>
         <field name="key">industry_real_estate.s_media_list_default_image_1</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
     </record>
     <record id="configurator_1_s_media_list_default_image_2" model="ir.attachment">
         <field name="name">website.s_media_list_default_image_2</field>
         <field name="raw" type="bytes" file="industry_real_estate/static/src/binary/ir_attachment/612-website.s_media_list_default_image_2"/>
         <field name="key">industry_real_estate.s_media_list_default_image_2</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
     </record>
     <record id="configurator_1_s_media_list_default_image_3" model="ir.attachment">
         <field name="name">website.s_media_list_default_image_3</field>
         <field name="raw" type="bytes" file="industry_real_estate/static/src/binary/ir_attachment/613-website.s_media_list_default_image_3"/>
         <field name="key">industry_real_estate.s_media_list_default_image_3</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
     </record>
     <record id="configurator_1_s_parallax_default_image" model="ir.attachment">
         <field name="name">website.s_parallax_default_image</field>
         <field name="raw" type="bytes" file="industry_real_estate/static/src/binary/ir_attachment/620-website.s_parallax_default_image"/>
         <field name="key">industry_real_estate.s_parallax_default_image</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
     </record>
     <record id="configurator_1_s_picture_default_image" model="ir.attachment">
         <field name="name">website.s_picture_default_image</field>
         <field name="raw" type="bytes" file="industry_real_estate/static/src/binary/ir_attachment/628-website.s_picture_default_image"/>
         <field name="key">industry_real_estate.s_picture_default_image</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
     </record>
     <record id="configurator_1_s_product_catalog_default_image" model="ir.attachment">
         <field name="name">website.s_product_catalog_default_image</field>
         <field name="raw" type="bytes" file="industry_real_estate/static/src/binary/ir_attachment/621-website.s_product_catalog_default_image"/>
         <field name="key">industry_real_estate.s_product_catalog_default_image</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
     </record>
     <record id="configurator_1_s_product_list_default_image_1" model="ir.attachment">
         <field name="name">website.s_product_list_default_image_1</field>
         <field name="raw" type="bytes" file="industry_real_estate/static/src/binary/ir_attachment/622-website.s_product_list_default_image_1"/>
         <field name="key">industry_real_estate.s_product_list_default_image_1</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
     </record>
     <record id="configurator_1_s_product_list_default_image_2" model="ir.attachment">
         <field name="name">website.s_product_list_default_image_2</field>
         <field name="raw" type="bytes" file="industry_real_estate/static/src/binary/ir_attachment/623-website.s_product_list_default_image_2"/>
         <field name="key">industry_real_estate.s_product_list_default_image_2</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
     </record>
     <record id="configurator_1_s_product_list_default_image_3" model="ir.attachment">
         <field name="name">website.s_product_list_default_image_3</field>
         <field name="raw" type="bytes" file="industry_real_estate/static/src/binary/ir_attachment/624-website.s_product_list_default_image_3"/>
         <field name="key">industry_real_estate.s_product_list_default_image_3</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
     </record>
     <record id="configurator_1_s_product_list_default_image_4" model="ir.attachment">
         <field name="name">website.s_product_list_default_image_4</field>
         <field name="raw" type="bytes" file="industry_real_estate/static/src/binary/ir_attachment/625-website.s_product_list_default_image_4"/>
         <field name="key">industry_real_estate.s_product_list_default_image_4</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
     </record>
     <record id="configurator_1_s_product_list_default_image_5" model="ir.attachment">
         <field name="name">website.s_product_list_default_image_5</field>
         <field name="raw" type="bytes" file="industry_real_estate/static/src/binary/ir_attachment/626-website.s_product_list_default_image_5"/>
         <field name="key">industry_real_estate.s_product_list_default_image_5</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
     </record>
     <record id="configurator_1_s_product_list_default_image_6" model="ir.attachment">
         <field name="name">website.s_product_list_default_image_6</field>
         <field name="raw" type="bytes" file="industry_real_estate/static/src/binary/ir_attachment/627-website.s_product_list_default_image_6"/>
         <field name="key">industry_real_estate.s_product_list_default_image_6</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
     </record>
     <record id="configurator_1_s_quotes_carousel_demo_image_0" model="ir.attachment">
         <field name="name">website.s_quotes_carousel_demo_image_0</field>
         <field name="raw" type="bytes" file="industry_real_estate/static/src/binary/ir_attachment/634-website.s_quotes_carousel_demo_image_0"/>
         <field name="key">industry_real_estate.s_quotes_carousel_demo_image_0</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
     </record>
     <record id="configurator_1_s_quotes_carousel_demo_image_1" model="ir.attachment">
         <field name="name">website.s_quotes_carousel_demo_image_1</field>
         <field name="raw" type="bytes" file="industry_real_estate/static/src/binary/ir_attachment/614-website.s_quotes_carousel_demo_image_1"/>
         <field name="key">industry_real_estate.s_quotes_carousel_demo_image_1</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
     </record>
     <record id="configurator_1_s_quotes_carousel_demo_image_2" model="ir.attachment">
         <field name="name">website.s_quotes_carousel_demo_image_2</field>
         <field name="raw" type="bytes" file="industry_real_estate/static/src/binary/ir_attachment/615-website.s_quotes_carousel_demo_image_2"/>
         <field name="key">industry_real_estate.s_quotes_carousel_demo_image_2</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
     </record>
     <record id="configurator_1_s_text_image_default_image" model="ir.attachment">
         <field name="name">website.s_text_image_default_image</field>
         <field name="raw" type="bytes" file="industry_real_estate/static/src/binary/ir_attachment/630-website.s_text_image_default_image"/>
         <field name="key">industry_real_estate.s_text_image_default_image</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
     </record>
     <record id="configurator_1_s_three_columns_default_image_1" model="ir.attachment">
         <field name="name">website.s_three_columns_default_image_1</field>
         <field name="raw" type="bytes" file="industry_real_estate/static/src/binary/ir_attachment/631-website.s_three_columns_default_image_1"/>
         <field name="key">industry_real_estate.s_three_columns_default_image_1</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
     </record>
     <record id="configurator_1_s_three_columns_default_image_2" model="ir.attachment">
         <field name="name">website.s_three_columns_default_image_2</field>
         <field name="raw" type="bytes" file="industry_real_estate/static/src/binary/ir_attachment/632-website.s_three_columns_default_image_2"/>
         <field name="key">industry_real_estate.s_three_columns_default_image_2</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
     </record>
     <record id="configurator_1_s_three_columns_default_image_3" model="ir.attachment">
         <field name="name">website.s_three_columns_default_image_3</field>
         <field name="raw" type="bytes" file="industry_real_estate/static/src/binary/ir_attachment/633-website.s_three_columns_default_image_3"/>
         <field name="key">industry_real_estate.s_three_columns_default_image_3</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
     </record>
     <record id="ir_attachment_601" model="ir.attachment">
         <field name="name">Team Member 1.jpg</field>
         <field name="raw" type="bytes" file="industry_real_estate/static/src/binary/ir_attachment/601-team_team_member_1.jpg" />
         <field name="key">industry_real_estate.s_company_team_image_1</field>
-        <field name="website_id" ref="website.default_website" />
+        <field name="website_id" ref="base.default_website" />
         <field name="public" eval="True"/>
     </record>
     <record id="ir_attachment_602" model="ir.attachment">
         <field name="name">Team Member 2.jpg</field>
         <field name="raw" type="bytes" file="industry_real_estate/static/src/binary/ir_attachment/602-team_team_member_2.jpg" />
         <field name="key">industry_real_estate.s_company_team_image_2</field>
-        <field name="website_id" ref="website.default_website" />
+        <field name="website_id" ref="base.default_website" />
         <field name="public" eval="True"/>
     </record>
     <record id="ir_attachment_603" model="ir.attachment">
         <field name="name">Team Member 3.jpg</field>
         <field name="raw" type="bytes" file="industry_real_estate/static/src/binary/ir_attachment/603-team_team_member_3.jpg" />
         <field name="key">industry_real_estate.s_company_team_image_3</field>
-        <field name="website_id" ref="website.default_website" />
+        <field name="website_id" ref="base.default_website" />
         <field name="public" eval="True"/>
     </record>
     <record id="ir_attachment_604" model="ir.attachment">
         <field name="name">Team Member 4.jpg</field>
         <field name="raw" type="bytes" file="industry_real_estate/static/src/binary/ir_attachment/604-team_team_member_4.jpg" />
         <field name="key">industry_real_estate.s_company_team_image_4</field>
-        <field name="website_id" ref="website.default_website" />
+        <field name="website_id" ref="base.default_website" />
         <field name="public" eval="True"/>
     </record>
 </odoo>

--- a/industry_real_estate/demo/website_menu.xml
+++ b/industry_real_estate/demo/website_menu.xml
@@ -5,9 +5,9 @@
         <field name="name">About Us</field>
         <field name="page_id" ref="website_page_9"/>
         <field name="parent_id" model="website.menu" eval="obj().search([
-                ('website_id', '=', ref('website.default_website')),
+                ('website_id', '=', ref('base.default_website')),
                 ('url', '=', '#'),
         ], limit=1).id"/>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
     </record>
 </odoo>

--- a/industry_real_estate/demo/website_page.xml
+++ b/industry_real_estate/demo/website_page.xml
@@ -3,7 +3,7 @@
     <record id="website_page_9" model="website.page">
         <field name="url">/about-us</field>
         <field name="is_published" eval="True"/>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="view_id" ref="ir_ui_view_1416"/>
     </record>
 </odoo>

--- a/industry_real_estate/demo/website_theme_apply.xml
+++ b/industry_real_estate/demo/website_theme_apply.xml
@@ -3,7 +3,7 @@
     <data noupdate="1">
         <function model="website.menu" name="write">
             <value model="website.menu" eval="obj().search([
-                ('website_id', '=', ref('website.default_website')),
+                ('website_id', '=', ref('base.default_website')),
                 ('url', '=', '/shop'),
             ], limit=1).id"/>
             <value eval="{'name': 'Properties'}"/>
@@ -11,13 +11,13 @@
     </data>
     
     <function name="button_choose_theme" model="ir.module.module" eval="[ref('base.module_theme_treehouse', raise_if_not_found=False) or ref('base.module_theme_default')]"/>
-    <function model="website.assets" name="make_scss_customization" context="{'website_id': ref('website.default_website')}">
+    <function model="website.assets" name="make_scss_customization" context="{'website_id': ref('base.default_website')}">
         <value eval="'/website/static/src/scss/options/colors/user_color_palette.scss'"/>
         <value eval="{'o-color-1': '#0A58CA','o-color-2': '#e0ccaf','o-color-3': '#f0f2f5','o-color-4': '#FFFFFF','o-color-5': '#141f2e', 'menu': 1, 'font': &quot;Poping&quot;}"/>
     </function>
 
     <function model="ir.ui.view" name="write">
-        <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('website.default_website').id).viewref('website.homepage').id"/>
+        <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('base.default_website').id).viewref('website.homepage').id"/>
         <value model="ir.ui.view" eval="{'arch': obj().env.ref('industry_real_estate.homepage').arch}"/>
     </function>
 

--- a/industry_real_estate/demo/website_view.xml
+++ b/industry_real_estate/demo/website_view.xml
@@ -3,7 +3,7 @@
     <record id="ir_ui_view_1416" model="ir.ui.view">
         <field name="name">About Us</field>
         <field name="key">website.about-us</field>
-        <field name="website_id" ref="website.default_website" />
+        <field name="website_id" ref="base.default_website" />
         <field name="type">qweb</field>
         <field name="arch" type="xml">
             <t name="About Us" t-name="website.about-us">
@@ -138,7 +138,7 @@
     <record id="homepage" model="ir.ui.view">
         <field name="name">Home</field>
         <field name="key">industry_real_estate.homepage</field>
-        <field name="website_id" ref="website.default_website" />
+        <field name="website_id" ref="base.default_website" />
         <field name="type">qweb</field>
         <field name="arch" type="xml">
             <t name="Homepage" t-name="website.homepage">
@@ -288,7 +288,7 @@
         <field name="active" eval="True"/>
         <field name="name">Header Hide Empty Cart link</field>
         <field name="type">qweb</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="arch" type="xml">
         <xpath expr="//t[@t-set='show_cart']" position="after">
             <t t-set="show_cart" t-value="website_sale_cart_quantity"/>

--- a/industry_restaurant/demo/website_attachment.xml
+++ b/industry_restaurant/demo/website_attachment.xml
@@ -4,70 +4,70 @@
     <record id="website_image_01" model="ir.attachment">
         <field name="name">website.library_image_02</field>
         <field name="key">industry_restaurant.library_image_02</field>
-        <field name="website_id" ref="website.default_website" />
+        <field name="website_id" ref="base.default_website" />
         <field name="raw" type="bytes" file="industry_restaurant/static/src/binary/ir_attachment/website_1.jpg" />
         <field name="public" eval="True"/>
     </record>
     <record id="website_image_02" model="ir.attachment">
         <field name="name">website.library_image_03</field>
         <field name="key">industry_restaurant.library_image_03</field>
-        <field name="website_id" ref="website.default_website" />
+        <field name="website_id" ref="base.default_website" />
         <field name="raw" type="bytes" file="industry_restaurant/static/src/binary/ir_attachment/website_2.jpg" />
         <field name="public" eval="True"/>
     </record>
     <record id="website_image_03" model="ir.attachment">
         <field name="name">website.library_image_05</field>
         <field name="key">industry_restaurant.library_image_05</field>
-        <field name="website_id" ref="website.default_website" />
+        <field name="website_id" ref="base.default_website" />
         <field name="raw" type="bytes" file="industry_restaurant/static/src/binary/ir_attachment/website_3.jpg" />
         <field name="public" eval="True"/>
     </record>
     <record id="website_image_04" model="ir.attachment">
         <field name="name">website.library_image_08</field>
         <field name="key">industry_restaurant.library_image_08</field>
-        <field name="website_id" ref="website.default_website" />
+        <field name="website_id" ref="base.default_website" />
         <field name="raw" type="bytes" file="industry_restaurant/static/src/binary/ir_attachment/website_4.jpg" />
         <field name="public" eval="True"/>
     </record>
     <record id="website_image_05" model="ir.attachment">
         <field name="name">website.library_image_10</field>
         <field name="key">industry_restaurant.library_image_10</field>
-        <field name="website_id" ref="website.default_website" />
+        <field name="website_id" ref="base.default_website" />
         <field name="raw" type="bytes" file="industry_restaurant/static/src/binary/ir_attachment/website_5.jpg" />
         <field name="public" eval="True"/>
     </record>
     <record id="website_image_06" model="ir.attachment">
         <field name="name">website.library_image_13</field>
         <field name="key">industry_restaurant.library_image_13</field>
-        <field name="website_id" ref="website.default_website" />
+        <field name="website_id" ref="base.default_website" />
         <field name="raw" type="bytes" file="industry_restaurant/static/src/binary/ir_attachment/website_6.jpg" />
         <field name="public" eval="True"/>
     </record>
     <record id="website_image_07" model="ir.attachment">
         <field name="name">website.library_image_14</field>
         <field name="key">industry_restaurant.library_image_14</field>
-        <field name="website_id" ref="website.default_website" />
+        <field name="website_id" ref="base.default_website" />
         <field name="raw" type="bytes" file="industry_restaurant/static/src/binary/ir_attachment/website_7.jpg" />
         <field name="public" eval="True"/>
     </record>
     <record id="website_image_08" model="ir.attachment">
         <field name="name">website.library_image_16</field>
         <field name="key">industry_restaurant.library_image_16</field>
-        <field name="website_id" ref="website.default_website" />
+        <field name="website_id" ref="base.default_website" />
         <field name="raw" type="bytes" file="industry_restaurant/static/src/binary/ir_attachment/website_8.jpg" />
         <field name="public" eval="True"/>
     </record>
     <record id="website_image_09" model="ir.attachment">
         <field name="name">website.s_banner_default_image</field>
         <field name="key">industry_restaurant.s_banner_default_image</field>
-        <field name="website_id" ref="website.default_website" />
+        <field name="website_id" ref="base.default_website" />
         <field name="raw" type="bytes" file="industry_restaurant/static/src/binary/ir_attachment/website_9.jpg" />
         <field name="public" eval="True"/>
     </record>
     <record id="website_image_10" model="ir.attachment">
         <field name="name">website.s_banner_default_image</field>
         <field name="key">industry_restaurant.s_banner_default_image</field>
-        <field name="website_id" ref="website.default_website" />
+        <field name="website_id" ref="base.default_website" />
         <field name="raw" type="bytes" file="industry_restaurant/static/src/binary/ir_attachment/website_10.jpg" />
         <field name="public" eval="True"/>
     </record>

--- a/industry_restaurant/demo/website_menu.xml
+++ b/industry_restaurant/demo/website_menu.xml
@@ -2,8 +2,8 @@
 <odoo noupdate="1">
     <record id="website_menu_14" model="website.menu">
         <field name="url">/menu</field>
-        <field name="parent_id" model="website.menu" eval="obj().search([('url', '=', '/default-main-menu'), ('website_id', '=', obj().env.ref('website.default_website').id)], limit=1).id"/>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="parent_id" model="website.menu" eval="obj().search([('url', '=', '/default-main-menu'), ('website_id', '=', obj().env.ref('base.default_website').id)], limit=1).id"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="name">Menu</field>
         <field name="sequence">11</field>
         <field name="page_id" ref="website_page_1"/>

--- a/industry_restaurant/demo/website_page.xml
+++ b/industry_restaurant/demo/website_page.xml
@@ -3,7 +3,7 @@
     <record id="website_page_1" model="website.page">
         <field name="url">/menu</field>
         <field name="view_id" ref="website_page_menu"/>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="is_published" eval="True"/>
     </record>
 </odoo>

--- a/industry_restaurant/demo/website_theme_apply.xml
+++ b/industry_restaurant/demo/website_theme_apply.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo>
     <function model="ir.ui.view" name="write">
-        <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('website.default_website').id).viewref('website.homepage').id"/>
+        <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('base.default_website').id).viewref('website.homepage').id"/>
         <value model="ir.ui.view" eval="{'arch': obj().env.ref('industry_restaurant.homepage').arch}"/>
     </function>
     <function model="website.assets" name="make_scss_customization">

--- a/industry_restaurant/demo/website_view.xml
+++ b/industry_restaurant/demo/website_view.xml
@@ -5,7 +5,7 @@
         <field name="name">Home</field>
         <field name="key">industry_restaurant.homepage</field>
         <field name="type">qweb</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="arch" type="xml">
             <t name="Homepage" t-name="website.homepage">
                 <t t-call="website.layout" pageName.f="homepage">
@@ -104,7 +104,7 @@
         <field name="name">Menu</field>
         <field name="key">industry_restaurant.menu</field>
         <field name="type">qweb</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="arch" type="xml">
             <t t-name="website.menu">
                 <t t-call="website.layout">
@@ -230,7 +230,7 @@
         <field name="name">Header Call to Action</field>
         <field name="type">qweb</field>
         <field name="key">website.header_call_to_action</field>
-        <field name="website_id" ref="website.default_website" />
+        <field name="website_id" ref="base.default_website" />
         <field name="inherit_id" ref="website.placeholder_header_call_to_action" />
         <field name="arch" type="xml">
             <data inherit_id="website.placeholder_header_call_to_action" name="Header Call to Action" active="True">

--- a/it_hardware/data/website_theme_apply.xml
+++ b/it_hardware/data/website_theme_apply.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo>
     <function name="write" model="ir.ui.view">
-        <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=ref('website.default_website')).viewref('website.contactus').id"/>
+        <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=ref('base.default_website')).viewref('website.contactus').id"/>
         <value model="ir.ui.view" eval="{'arch': obj().env.ref('it_hardware.contactus').arch}"/>
     </function>
 </odoo>

--- a/it_hardware/data/website_view.xml
+++ b/it_hardware/data/website_view.xml
@@ -4,7 +4,7 @@
         <field name="name">Contact Us</field>
         <field name="key">it_hardware.contactus</field>
         <field name="type">qweb</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="active" eval="True"/>
         <field name="arch" type="xml">
             <t name="Contact Us" t-name="website.contactus">

--- a/it_hardware/demo/sale_order.xml
+++ b/it_hardware/demo/sale_order.xml
@@ -2,7 +2,7 @@
 <odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
     <record id="sale_order_1" model="sale.order">
         <field name="partner_id" ref="base.partner_admin"/>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="user_id" ref="base.user_admin"/>
     </record>
     <record id="sale_order_2" model="sale.order">
@@ -11,12 +11,12 @@
     </record>
     <record id="sale_order_3" model="sale.order">
         <field name="partner_id" ref="res_partner_14"/>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="user_id" ref="base.user_admin"/>
     </record>
     <record id="sale_order_4" model="sale.order">
         <field name="partner_id" ref="base.public_partner"/>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="user_id" ref="base.user_admin"/>
     </record>
 </odoo>

--- a/it_hardware/demo/website.xml
+++ b/it_hardware/demo/website.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-    <record id="website.default_website" model="website" forcecreate="1">
+    <record id="base.default_website" model="website" forcecreate="1">
         <field name="name">demo-ithardwaresaleservice</field>
         <field name="theme_id" search="[('id', '=', ref('base.module_theme_graphene', raise_if_not_found=False))]"/>
         <field name="logo" type="bytes" file="it_hardware/static/description/icon.png"/>

--- a/it_hardware/demo/website_attachment.xml
+++ b/it_hardware/demo/website_attachment.xml
@@ -3,28 +3,28 @@
     <record id="ir_attachment_527" model="ir.attachment">
         <field name="name">computer-desktop-pc-logo-design-icon-vector-27041769.jpg</field>
         <field name="res_model">ir.ui.view</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
         <field name="raw" type="bytes" file="it_hardware/static/src/binary/ir_attachment/527-computer-desktop-pc-logo-design-icon-vector-27041769.jpg"/>
     </record>
     <record id="configurator_1_s_cover_default_image" model="ir.attachment">
         <field name="name">website.s_cover_default_image</field>
         <field name="key">website.s_cover_default_image</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
         <field name="raw" type="bytes" file="it_hardware/static/src/binary/ir_attachment/432-website.s_cover_default_image"/>
     </record>
     <record id="configurator_1_s_picture_default_image" model="ir.attachment">
         <field name="name">website.s_picture_default_image</field>
         <field name="key">website.s_picture_default_image</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
         <field name="raw" type="bytes" file="it_hardware/static/src/binary/ir_attachment/451-website.s_picture_default_image"/>
     </record>
     <record id="configurator_1_s_text_image_default_image" model="ir.attachment">
         <field name="name">website.s_text_image_default_image</field>
         <field name="key">website.s_text_image_default_image</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
         <field name="raw" type="bytes" file="it_hardware/static/src/binary/ir_attachment/453-website.s_text_image_default_image"/>
     </record>

--- a/it_hardware/demo/website_theme_apply.xml
+++ b/it_hardware/demo/website_theme_apply.xml
@@ -2,13 +2,13 @@
 <odoo>
     <function name="button_choose_theme" model="ir.module.module" eval="[ref('base.module_theme_graphene', raise_if_not_found=False) or ref('base.module_theme_default')]"/>
 
-    <function model="website.assets" name="make_scss_customization" context="{'website_id': ref('website.default_website')}">
+    <function model="website.assets" name="make_scss_customization" context="{'website_id': ref('base.default_website')}">
         <value eval="'/website/static/src/scss/options/colors/user_color_palette.scss'"/>
         <value eval="{'o-color-1': '#0b4f9f','o-color-2': '#101c35','o-color-3': '#E7E8EB','o-color-4': '#FFFFFF','o-color-5': '#083B77', 'menu': 1}"/>
     </function>
     
     <function model="ir.ui.view" name="write">
-        <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('website.default_website').id).viewref('website.homepage').id"/>
+        <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('base.default_website').id).viewref('website.homepage').id"/>
         <value model="ir.ui.view" eval="{'arch': obj().env.ref('it_hardware.homepage').arch.replace(
             '*filter_newest_products_it_hardware*', str(obj().env.ref('website_sale.dynamic_filter_newest_products').id)
         )}"/>

--- a/it_hardware/demo/website_view.xml
+++ b/it_hardware/demo/website_view.xml
@@ -4,7 +4,7 @@
         <field name="name">Home</field>
         <field name="type">qweb</field>
         <field name="key">it_hardware.homepage</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="arch" type="xml">
             <t name="Homepage" t-name="website.homepage">
                 <t t-call="website.layout" pageName.f="homepage">

--- a/library/demo/product_pricelist.xml
+++ b/library/demo/product_pricelist.xml
@@ -1,10 +1,10 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
   <record id="product_pricelist_1" model="product.pricelist">
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
     <field name="selectable" eval="True"/>
   </record>
   <record id="product_pricelist_2" model="product.pricelist">
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
   </record>
 </odoo>

--- a/library/demo/website.xml
+++ b/library/demo/website.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-  <record id="website.default_website" model="website" forcecreate="1">
+  <record id="base.default_website" model="website" forcecreate="1">
     <field name="name">Library</field>
     <field name="configurator_done" eval="True"/>
     <field name="logo" type="bytes" file="library/static/description/icon.png"/>

--- a/library/demo/website_page.xml
+++ b/library/demo/website_page.xml
@@ -2,13 +2,13 @@
 <odoo noupdate="1">
   <record id="website_page_4" model="website.page">
     <field name="view_id" ref="ir_ui_view_1678"/>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
     <field name="is_published" eval="True"/>
     <field name="url">/</field>
   </record>
   <record id="website_page_7" model="website.page">
     <field name="view_id" ref="ir_ui_view_3890"/>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
     <field name="is_published" eval="True"/>
     <field name="url">/privacy</field>
   </record>

--- a/library/demo/website_theme_apply.xml
+++ b/library/demo/website_theme_apply.xml
@@ -4,36 +4,36 @@
   <function name="button_choose_theme" model="ir.module.module" eval="[ref('base.module_theme_bewise', raise_if_not_found=False)  or ref('base.module_theme_default')]"/>
 
   <function model="ir.ui.view" name="write">
-    <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('website.default_website').id).viewref('website.homepage').id"/>
+    <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('base.default_website').id).viewref('website.homepage').id"/>
     <value model="ir.ui.view" eval="{'arch': obj().env.ref('library.ir_ui_view_1678').arch.replace(
       '*filter_newest_products_library*', str(obj().env.ref('website_sale.dynamic_filter_newest_products').id)
     )}"/>
   </function>
 
   <function model="ir.ui.view" name="write">
-    <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('website.default_website').id).viewref('website.contactus').id"/>
+    <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('base.default_website').id).viewref('website.contactus').id"/>
     <value model="ir.ui.view" eval="{'arch': obj().env.ref('library.ir_ui_view_3951').arch}"/>
   </function>
   <function model="ir.ui.view" name="write">
-    <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('website.default_website').id).viewref('website.template_footer_headline').id"/>
+    <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('base.default_website').id).viewref('website.template_footer_headline').id"/>
     <value model="ir.ui.view" eval="{'arch': obj().env.ref('library.ir_ui_view_3888').arch}"/>
   </function>
 
   <function model="ir.ui.view" name="write">
-    <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=ref('website.default_website')).viewref('website.footer_custom').id"/>
+    <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=ref('base.default_website')).viewref('website.footer_custom').id"/>
     <value eval="{'active': False}"/>
   </function>
   <function model="ir.ui.view" name="write">
-    <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=ref('website.default_website')).viewref('website.template_footer_headline').id"/>
+    <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=ref('base.default_website')).viewref('website.template_footer_headline').id"/>
     <value eval="{'active': True}"/>
   </function>
 
   <function name="write" model="ir.ui.view">
-    <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=ref('website.default_website')).viewref('website_sale.filter_products_price').id"/>
+    <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=ref('base.default_website')).viewref('website_sale.filter_products_price').id"/>
     <value model="ir.ui.view" eval="{'active': False}"/>
   </function>
   <function name="write" model="ir.ui.view">
-    <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=ref('website.default_website')).viewref('website_sale.filmstrip_categories_images').id"/>
+    <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=ref('base.default_website')).viewref('website_sale.filmstrip_categories_images').id"/>
     <value model="ir.ui.view" eval="{'active': True}"/>
   </function>
 
@@ -77,13 +77,13 @@
   <data noupdate="1">
     <function model="website.menu" name="unlink">
       <value model="website.menu" eval="obj().search([
-            ('website_id', '=', ref('website.default_website')),
+            ('website_id', '=', ref('base.default_website')),
             ('url', '=', '/appointment'),
           ]).ids"/>
     </function>
     <function model="website.menu" name="write">
       <value model="website.menu" eval="obj().search([
-              ('website_id', '=', ref('website.default_website')),
+              ('website_id', '=', ref('base.default_website')),
               ('name', '=', 'Shop'),
           ], limit=1).id"/>
       <value eval="{'name': 'Catalog'}"/>

--- a/library/demo/website_view.xml
+++ b/library/demo/website_view.xml
@@ -69,7 +69,7 @@
     <field name="mode">extension</field>
     <field name="name">Headline</field>
     <field name="type">qweb</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
   </record>
   <record id="ir_ui_view_1678" model="ir.ui.view">
     <field name="arch" type="xml">
@@ -184,7 +184,7 @@
     <field name="key">library.homepage</field>
     <field name="name">Home</field>
     <field name="type">qweb</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
   </record>
   <record id="ir_ui_view_3890" model="ir.ui.view">
     <field name="arch" type="xml">
@@ -256,7 +256,7 @@
     <field name="key">website.privacy-policy</field>
     <field name="name">Privacy Policy</field>
     <field name="type">qweb</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
   </record>
   <record id="ir_ui_view_3953" model="ir.ui.view">
     <field name="arch" type="xml">
@@ -276,7 +276,7 @@
     <field name="key">website.record_cover</field>
     <field name="name">record_cover</field>
     <field name="type">qweb</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
   </record>
   <record id="ir_ui_view_3951" model="ir.ui.view">
     <field name="arch" type="xml">
@@ -395,6 +395,6 @@
     <field name="key">library.website.contactus</field>
     <field name="name">Contact Us</field>
     <field name="type">qweb</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
   </record>
 </odoo>

--- a/marketing_agency/data/res_config_settings.xml
+++ b/marketing_agency/data/res_config_settings.xml
@@ -1,13 +1,10 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
     <record id="res_config_account_setting_marketing" model="res.config.settings">
-        <field name="extract_single_line_per_tax" eval="0"/>
         <field name="group_analytic_accounting" eval="1"/>
         <field name="group_product_pricelist" eval="1"/>
         <field name="group_project_stages" eval="1"/>
         <field name="group_sale_order_template" eval="1"/>
-        <field name="module_sale_pdf_quote_builder" eval="1"/>
-        <field name="predict_bill_product" eval="0"/>
     </record>
     <function name="execute" model="res.config.settings" eval="[ref('res_config_account_setting_marketing')]"/>
 </odoo>

--- a/marketing_agency/demo/website.xml
+++ b/marketing_agency/demo/website.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-    <record id="website.default_website" model="website" forcecreate="1">
+    <record id="base.default_website" model="website" forcecreate="1">
         <field name="name">Marketing Agency</field>
         <field name="logo" type="bytes" file="marketing_agency/static/src/binary/website/1-logo"/>
         <field name="favicon" type="bytes" file="marketing_agency/static/src/binary/website/1-favicon"/>

--- a/marketing_agency/demo/website_theme_apply.xml
+++ b/marketing_agency/demo/website_theme_apply.xml
@@ -4,11 +4,11 @@
 
     <!-- <function model="theme.utils" name="enable_view" eval="['website.template_header_hamburger']"/> -->
     <function model="theme.utils" name="enable_view" eval="['website.no_autohide_menu']"/>
-    <function name="make_scss_customization" model="website.assets" context="{'website_id': ref('website.default_website')}">
+    <function name="make_scss_customization" model="website.assets" context="{'website_id': ref('base.default_website')}">
         <value eval="'/website/static/src/scss/options/colors/user_color_palette.scss'"/>
         <value eval="{'o-color-1': '#D23C47','o-color-2': '#FFC300','o-color-3': '#E9E9E9','o-color-5': '#191919'}"/>
     </function>
-    <function model="website.assets" name="make_scss_customization" context="{'website_id': ref('website.default_website')}">
+    <function model="website.assets" name="make_scss_customization" context="{'website_id': ref('base.default_website')}">
         <value eval="'/website/static/src/scss/options/user_values.scss'"/>
         <value eval="{
             'menu-gradient': 'null',
@@ -44,32 +44,32 @@
         }"/>
     </function>
     <function model="ir.ui.view" name="write">
-        <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('website.default_website').id).viewref('website.homepage').id"/>
+        <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('base.default_website').id).viewref('website.homepage').id"/>
         <value model="ir.ui.view" eval="{'arch': obj().env.ref('marketing_agency.ir_ui_view_1840').arch}"/>
     </function>
     <function model="ir.ui.view" name="write">
-        <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('website.default_website').id).viewref('website.contactus').id"/>
+        <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('base.default_website').id).viewref('website.contactus').id"/>
         <value model="ir.ui.view" eval="{'arch': obj().env.ref('marketing_agency.ir_ui_view_3354').arch.replace(
         '*sales_team_team_sales_department*', str(obj().env.ref('sales_team.team_sales_department').id)).replace(
         '*base_user_admin*', str(obj().env.ref('base.user_admin').id))
         }"/>
     </function>
     <function model="ir.ui.view" name="write">
-        <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('website.default_website').id).viewref('website.template_footer_call_to_action').id"/>
+        <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('base.default_website').id).viewref('website.template_footer_call_to_action').id"/>
         <value model="ir.ui.view" eval="{'arch': obj().env.ref('marketing_agency.ir_ui_view_3353').arch}"/>
     </function>
     <function model="ir.ui.view" name="write">
-        <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('website.default_website').id).viewref('website.footer_copyright_company_name').id"/>
+        <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('base.default_website').id).viewref('website.footer_copyright_company_name').id"/>
         <value model="ir.ui.view" eval="{'arch': obj().env.ref('marketing_agency.ir_ui_view_3356').arch}"/>
     </function>
     <function model="ir.ui.view" name="write">
-        <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('website.default_website').id).viewref('website.record_cover').id"/>
+        <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('base.default_website').id).viewref('website.record_cover').id"/>
         <value model="ir.ui.view" eval="{'arch': obj().env.ref('marketing_agency.ir_ui_view_3347').arch}"/>
     </function>
     
     <data noupdate="1">
         <function model="website.menu" name="unlink">
-            <value model="website.menu" eval="obj().search([('website_id', '=', ref('website.default_website')), ('url', '=', '/shop')]).ids"/>
+            <value model="website.menu" eval="obj().search([('website_id', '=', ref('base.default_website')), ('url', '=', '/shop')]).ids"/>
         </function>
     </data>
 </odoo>

--- a/marketing_agency/demo/website_view.xml
+++ b/marketing_agency/demo/website_view.xml
@@ -29,7 +29,7 @@
         <field name="mode">extension</field>
         <field name="name">Call-to-Action</field>
         <field name="type">qweb</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
     </record>
     <record id="ir_ui_view_3354" model="ir.ui.view">
         <field name="arch" type="xml">
@@ -175,7 +175,7 @@
         <field name="key">marketing.contactus</field>
         <field name="name">Contact Us</field>
         <field name="type">qweb</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
     </record>
     <record id="ir_ui_view_1840" model="ir.ui.view">
         <field name="arch" type="xml">
@@ -521,7 +521,7 @@
         <field name="key">marketing.homepage</field>
         <field name="name">Home</field>
         <field name="type">qweb</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
     </record>
     <record id="ir_ui_view_3356" model="ir.ui.view">
         <field name="arch" type="xml">
@@ -536,7 +536,7 @@
         <field name="mode">extension</field>
         <field name="name">footer_copyright_company_name</field>
         <field name="type">qweb</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
     </record>
     <record id="ir_ui_view_3347" model="ir.ui.view">
         <field name="arch" type="xml">
@@ -556,7 +556,7 @@
         <field name="key">marketing.record_cover</field>
         <field name="name">record_cover</field>
         <field name="type">qweb</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
     </record>
     <record id="website_sale.header_hide_empty_cart_link" model="ir.ui.view" forcecreate="0">
         <field name="active" eval="True"/>

--- a/members_club/demo/website.xml
+++ b/members_club/demo/website.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-  <record id="website.default_website" model="website" forcecreate="1">
+  <record id="base.default_website" model="website" forcecreate="1">
     <field name="name">members-club</field>
     <field name="configurator_done" eval="True"/>
     <field name="logo" type="bytes" file="members_club/static/description/icon.png"/>

--- a/members_club/demo/website_menu.xml
+++ b/members_club/demo/website_menu.xml
@@ -2,37 +2,37 @@
 <odoo auto_sequence="1" noupdate="1">
   <function model="website.menu" name="unlink">
         <value model="website.menu"
-            eval="obj().search([('website_id', '=', ref('website.default_website')), ('url', '=', '#')]).ids" />
+            eval="obj().search([('website_id', '=', ref('base.default_website')), ('url', '=', '#')]).ids" />
   </function>
   <record id="website_menu_4" model="website.menu">
     <field name="name">Top Menu for Website 1</field>
     <field name="url">/</field>
     <field name="sequence" eval="False"/>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
   </record>
   <record id="website_menu_5" model="website.menu">
     <field name="name">Home</field>
     <field name="url">/</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
     <field name="parent_id" ref="website_menu_4"/>
   </record>
   <record id="website_menu_11" model="website.menu">
     <field name="name">Events</field>
     <field name="url">/event</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
     <field name="parent_id" ref="website_menu_4"/>
   </record>
   <record id="website_menu_13" model="website.menu">
     <field name="name">News</field>
     <field name="url">/blog/news-2</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
     <field name="parent_id" ref="website_menu_4"/>
   </record>
   <record id="website_menu_15" model="website.menu">
     <field name="name">Donations</field>
     <field name="page_id" ref="website_page_7"/>
     <field name="url">/donations</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
     <field name="parent_id" ref="website_menu_4"/>
     <field name="group_ids" eval="[(6, 0, [ref('base.group_user')])]"/>
   </record>

--- a/members_club/demo/website_page.xml
+++ b/members_club/demo/website_page.xml
@@ -2,13 +2,13 @@
 <odoo noupdate="1">
   <record id="website_page_6" model="website.page">
     <field name="view_id" ref="ir_ui_view_3733"/>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
     <field name="is_published" eval="True"/>
     <field name="url">/become-a-member</field>
   </record>
   <record id="website_page_7" model="website.page">
     <field name="view_id" ref="ir_ui_view_3759"/>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
     <field name="is_published" eval="True"/>
     <field name="url">/donations</field>
   </record>

--- a/members_club/demo/website_theme_apply.xml
+++ b/members_club/demo/website_theme_apply.xml
@@ -12,11 +12,11 @@
   <function model="theme.utils" name="disable_view" eval="['website_sale.products_categories_top']"/>
   <function model="theme.utils" name="enable_view" eval="['website_sale.header_hide_empty_cart_link']"/>
   <function model="ir.ui.view" name="write">
-    <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('website.default_website').id).viewref('website.template_footer_centered').id"/>
+    <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('base.default_website').id).viewref('website.template_footer_centered').id"/>
     <value model="ir.ui.view" eval="{'arch': obj().env.ref('members_club.ir_ui_view_3646').arch}"/>
   </function>
   <function model="ir.ui.view" name="write">
-    <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('website.default_website').id).viewref('website.homepage').id"/>
+    <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('base.default_website').id).viewref('website.homepage').id"/>
     <value model="ir.ui.view" eval="{'arch': obj().env.ref('members_club.homepage').arch}"/>
   </function>
 

--- a/members_club/demo/website_view.xml
+++ b/members_club/demo/website_view.xml
@@ -102,7 +102,7 @@
     <field name="key">website.become-a-member</field>
     <field name="name">Become a member</field>
     <field name="type">qweb</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
   </record>
   <record id="ir_ui_view_3646" model="ir.ui.view">
     <field name="arch" type="xml">
@@ -154,7 +154,7 @@
     <field name="mode">extension</field>
     <field name="name">Centered</field>
     <field name="type">qweb</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
   </record>
   <record id="ir_ui_view_3759" model="ir.ui.view">
     <field name="arch" type="xml">
@@ -215,7 +215,7 @@
     <field name="key">website.donations</field>
     <field name="name">Donations</field>
     <field name="type">qweb</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
   </record>
   <record id="ir_ui_view_3741" model="ir.ui.view">
     <field name="arch" type="xml">
@@ -230,7 +230,7 @@
     <field name="mode">extension</field>
     <field name="name">Events (oe_structure_we_index_0)</field>
     <field name="type">qweb</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
   </record>
   <record id="ir_ui_view_3734" model="ir.ui.view">
     <field name="arch" type="xml">
@@ -253,7 +253,7 @@
     <field name="mode">extension</field>
     <field name="name">Header Call to Action</field>
     <field name="type">qweb</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
   </record>
   <record id="ir_ui_view_3756" model="ir.ui.view">
     <field name="arch" type="xml">
@@ -286,7 +286,7 @@
     <field name="mode">extension</field>
     <field name="name">Header Social Links</field>
     <field name="type">qweb</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
   </record>
   <record id="homepage" model="ir.ui.view">
     <field name="arch" type="xml">
@@ -490,7 +490,7 @@
     <field name="key">members_club.homepage</field>
     <field name="name">Home</field>
     <field name="type">qweb</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
   </record>
   <record id="ir_ui_view_3774" model="ir.ui.view">
     <field name="arch" type="xml">
@@ -523,7 +523,7 @@
     <field name="mode">extension</field>
     <field name="name">Products (oe_structure_website_sale_products_1)</field>
     <field name="type">qweb</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
   </record>
   <record id="website_sale.sort" model="ir.ui.view" forcecreate="0">
     <field name="active" eval="False"/>

--- a/metal_fabricator/demo/website.xml
+++ b/metal_fabricator/demo/website.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-  <record id="website.default_website" model="website" forcecreate="1">
+  <record id="base.default_website" model="website" forcecreate="1">
     <field name="name">Metal-Fabricator</field>
     <field name="configurator_done" eval="True"/>
     <field name="logo" type="bytes" file="metal_fabricator/static/description/icon.png"/>

--- a/metal_fabricator/demo/website_theme_apply.xml
+++ b/metal_fabricator/demo/website_theme_apply.xml
@@ -3,15 +3,15 @@
   <function name="button_choose_theme" model="ir.module.module" eval="[ref('base.module_theme_vehicle', raise_if_not_found=False) or ref('base.module_theme_default')]"/>
 
   <function model="ir.ui.view" name="write">
-    <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('website.default_website').id).viewref('website.homepage').id"/>
+    <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('base.default_website').id).viewref('website.homepage').id"/>
     <value model="ir.ui.view" eval="{'arch': obj().env.ref('metal_fabricator.homepage').arch}"/>
   </function>
   <function model="ir.ui.view" name="write">
-    <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('website.default_website').id).viewref('website.contactus').id"/>
+    <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('base.default_website').id).viewref('website.contactus').id"/>
     <value model="ir.ui.view" eval="{'arch': obj().env.ref('metal_fabricator.contactus').arch}"/>
   </function>
    <function model="ir.ui.view" name="write">
-    <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('website.default_website').id).viewref('website.template_footer_descriptive').id"/>
+    <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('base.default_website').id).viewref('website.template_footer_descriptive').id"/>
     <value model="ir.ui.view" eval="{'arch': obj().env.ref('metal_fabricator.footer').arch}"/>
   </function>
 

--- a/metal_fabricator/demo/website_view.xml
+++ b/metal_fabricator/demo/website_view.xml
@@ -129,7 +129,7 @@
     <field name="key">metal_fabricator.contactus</field>
     <field name="name">Contact Us</field>
     <field name="type">qweb</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
   </record>
   <record id="homepage" model="ir.ui.view">
     <field name="arch" type="xml">
@@ -200,7 +200,7 @@
     <field name="key">metal_fabricator.homepage</field>
     <field name="name">Home</field>
     <field name="type">qweb</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
   </record>
   <record id="footer" model="ir.ui.view">
     <field name="arch" type="xml">
@@ -256,6 +256,6 @@
     <field name="mode">extension</field>
     <field name="name">Minimalist</field>
     <field name="type">qweb</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
   </record>
 </odoo>

--- a/micro_brewery/data/website_view.xml
+++ b/micro_brewery/data/website_view.xml
@@ -5,7 +5,7 @@
         <field name="key">micro_brewery.contactus</field>
         <field name="type">qweb</field>
         <field name="active" eval="True"/>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="arch" type="xml">
             <t name="Contact Us" t-name="website.contactus">
                 <t t-call="website.layout"
@@ -150,7 +150,7 @@
         </field>
     </record>
     <function name="write" model="ir.ui.view">
-        <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=ref('website.default_website')).viewref('website.contactus').id"/>
+        <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=ref('base.default_website')).viewref('website.contactus').id"/>
         <value model="ir.ui.view" eval="{'arch': obj().env.ref('micro_brewery.contactus').arch.replace(
         '*base_user_admin*', str(obj().env.ref('base.user_admin').id)
         )}"/>

--- a/micro_brewery/demo/website.xml
+++ b/micro_brewery/demo/website.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-  <record id="website.default_website" model="website" forcecreate="1">
+  <record id="base.default_website" model="website" forcecreate="1">
     <field name="name">Micro Brewery</field>
     <field name="configurator_done" eval="True"/>
     <field name="logo" type="bytes" file="micro_brewery/static/description/icon.png"/>

--- a/micro_brewery/demo/website_menu.xml
+++ b/micro_brewery/demo/website_menu.xml
@@ -3,28 +3,28 @@
   <record id="website_menu_4" model="website.menu">
     <field name="name">Top Menu for Website 1</field>
     <field name="sequence" eval="False"/>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
   </record>
   <record id="website_menu_5" model="website.menu">
     <field name="name">o-beer</field>
     <field name="page_id" ref="website_page_4"/>
     <field name="url">/</field>
     <field name="sequence" eval="False"/>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
     <field name="parent_id" ref="website_menu_4"/>
   </record>
   <record id="website_menu_9" model="website.menu">
     <field name="name">Our eShop</field>
     <field name="url">/shop</field>
     <field name="sequence">1</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
     <field name="parent_id" ref="website_menu_4"/>
   </record>
   <record id="website_menu_11" model="website.menu">
     <field name="name">Visit the brewery</field>
     <field name="url">/appointment</field>
     <field name="sequence">2</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
     <field name="parent_id" ref="website_menu_4"/>
   </record>
   <record id="website_menu_6" model="website.menu">
@@ -32,7 +32,7 @@
     <field name="page_id" ref="website_page_6"/>
     <field name="url">/contactus</field>
     <field name="sequence">3</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
     <field name="parent_id" ref="website_menu_4"/>
   </record>
 </odoo>

--- a/micro_brewery/demo/website_page.xml
+++ b/micro_brewery/demo/website_page.xml
@@ -2,13 +2,13 @@
 <odoo noupdate="1">
   <record id="website_page_6" model="website.page">
     <field name="view_id" ref="contactus"/>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
     <field name="is_published" eval="True"/>
     <field name="url">/contactus</field>
   </record>
   <record id="website_page_4" model="website.page">
     <field name="view_id" ref="homepage"/>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
     <field name="is_published" eval="True"/>
     <field name="url">/</field>
   </record>

--- a/micro_brewery/demo/website_theme_apply.xml
+++ b/micro_brewery/demo/website_theme_apply.xml
@@ -2,13 +2,13 @@
 <odoo>
   <function name="button_choose_theme" model="ir.module.module" eval="[ref('base.module_theme_enark', raise_if_not_found=False) or ref('base.module_theme_default')]"/>
     
-  <function name="make_scss_customization" model="website.assets" context="{'website_id': ref('website.default_website')}">
+  <function name="make_scss_customization" model="website.assets" context="{'website_id': ref('base.default_website')}">
     <value eval="'/website/static/src/scss/options/colors/user_color_palette.scss'"/>
     <value eval="{'o-color-1': '#e6b500','o-color-2': '#080903','o-color-3': '#FBFBFB','o-color-4': '#FFFFFF','o-color-5': '#714b67', 'menu': 1}"/>
   </function>
 
   <function name="write" model="ir.ui.view">
-    <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=ref('website.default_website')).viewref('website.homepage').id"/>
+    <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=ref('base.default_website')).viewref('website.homepage').id"/>
     <value model="ir.ui.view" eval="{'arch': obj().env.ref('micro_brewery.homepage').arch.replace(
       '*filter_newest_products_micro_brewery*', str(obj().env.ref('website_sale.dynamic_filter_newest_products').id)
     )}"/>

--- a/micro_brewery/demo/website_view.xml
+++ b/micro_brewery/demo/website_view.xml
@@ -75,7 +75,7 @@
     <field name="mode">extension</field>
     <field name="name">Default</field>
     <field name="type">qweb</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
   </record>
   <record id="homepage" model="ir.ui.view">
     <field name="arch" type="xml">
@@ -233,7 +233,7 @@
     <field name="key">micro_brewery.website.homepage</field>
     <field name="name">Home</field>
     <field name="type">qweb</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
   </record>
   <record id="ir_ui_view_3854" model="ir.ui.view">
     <field name="arch" type="xml">
@@ -269,10 +269,10 @@
     <field name="name">Share Buttons</field>
     <field name="priority">22</field>
     <field name="type">qweb</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
   </record>
   <function model="ir.ui.view" name="write">
-    <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('website.default_website').id).viewref('website.homepage').id"/>
+    <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('base.default_website').id).viewref('website.homepage').id"/>
     <value model="ir.ui.view" eval="{'arch': obj().env.ref('micro_brewery.homepage').arch}"/>
   </function>
 </odoo>

--- a/museum/demo/website.xml
+++ b/museum/demo/website.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-  <record id="website.default_website" model="website" forcecreate="1">
+  <record id="base.default_website" model="website" forcecreate="1">
     <field name="name">Museum</field>
     <field name="configurator_done" eval="True"/>
     <field name="logo" type="bytes" file="museum/static/description/icon.png"/>

--- a/museum/demo/website_menu.xml
+++ b/museum/demo/website_menu.xml
@@ -5,9 +5,9 @@
     <field name="page_id" ref="website_page_6"/>
     <field name="url">/exhibitions</field>
     <field name="sequence">11</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
     <field name="parent_id" model="website.menu" eval="obj().search([
-                ('website_id', '=', ref('website.default_website')),
+                ('website_id', '=', ref('base.default_website')),
                 ('url', '=', '#'),
     ], limit=1).id"/>
   </record>
@@ -15,9 +15,9 @@
     <field name="name">VISIT</field>
     <field name="url" model="event.event" eval="obj().env.ref('museum.event_event_4').website_url"/>
     <field name="sequence">12</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
     <field name="parent_id" model="website.menu" eval="obj().search([
-                ('website_id', '=', ref('website.default_website')),
+                ('website_id', '=', ref('base.default_website')),
                 ('url', '=', '#'),
     ], limit=1).id"/>
   </record>

--- a/museum/demo/website_page.xml
+++ b/museum/demo/website_page.xml
@@ -2,25 +2,25 @@
 <odoo noupdate="1">
   <record id="website_page_6" model="website.page">
       <field name="view_id" ref="exhibitions"/>
-      <field name="website_id" ref="website.default_website"/>
+      <field name="website_id" ref="base.default_website"/>
       <field name="url">/exhibitions</field>
       <field name="is_published" eval="True"/>
   </record>
   <record id="website_page_8" model="website.page">
       <field name="view_id" ref="donations"/>
-      <field name="website_id" ref="website.default_website"/>
+      <field name="website_id" ref="base.default_website"/>
       <field name="url">/donations</field>
       <field name="is_published" eval="True"/>
   </record>
   <record id="website_page_4" model="website.page">
       <field name="view_id" ref="homepage"/>
-      <field name="website_id" ref="website.default_website"/>
+      <field name="website_id" ref="base.default_website"/>
       <field name="is_published" eval="True"/>
       <field name="url">/</field>
   </record>
   <record id="website_page_7" model="website.page">
         <field name="view_id" ref="contactus"/>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="is_published" eval="True"/>
         <field name="url">/contactus</field>
   </record>

--- a/museum/demo/website_theme_apply.xml
+++ b/museum/demo/website_theme_apply.xml
@@ -40,12 +40,12 @@
     </function>
 
     <function model="ir.ui.view" name="write">
-      <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('website.default_website').id).viewref('website.homepage').id"/>
+      <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('base.default_website').id).viewref('website.homepage').id"/>
       <value model="ir.ui.view" eval="{'arch': obj().env.ref('museum.homepage').arch}"/>
     </function>
 
     <function name="write" model="ir.ui.view">
-        <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=ref('website.default_website')).viewref('website.contactus').id"/>
+        <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=ref('base.default_website')).viewref('website.contactus').id"/>
         <value model="ir.ui.view" eval="{'arch': obj().env.ref('museum.contactus').arch}"/>
     </function>
 
@@ -56,18 +56,18 @@
 
     <data noupdate="1">
       <function name="write" model="website.menu">
-        <value model="website.menu" eval="obj().search([('url', '=', '/'), ('website_id', '=', ref('website.default_website'))], limit=1).id"/>
+        <value model="website.menu" eval="obj().search([('url', '=', '/'), ('website_id', '=', ref('base.default_website'))], limit=1).id"/>
         <value eval="{'name': 'HOME'}"/>
       </function>
       <function name="write" model="website.menu">
-            <value model="website.menu" eval="obj().search([('url', '=', '/contactus'), ('website_id', '=', ref('website.default_website'))], limit=1).id"/>
+            <value model="website.menu" eval="obj().search([('url', '=', '/contactus'), ('website_id', '=', ref('base.default_website'))], limit=1).id"/>
             <value eval="{'name': 'CONTACT US'}"/>
         </function>
       <function model="website.menu" name="unlink">
-        <value model="website.menu" eval="obj().search([('website_id', '=', ref('website.default_website')), ('url', '=', '/shop')]).ids"/>
+        <value model="website.menu" eval="obj().search([('website_id', '=', ref('base.default_website')), ('url', '=', '/shop')]).ids"/>
       </function>
       <function model="website.menu" name="unlink">
-        <value model="website.menu" eval="obj().search([('website_id', '=', ref('website.default_website')), ('url', '=', '/event')]).ids"/>
+        <value model="website.menu" eval="obj().search([('website_id', '=', ref('base.default_website')), ('url', '=', '/event')]).ids"/>
       </function>
     </data>
     <function model="ir.ui.view" name="write">

--- a/museum/demo/website_view.xml
+++ b/museum/demo/website_view.xml
@@ -4,7 +4,7 @@
     <field name="name">Donations</field>
     <field name="key">museum.donations</field>
     <field name="type">qweb</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
     <field name="arch" type="xml">
       <t t-name="website.donations">
         <t t-call="website.layout">
@@ -75,7 +75,7 @@
     <field name="name">EXHIBITIONS</field>
     <field name="key">museum.exhibitions</field>
     <field name="type">qweb</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
     <field name="arch" type="xml">
       <t t-name="website.exhibitions">
         <t t-call="website.layout">
@@ -363,13 +363,13 @@ Public readings, workshops, and open dialogue
     <field name="mode">extension</field>
     <field name="name">Header Call to Action</field>
     <field name="type">qweb</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
   </record>
   <record id="homepage" model="ir.ui.view">
     <field name="name">Home</field>
     <field name="key">museum.homepage</field>
     <field name="type">qweb</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
     <field name="arch" type="xml">
       <t name="Homepage" t-name="website.homepage">
         <t t-call="website.layout" pageName.f="homepage">
@@ -534,14 +534,14 @@ Public readings, workshops, and open dialogue
     <field name="key">website.record_cover</field>
     <field name="name">record_cover</field>
     <field name="type">qweb</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
   </record>
   <record id="contactus" model="ir.ui.view">
         <field name="name">Contact Us</field>
         <field name="key">museum.contactus</field>
         <field name="active" eval="True"/>
         <field name="type">qweb</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="arch" type="xml">
           <t name="Contact Us" t-name="website.contactus">
             <t t-call="website.layout"

--- a/night_clubs/data/website_menu.xml
+++ b/night_clubs/data/website_menu.xml
@@ -2,7 +2,7 @@
 <odoo noupdate="1">
   <function model="website.menu" name="write">
         <value model="website.menu" eval="obj().search([
-            ('website_id', '=', ref('website.default_website')),
+            ('website_id', '=', ref('base.default_website')),
             ('url', '=', '/event'),
         ], limit=1).id"/>
         <value eval="{'name': 'Parties'}"/>
@@ -10,7 +10,7 @@
 
     <function model="website.menu" name="write">
         <value model="website.menu" eval="obj().search([
-            ('website_id', '=', ref('website.default_website')),
+            ('website_id', '=', ref('base.default_website')),
             ('url', '=', '/contactus'),
         ], limit=1).id"/>
         <value eval="{'name': 'Enquiries'}"/>

--- a/night_clubs/demo/sale_order.xml
+++ b/night_clubs/demo/sale_order.xml
@@ -3,6 +3,6 @@
     <record id="sale_order_1" model="sale.order">
         <field name="partner_id" ref="base.partner_admin" />
         <field name="user_id" ref="base.user_admin" />
-        <field name="website_id" ref="website.default_website" />
+        <field name="website_id" ref="base.default_website" />
     </record>
 </odoo>

--- a/night_clubs/demo/website.xml
+++ b/night_clubs/demo/website.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-    <record id="website.default_website" model="website" forcecreate="1">
+    <record id="base.default_website" model="website" forcecreate="1">
         <field name="name">Nightclubs</field>
         <field name="configurator_done" eval="True" />
         <field name="user_id" ref="base.public_user" />

--- a/night_clubs/demo/website_theme_apply.xml
+++ b/night_clubs/demo/website_theme_apply.xml
@@ -6,20 +6,20 @@
     <function model="theme.utils" name="enable_view" eval="['website_event.opt_event_description_cover_top']"/>
 
     <function model="ir.ui.view" name="write">
-        <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('website.default_website').id).viewref('website.homepage').id"/>
+        <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('base.default_website').id).viewref('website.homepage').id"/>
         <value model="ir.ui.view" eval="{'arch': obj().env.ref('night_clubs.homepage').arch.replace(
             '*filter_upcoming_and_ongoing_event_night_clubs*', str(obj().env.ref('website_event.website_snippet_filter_event_list_unfinished').id)
         )}"/>
     </function>
     <function model="ir.ui.view" name="write">
-        <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('website.default_website').id).viewref('website.contactus').id"/>
+        <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('base.default_website').id).viewref('website.contactus').id"/>
         <value model="ir.ui.view" eval="{'arch': obj().env.ref('night_clubs.contactus').arch}"/>
     </function>
 
     <data noupdate="1">
         <function model="website.menu" name="unlink">
             <value model="website.menu" eval="obj().search([
-                ('website_id', '=', ref('website.default_website')),
+                ('website_id', '=', ref('base.default_website')),
                 ('url', '=', '/shop'),
             ]).ids"/>
         </function>
@@ -53,7 +53,7 @@
         }"/>
     </function>
 
-    <function model="website.assets" name="make_scss_customization" context="{'website_id': ref('website.default_website')}">
+    <function model="website.assets" name="make_scss_customization" context="{'website_id': ref('base.default_website')}">
         <value eval="'/website/static/src/scss/options/colors/user_color_palette.scss'"/>
         <value eval="{
             'menu': 4,

--- a/night_clubs/demo/website_view.xml
+++ b/night_clubs/demo/website_view.xml
@@ -9,7 +9,7 @@
         <field name="key">website_event.navbar</field>
         <field name="name">Event Navbar</field>
         <field name="type">qweb</field>
-        <field name="website_id" ref="website.default_website" />
+        <field name="website_id" ref="base.default_website" />
         <field name="inherit_id" ref="website_event.navbar"/>
     </record>
     <record id="contactus" model="ir.ui.view">
@@ -124,7 +124,7 @@
         <field name="key">night_clubs.contactus</field>
         <field name="name">Contact Us</field>
         <field name="type">qweb</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
     </record>
     <record id="ir_ui_view_3315" model="ir.ui.view">
         <field name="arch" type="xml">
@@ -147,7 +147,7 @@
         <field name="mode">extension</field>
         <field name="name">Header Call to Action</field>
         <field name="type">qweb</field>
-        <field name="website_id" ref="website.default_website" />
+        <field name="website_id" ref="base.default_website" />
     </record>
     <record id="homepage" model="ir.ui.view">
         <field name="arch" type="xml">
@@ -334,7 +334,7 @@
         <field name="key">night_clubs.homepage</field>
         <field name="name">Home</field>
         <field name="type">qweb</field>
-        <field name="website_id" ref="website.default_website" />
+        <field name="website_id" ref="base.default_website" />
     </record>
     <record id="ir_ui_view_3822" model="ir.ui.view">
         <field name="arch" type="xml">
@@ -345,7 +345,7 @@
         <field name="key">website_event.index_topbar</field>
         <field name="name">Topbar</field>
         <field name="type">qweb</field>
-        <field name="website_id" ref="website.default_website" />
+        <field name="website_id" ref="base.default_website" />
         <field name="inherit_id" ref="website_event.index_topbar"/>
     </record>
 </odoo>

--- a/non_profit_organization/data/ir_attachment.xml
+++ b/non_profit_organization/data/ir_attachment.xml
@@ -11,7 +11,7 @@
             file="non_profit_organization/static/src/binary/ir_attachment/ir_attachment_2.webp"/>
         <field name="url">/attachment/ir_attachment_2.jpg</field>
         <field name="public" eval="True"/>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
     </record>
     <record id="ir_attachment_3" model="ir.attachment">
         <field name="name">ir_attachment_3.jpg</field>
@@ -19,7 +19,7 @@
             file="non_profit_organization/static/src/binary/ir_attachment/ir_attachment_3.jpg"/>
         <field name="url">/attachment/ir_attachment_3.jpg</field>
         <field name="public" eval="True"/>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
     </record>
     <record id="ir_attachment_4" model="ir.attachment">
         <field name="name">ir_attachment_4.jpg</field>
@@ -27,7 +27,7 @@
             file="non_profit_organization/static/src/binary/ir_attachment/ir_attachment_4.jpg"/>
         <field name="url">/attachment/ir_attachment_4.jpg</field>
         <field name="public" eval="True"/>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
     </record>
     <record id="ir_attachment_5" model="ir.attachment">
         <field name="name">ir_attachment_5.webp</field>
@@ -35,7 +35,7 @@
             file="non_profit_organization/static/src/binary/ir_attachment/ir_attachment_5.webp"/>
         <field name="url">/attachment/ir_attachment_6.jpg</field>
         <field name="public" eval="True"/>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
     </record>
     <record id="ir_attachment_6" model="ir.attachment">
         <field name="name">ir_attachment_6.webp</field>
@@ -43,7 +43,7 @@
             file="non_profit_organization/static/src/binary/ir_attachment/ir_attachment_6.webp"/>
         <field name="url">/attachment/ir_attachment_6.jpg</field>
         <field name="public" eval="True"/>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
     </record>
     <record id="ir_attachment_7" model="ir.attachment">
         <field name="name">ir_attachment_7.jpg</field>
@@ -51,7 +51,7 @@
             file="non_profit_organization/static/src/binary/ir_attachment/ir_attachment_7.jpg"/>
         <field name="url">/attachment/ir_attachment_7.jpg</field>
         <field name="public" eval="True"/>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
     </record>
     <record id="ir_attachment_8" model="ir.attachment">
         <field name="name">ir_attachment_8.jpg</field>
@@ -59,7 +59,7 @@
             file="non_profit_organization/static/src/binary/ir_attachment/ir_attachment_8.jpg"/>
         <field name="url">/attachment/ir_attachment_8.jpg</field>
         <field name="public" eval="True"/>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
     </record>
     <record id="ir_attachment_9" model="ir.attachment">
         <field name="name">ir_attachment_9.jpg</field>
@@ -67,7 +67,7 @@
             file="non_profit_organization/static/src/binary/ir_attachment/ir_attachment_9.jpg"/>
         <field name="url">/attachment/ir_attachment_9.jpg</field>
         <field name="public" eval="True"/>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
     </record>
     <record id="ir_attachment_10" model="ir.attachment">
         <field name="name">ir_attachment_10.jpg</field>
@@ -75,7 +75,7 @@
             file="non_profit_organization/static/src/binary/ir_attachment/ir_attachment_10.jpg"/>
         <field name="url">/attachment/ir_attachment_10.jpg</field>
         <field name="public" eval="True"/>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
     </record>
     <record id="ir_attachment_11" model="ir.attachment">
         <field name="name">ir_attachment_11.webp</field>
@@ -83,7 +83,7 @@
             file="non_profit_organization/static/src/binary/ir_attachment/ir_attachment_11.webp"/>
         <field name="url">/attachment/ir_attachment_11.jpg</field>
         <field name="public" eval="True"/>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
     </record>
     <record id="ir_attachment_12" model="ir.attachment">
         <field name="name">ir_attachment_12.jpg</field>
@@ -91,7 +91,7 @@
             file="non_profit_organization/static/src/binary/ir_attachment/ir_attachment_12.jpg"/>
         <field name="url">/attachment/ir_attachment_12.jpg</field>
         <field name="public" eval="True"/>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
     </record>
     <record id="ir_attachment_13" model="ir.attachment">
         <field name="name">ir_attachment_13.webp</field>
@@ -99,7 +99,7 @@
             file="non_profit_organization/static/src/binary/ir_attachment/ir_attachment_13.webp"/>
         <field name="url">/attachment/ir_attachment_13.jpg</field>
         <field name="public" eval="True"/>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
     </record>
     <record id="ir_attachment_14" model="ir.attachment">
         <field name="name">ir_attachment_14.jpg</field>
@@ -107,7 +107,7 @@
             file="non_profit_organization/static/src/binary/ir_attachment/ir_attachment_14.jpg"/>
         <field name="url">/attachment/ir_attachment_14.jpg</field>
         <field name="public" eval="True"/>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
     </record>
     <record id="ir_attachment_15" model="ir.attachment">
         <field name="name">ir_attachment_15.jpg</field>
@@ -115,7 +115,7 @@
             file="non_profit_organization/static/src/binary/ir_attachment/ir_attachment_15.jpg"/>
         <field name="url">/attachment/ir_attachment_15.jpg</field>
         <field name="public" eval="True"/>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
     </record>
     <record id="ir_attachment_16" model="ir.attachment">
         <field name="name">ir_attachment_16.jpg</field>
@@ -123,7 +123,7 @@
             file="non_profit_organization/static/src/binary/ir_attachment/ir_attachment_16.jpg"/>
         <field name="url">/attachment/ir_attachment_16.jpg</field>
         <field name="public" eval="True"/>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
     </record>
     <record id="ir_attachment_17" model="ir.attachment">
         <field name="name">ir_attachment_17.jpg</field>
@@ -131,7 +131,7 @@
             file="non_profit_organization/static/src/binary/ir_attachment/ir_attachment_17.jpg"/>
         <field name="url">/attachment/ir_attachment_17.jpg</field>
         <field name="public" eval="True"/>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
     </record>
     <record id="ir_attachment_18" model="ir.attachment">
         <field name="name">ir_attachment_18.jpg</field>
@@ -139,7 +139,7 @@
             file="non_profit_organization/static/src/binary/ir_attachment/ir_attachment_18.jpg"/>
         <field name="url">/attachment/ir_attachment_18.jpg</field>
         <field name="public" eval="True"/>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
     </record>
     <record id="ir_attachment_19" model="ir.attachment">
         <field name="name">ir_attachment_19.jpg</field>
@@ -147,7 +147,7 @@
             file="non_profit_organization/static/src/binary/ir_attachment/ir_attachment_19.jpg"/>
         <field name="url">/attachment/ir_attachment_19.jpg</field>
         <field name="public" eval="True"/>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
     </record>
     <record id="ir_attachment_20" model="ir.attachment">
         <field name="name">ir_attachment_20.jpg</field>
@@ -155,7 +155,7 @@
             file="non_profit_organization/static/src/binary/ir_attachment/ir_attachment_20.jpg"/>
         <field name="url">/attachment/ir_attachment_20.jpg</field>
         <field name="public" eval="True"/>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
     </record>
     <record id="ir_attachment_21" model="ir.attachment">
         <field name="name">ir_attachment_21.jpg</field>
@@ -163,7 +163,7 @@
             file="non_profit_organization/static/src/binary/ir_attachment/ir_attachment_21.jpg"/>
         <field name="url">/attachment/ir_attachment_21.jpg</field>
         <field name="public" eval="True"/>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
     </record>
     <record id="ir_attachment_22" model="ir.attachment">
         <field name="name">ir_attachment_22.jpg</field>
@@ -171,7 +171,7 @@
             file="non_profit_organization/static/src/binary/ir_attachment/ir_attachment_22.jpg"/>
         <field name="url">/attachment/ir_attachment_22.jpg</field>
         <field name="public" eval="True"/>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
     </record>
     <record id="ir_attachment_23" model="ir.attachment">
         <field name="name">ir_attachment_23.jpg</field>
@@ -179,7 +179,7 @@
             file="non_profit_organization/static/src/binary/ir_attachment/ir_attachment_23.jpg"/>
         <field name="url">/attachment/ir_attachment_23.jpg</field>
         <field name="public" eval="True"/>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
     </record>
     <record id="ir_attachment_24" model="ir.attachment">
         <field name="name">ir_attachment_24.jpg</field>
@@ -187,7 +187,7 @@
             file="non_profit_organization/static/src/binary/ir_attachment/ir_attachment_24.jpg"/>
         <field name="url">/attachment/ir_attachment_24.jpg</field>
         <field name="public" eval="True"/>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
     </record>
     <record id="ir_attachment_25" model="ir.attachment" forcecreate="1">
         <field name="name">ir_attachment_25</field>
@@ -195,7 +195,7 @@
             file="non_profit_organization/static/src/binary/ir_attachment/ir_attachment_25" />
         <field name="url">/attachment/ir_attachment_25.jpg</field>
         <field name="public" eval="True"/>
-        <field name="website_id" ref="website.default_website" />
+        <field name="website_id" ref="base.default_website" />
     </record>
     <record id="ir_attachment_26" model="ir.attachment" forcecreate="1">
         <field name="name">ir_attachment_26</field>
@@ -203,6 +203,6 @@
             file="non_profit_organization/static/src/binary/ir_attachment/ir_attachment_26"/>
         <field name="url">/attachment/ir_attachment_26.jpg</field>
         <field name="public" eval="True"/>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
     </record>
 </odoo>

--- a/non_profit_organization/data/qweb_view.xml
+++ b/non_profit_organization/data/qweb_view.xml
@@ -495,7 +495,7 @@
         <field name="name">Petition</field>
         <field name="active" eval="True"/>
         <field name="type">qweb</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
     </record>
     <record id="petition_form_qweb_view" model="ir.ui.view">
         <field name="arch" type="xml">
@@ -762,7 +762,7 @@
         <field name="name">Petition</field>
         <field name="active" eval="True"/>
         <field name="type">qweb</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
     </record>
     <record id="signature_thanks_qweb_view" model="ir.ui.view">
         <field name="arch" type="xml">
@@ -819,7 +819,7 @@
         <field name="name">Thanks (Contact us)</field>
         <field name="active" eval="True"/>
         <field name="type">qweb</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
     </record>
 
     <record id="website_checkout_extra_info" model="ir.ui.view">
@@ -871,10 +871,10 @@
         <field name="name">Checkout Extra Info</field>
         <field name="type">qweb</field>
         <field name="active" eval="True"/>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
     </record>
     <function model="ir.ui.view" name="write">
-        <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('website.default_website').id).viewref('website_sale.extra_info').id"/>
+        <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('base.default_website').id).viewref('website_sale.extra_info').id"/>
         <value model="ir.ui.view" eval="{'arch': obj().env.ref('non_profit_organization.website_checkout_extra_info').arch}"/>
     </function>
     <function model="ir.model.fields" name="formbuilder_whitelist">

--- a/non_profit_organization/data/website_controller_page.xml
+++ b/non_profit_organization/data/website_controller_page.xml
@@ -3,7 +3,7 @@
     <record id="website_controller_website_page" model="website.controller.page">
         <field name="name">Petition</field>
         <field name="model_id" ref="x_petition_model"/>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="website_published" eval="True"/>
         <field name="view_id" ref="petition_list_qweb_view"/>
         <field name="record_view_id" ref="petition_form_qweb_view"/>

--- a/non_profit_organization/data/website_menu.xml
+++ b/non_profit_organization/data/website_menu.xml
@@ -3,10 +3,10 @@
     <record id="website_menu_16" model="website.menu">
         <field name="name">Get involved</field>
         <field name="sequence">15</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="parent_id" model="website.menu"
             eval="obj().search([
-                ('website_id', '=', ref('website.default_website')),
+                ('website_id', '=', ref('base.default_website')),
                 ('url', '=', '#'),
         ], limit=1).id"/>
     </record>
@@ -14,7 +14,7 @@
         <field name="name">Petitions</field>
         <field name="url">/model/petition</field>
         <field name="sequence">1</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="parent_id" ref="website_menu_16"/>
     </record>
 </odoo>

--- a/non_profit_organization/data/website_page.xml
+++ b/non_profit_organization/data/website_page.xml
@@ -2,7 +2,7 @@
 <odoo noupdate="1">
     <record id="website_page_14" model="website.page">
         <field name="view_id" ref="signature_thanks_qweb_view"/>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="is_published" eval="True"/>
         <field name="url">/signature-thank-you</field>
         <field name="website_indexed" eval="False"/>

--- a/non_profit_organization/data/website_theme_apply.xml
+++ b/non_profit_organization/data/website_theme_apply.xml
@@ -8,7 +8,7 @@
         <function model="website.checkout.step" name="write">
             <value model="website.checkout.step" eval="obj().search([
                 ('step_href', '=', '/shop/extra_info'),
-                ('website_id', '=', ref('website.default_website')),
+                ('website_id', '=', ref('base.default_website')),
             ]).ids"/>
             <value eval="{'is_published': True}"/>
         </function>

--- a/non_profit_organization/demo/qweb_view.xml
+++ b/non_profit_organization/demo/qweb_view.xml
@@ -124,7 +124,7 @@
         <field name="name">Become a member</field>
         <field name="active" eval="True"/>
         <field name="type">qweb</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
     </record>
     <record id="contact_us_qweb_view" model="ir.ui.view">
         <field name="arch" type="xml">
@@ -305,7 +305,7 @@
         <field name="name">Contact Us</field>
         <field name="active" eval="True"/>
         <field name="type">qweb</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
     </record>
     <record id="website_footer_qweb_view" model="ir.ui.view">
         <field name="arch" type="xml">
@@ -392,7 +392,7 @@
         <field name="name">Headline</field>
         <field name="active" eval="True"/>
         <field name="type">qweb</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
     </record>
     <record id="website_homepage_qweb_view" model="ir.ui.view">
         <field name="arch" type="xml">
@@ -745,6 +745,6 @@
         <field name="name">Home</field>
         <field name="active" eval="True"/>
         <field name="type">qweb</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
     </record>
 </odoo>

--- a/non_profit_organization/demo/sale_order.xml
+++ b/non_profit_organization/demo/sale_order.xml
@@ -13,7 +13,7 @@
         <field name="user_id" ref="base.user_admin"/>
         <field name="carrier_id" ref="delivery.free_delivery_carrier"/>
         <field name="starred_user_ids" eval="[(6, 0, [])]"/>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
     </record>
     <record id="sale_order_2" model="sale.order">
         <field name="partner_id" ref="res_partner_29"/>

--- a/non_profit_organization/demo/website.xml
+++ b/non_profit_organization/demo/website.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <odoo noupdate="1">
-    <record id="website.default_website" model="website" forcecreate="True">
+    <record id="base.default_website" model="website" forcecreate="True">
         <field name="name">Non-Profit Organization</field>
         <field name="logo" type="bytes" file="non_profit_organization/static/description/icon.png"/>
     </record>

--- a/non_profit_organization/demo/website_menu.xml
+++ b/non_profit_organization/demo/website_menu.xml
@@ -4,20 +4,20 @@
         <field name="name">Become a member</field>
         <field name="url">/become-a-member</field>
         <field name="sequence" eval="False"/>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="parent_id" ref="website_menu_16"/>
     </record>
     <record id="website_menu_18" model="website.menu">
         <field name="name">Donate now</field>
         <field name="url" eval="'/shop/' + str(ref('non_profit_organization.product_product_donation'))"/>
         <field name="sequence">2</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="parent_id" ref="website_menu_16"/>
     </record>
     <function name="write" model="website.menu">
         <value model="website.menu"
             eval="obj().search([
-                ('website_id', '=', ref('website.default_website')),
+                ('website_id', '=', ref('base.default_website')),
                 ('url', '=', '/event'),
         ], limit=1).id"/>
         <value eval="{'sequence':16}"/>

--- a/non_profit_organization/demo/website_page.xml
+++ b/non_profit_organization/demo/website_page.xml
@@ -2,13 +2,13 @@
 <odoo noupdate="1">
     <record id="website_page_7" model="website.page">
         <field name="view_id" ref="contact_us_qweb_view"/>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="is_published" eval="True"/>
         <field name="url">/contactus</field>
     </record>
     <record id="website_page_8" model="website.page">
         <field name="view_id" ref="become_a_member_qweb_view"/>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="is_published" eval="True"/>
         <field name="url">/become-a-member</field>
     </record>s

--- a/non_profit_organization/demo/website_theme_apply.xml
+++ b/non_profit_organization/demo/website_theme_apply.xml
@@ -5,12 +5,12 @@
 
     <function model="ir.ui.view" name="write">
         <value model="ir.ui.view"
-            eval="obj().env['website'].with_context(website_id=obj().env.ref('website.default_website').id).viewref('website.template_footer_headline').id"/>
+            eval="obj().env['website'].with_context(website_id=obj().env.ref('base.default_website').id).viewref('website.template_footer_headline').id"/>
         <value model="ir.ui.view" eval="{'arch': obj().env.ref('non_profit_organization.website_footer_qweb_view').arch}"/>
     </function>
     <function model="ir.ui.view" name="write">
         <value model="ir.ui.view"
-            eval="obj().env['website'].with_context(website_id=obj().env.ref('website.default_website').id).viewref('website.homepage').id"/>
+            eval="obj().env['website'].with_context(website_id=obj().env.ref('base.default_website').id).viewref('website.homepage').id"/>
         <value model="ir.ui.view" eval="{'arch': obj().env.ref('non_profit_organization.website_homepage_qweb_view').arch.replace(
         '*donation_product*', str(obj().env.ref('non_profit_organization.product_product_donation').website_url))
         }"/>

--- a/odoo_partner/data/res_config_settings.xml
+++ b/odoo_partner/data/res_config_settings.xml
@@ -3,7 +3,6 @@
     <record id="res_config_settings_enable" model="res.config.settings">
         <field name="group_product_pricelist" eval="1"/>
         <field name="group_sale_order_template" eval="1"/>
-        <field name="company_so_template_id" ref="sale_order_template_1"/>
     </record>
     <function model="res.config.settings" name="execute" eval="[ref('res_config_settings_enable')]"/>
 </odoo>

--- a/outdoor_activities/demo/website.xml
+++ b/outdoor_activities/demo/website.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-    <record id="website.default_website" model="website" forcecreate="1">
+    <record id="base.default_website" model="website" forcecreate="1">
         <field name="name">My Website</field>
         <field name="configurator_done" eval="True" />
         <field name="logo" type="bytes" file="outdoor_activities/static/src/binary/website/1-logo" />

--- a/outdoor_activities/demo/website_menu.xml
+++ b/outdoor_activities/demo/website_menu.xml
@@ -3,27 +3,27 @@
     <record id="website_menu_4" model="website.menu">
         <field name="name">Top Menu for Website 1</field>
         <field name="url">/default-main-menu</field>
-        <field name="website_id" ref="website.default_website" />
+        <field name="website_id" ref="base.default_website" />
     </record>
     <record id="website_menu_5" model="website.menu">
         <field name="name">Home</field>
         <field name="url">/</field>
         <field name="page_id" ref="website_page_4" />
-        <field name="website_id" ref="website.default_website" />
+        <field name="website_id" ref="base.default_website" />
         <field name="parent_id" ref="website_menu_4" />
     </record>
     <record id="website_menu_7" model="website.menu">
         <field name="name">Expeditions</field>
         <field name="url">/appointment</field>
         <field name="sequence">1</field>
-        <field name="website_id" ref="website.default_website" />
+        <field name="website_id" ref="base.default_website" />
         <field name="parent_id" ref="website_menu_4" />
     </record>
     <record id="website_menu_9" model="website.menu">
         <field name="name">Certification Courses</field>
         <field name="url">/event</field>
         <field name="sequence">2</field>
-        <field name="website_id" ref="website.default_website" />
+        <field name="website_id" ref="base.default_website" />
         <field name="parent_id" ref="website_menu_4" />
     </record>
     <record id="website_menu_6" model="website.menu">
@@ -31,7 +31,7 @@
         <field name="url">/contactus</field>
         <field name="page_id" ref="website_page_6" />
         <field name="sequence">3</field>
-        <field name="website_id" ref="website.default_website" />
+        <field name="website_id" ref="base.default_website" />
         <field name="parent_id" ref="website_menu_4" />
     </record>
 </odoo>

--- a/outdoor_activities/demo/website_page.xml
+++ b/outdoor_activities/demo/website_page.xml
@@ -2,13 +2,13 @@
 <odoo noupdate="1">
     <record id="website_page_4" model="website.page">
         <field name="view_id" ref="homepage" />
-        <field name="website_id" ref="website.default_website" />
+        <field name="website_id" ref="base.default_website" />
         <field name="is_published" eval="True"/>
         <field name="url">/</field>
     </record>
     <record id="website_page_6" model="website.page">
         <field name="view_id" ref="contact_us" />
-        <field name="website_id" ref="website.default_website" />
+        <field name="website_id" ref="base.default_website" />
         <field name="is_published" eval="True"/>
         <field name="url">/contactus</field>
     </record>

--- a/outdoor_activities/demo/website_views.xml
+++ b/outdoor_activities/demo/website_views.xml
@@ -215,7 +215,7 @@
         <field name="key">outdoor_activities.website.contactus</field>
         <field name="name">Contact Us</field>
         <field name="type">qweb</field>
-        <field name="website_id" ref="website.default_website" />
+        <field name="website_id" ref="base.default_website" />
     </record>
     <record id="footer" model="ir.ui.view">
         <field name="arch" type="xml">
@@ -301,7 +301,7 @@
         <field name="mode">extension</field>
         <field name="name">Descriptive</field>
         <field name="type">qweb</field>
-        <field name="website_id" ref="website.default_website" />
+        <field name="website_id" ref="base.default_website" />
     </record>
     <record id="homepage" model="ir.ui.view">
         <field name="arch" type="xml">
@@ -494,7 +494,7 @@
         <field name="key">outdoor_activities.website.homepage</field>
         <field name="name">Home</field>
         <field name="type">qweb</field>
-        <field name="website_id" ref="website.default_website" />
+        <field name="website_id" ref="base.default_website" />
     </record>
     <record id="ir_ui_view_3240" model="ir.ui.view">
         <field name="arch" type="xml">
@@ -522,7 +522,7 @@
         <field name="key">outdoor_activities.website.record_cover</field>
         <field name="name">record_cover</field>
         <field name="type">qweb</field>
-        <field name="website_id" ref="website.default_website" />
+        <field name="website_id" ref="base.default_website" />
     </record>
     <record id="ir_ui_view_3241" model="ir.ui.view">
         <field name="arch" type="xml">
@@ -607,20 +607,20 @@
         <field name="mode">extension</field>
         <field name="name">Events (oe_structure_we_index_2)</field>
         <field name="type">qweb</field>
-        <field name="website_id" ref="website.default_website" />
+        <field name="website_id" ref="base.default_website" />
     </record>
     <function model="ir.ui.view" name="write">
-        <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('website.default_website').id).viewref('website.template_footer_descriptive').id" />
+        <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('base.default_website').id).viewref('website.template_footer_descriptive').id" />
         <value model="ir.ui.view" eval="{'arch': obj().env.ref('outdoor_activities.footer').arch}" />
     </function>
     <function model="ir.ui.view" name="write">
-        <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('website.default_website').id).viewref('website.homepage').id" />
+        <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('base.default_website').id).viewref('website.homepage').id" />
         <value model="ir.ui.view" eval="{'arch': obj().env.ref('outdoor_activities.homepage').arch.replace(
         '*filter_upcoming_event_outdoor_activities*', str(obj().env.ref('website_event.website_snippet_filter_event_list').id)
         )}" />
     </function>
     <function model="ir.ui.view" name="write">
-        <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('website.default_website').id).viewref('website.contactus').id" />
+        <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('base.default_website').id).viewref('website.contactus').id" />
         <value model="ir.ui.view" eval="{'arch': obj().env.ref('outdoor_activities.contact_us').arch.replace(
         '*group_booking_tag*', str(obj().env.ref('outdoor_activities.crm_tag_1').id)).replace(
         '*private_tour_tag*', str(obj().env.ref('outdoor_activities.crm_tag_2').id)).replace(

--- a/pet_groomer/demo/website.xml
+++ b/pet_groomer/demo/website.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-  <record id="website.default_website" model="website" forcecreate="1">
+  <record id="base.default_website" model="website" forcecreate="1">
     <field name="name">Pet groomer</field>
     <field name="configurator_done" eval="True"/>
     <field name="user_id" ref="base.public_user"/>

--- a/pet_groomer/demo/website_theme_apply.xml
+++ b/pet_groomer/demo/website_theme_apply.xml
@@ -38,12 +38,12 @@
     </function>
 
     <function model="ir.ui.view" name="write">
-      <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('website.default_website').id).viewref('website.homepage').id"/>
+      <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('base.default_website').id).viewref('website.homepage').id"/>
       <value model="ir.ui.view" eval="{'arch': obj().env.ref('pet_groomer.homepage').arch}"/>
     </function>
 
     <function model="ir.ui.view" name="write">
-      <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('website.default_website').id).viewref('website.contactus').id"/>
+      <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('base.default_website').id).viewref('website.contactus').id"/>
       <value model="ir.ui.view" eval="{'arch': obj().env.ref('pet_groomer.contactus').arch}"/>
     </function>
 
@@ -53,7 +53,7 @@
     </function>
 
     <function model="ir.ui.view" name="write">
-        <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('website.default_website').id).viewref('website.template_footer_centered').id"/>
+        <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('base.default_website').id).viewref('website.template_footer_centered').id"/>
         <value model="ir.ui.view" eval="{
             'arch': obj().env.ref('pet_groomer.ir_ui_view_3646').arch,
             'active': True
@@ -63,12 +63,12 @@
     <data noupdate="1">
       <function model="website.menu" name="unlink">
           <value model="website.menu" eval="obj().search([
-              ('website_id', '=', ref('website.default_website')),
+              ('website_id', '=', ref('base.default_website')),
               ('url', '=', '/appointment')], limit=1).id"/>
       </function>
       <function model="website.menu" name="unlink">
           <value model="website.menu" eval="obj().search([
-              ('website_id', '=', ref('website.default_website')),
+              ('website_id', '=', ref('base.default_website')),
               ('url', '=', '/shop')], limit=1).id"/>
       </function>
   </data>

--- a/pet_groomer/demo/website_view.xml
+++ b/pet_groomer/demo/website_view.xml
@@ -118,7 +118,7 @@
     <field name="key">website.contactus</field>
     <field name="name">Contact Us</field>
     <field name="type">qweb</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
   </record>
   <record id="ir_ui_view_2987" model="ir.ui.view">
     <field name="arch" type="xml">
@@ -141,7 +141,7 @@
     <field name="mode">extension</field>
     <field name="name">Header Call to Action</field>
     <field name="type">qweb</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
   </record>
   <template id="custom_appointment_info_pet_groomers_view" inherit_id="appointment.appointment_details_column">
     <xpath expr="//div[hasclass('lh-base') and hasclass('h6')]" position="replace">
@@ -285,7 +285,7 @@
     <field name="key">pet_groomer.homepage</field>
     <field name="name">Home</field>
     <field name="type">qweb</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
   </record>
   <record id="ir_ui_view_3646" model="ir.ui.view">
     <field name="arch" type="xml">
@@ -337,6 +337,6 @@
     <field name="mode">extension</field>
     <field name="name">Centered</field>
     <field name="type">qweb</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
   </record>
 </odoo>

--- a/photography/data/website_theme_apply.xml
+++ b/photography/data/website_theme_apply.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo>
     <function model="ir.ui.view" name="write">
-        <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('website.default_website').id).viewref('website.contactus').id"/>
+        <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('base.default_website').id).viewref('website.contactus').id"/>
         <value model="ir.ui.view" eval="{'arch': obj().env.ref('photography.contactus').arch.replace(
         '*wedding_tag*', str(obj().env.ref('photography.crm_tag_wedding').id)).replace(
         '*portrait_tag*', str(obj().env.ref('photography.crm_tag_portrait').id)).replace(

--- a/photography/data/website_view.xml
+++ b/photography/data/website_view.xml
@@ -5,7 +5,7 @@
         <field name="key">photography.contactus</field>
         <field name="active" eval="True"/>
         <field name="type">qweb</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="arch" type="xml">
           <t name="Contact Us" t-name="photography.contactus">
             <t t-call="website.layout"

--- a/photography/demo/website.xml
+++ b/photography/demo/website.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-  <record id="website.default_website" model="website" forcecreate="1">
+  <record id="base.default_website" model="website" forcecreate="1">
     <field name="name">photography</field>
     <field name="configurator_done" eval="True"/>
     <field name="logo" type="bytes" file="photography/static/description/icon.png"/>

--- a/photography/demo/website_menu.xml
+++ b/photography/demo/website_menu.xml
@@ -1,26 +1,26 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
   <function model="website.menu" name="unlink">
-    <value model="website.menu" eval="obj().search([('website_id', '=', ref('website.default_website')), ('url', '=', '/default-main-menu')]).ids"/>
+    <value model="website.menu" eval="obj().search([('website_id', '=', ref('base.default_website')), ('url', '=', '/default-main-menu')]).ids"/>
   </function>
   <record id="website_menu_4" model="website.menu">
     <field name="name">Top Menu for Website 1</field>
     <field name="sequence" eval="False"/>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
   </record>
   <record id="website_menu_5" model="website.menu">
     <field name="name">Home</field>
     <field name="page_id" ref="website_page_4"/>
     <field name="url">/</field>
     <field name="sequence" eval="False"/>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
     <field name="parent_id" ref="website_menu_4"/>
   </record>
   <record id="website_menu_20" model="website.menu">
     <field name="name">Services</field>
     <field name="page_id" ref="website_page_4"/>
     <field name="sequence">2</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
     <field name="parent_id" ref="website_menu_4"/>
   </record>
   <record id="website_menu_18" model="website.menu">
@@ -28,7 +28,7 @@
     <field name="page_id" ref="website_page_8"/>
     <field name="url">/weddings</field>
     <field name="sequence" eval="False"/>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
     <field name="parent_id" ref="website_menu_20"/>
   </record>
   <record id="website_menu_17" model="website.menu">
@@ -36,7 +36,7 @@
     <field name="page_id" ref="website_page_10"/>
     <field name="url">/studio-sessions</field>
     <field name="sequence">1</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
     <field name="parent_id" ref="website_menu_20"/>
   </record>
   <record id="website_menu_19" model="website.menu">
@@ -44,14 +44,14 @@
     <field name="page_id" ref="website_page_9"/>
     <field name="url">/corporate-events</field>
     <field name="sequence">2</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
     <field name="parent_id" ref="website_menu_20"/>
   </record>
   <record id="website_menu_7" model="website.menu">
     <field name="name">Book a session</field>
     <field name="url">/appointment</field>
     <field name="sequence">4</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
     <field name="parent_id" ref="website_menu_4"/>
   </record>
 </odoo>

--- a/photography/demo/website_page.xml
+++ b/photography/demo/website_page.xml
@@ -2,25 +2,25 @@
 <odoo noupdate="1">
   <record id="website_page_4" model="website.page">
     <field name="view_id" ref="homepage"/>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
     <field name="is_published" eval="True"/>
     <field name="url">/</field>
   </record>
   <record id="website_page_8" model="website.page">
     <field name="view_id" ref="ir_ui_view_1958"/>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
     <field name="is_published" eval="True"/>
     <field name="url">/weddings</field>
   </record>
   <record id="website_page_9" model="website.page">
     <field name="view_id" ref="ir_ui_view_1959"/>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
     <field name="is_published" eval="True"/>
     <field name="url">/corporate-events</field>
   </record>
   <record id="website_page_10" model="website.page">
     <field name="view_id" ref="ir_ui_view_1960"/>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
     <field name="is_published" eval="True"/>
     <field name="url">/studio-sessions</field>
   </record>

--- a/photography/demo/website_theme_apply.xml
+++ b/photography/demo/website_theme_apply.xml
@@ -2,7 +2,7 @@
 <odoo>
     <function name="button_choose_theme" model="ir.module.module" eval="[ref('base.module_theme_nano', raise_if_not_found=False) or ref('base.module_theme_default')]"/>
 
-    <function model="website.assets" name="make_scss_customization" context="{'website_id': ref('website.default_website')}">
+    <function model="website.assets" name="make_scss_customization" context="{'website_id': ref('base.default_website')}">
         <value eval="'/website/static/src/scss/options/colors/user_color_palette.scss'"/>
         <value eval="{
             'o-color-1': '#92657E',
@@ -21,7 +21,7 @@
         <value eval="{'btn-border-radius': '0rem','navbar-font': 'Quicksand','buttons-font': 'Quicksand'}"/>
     </function>
 
-    <function model="website.assets" name="make_scss_customization" context="{'website_id': ref('website.default_website')}">
+    <function model="website.assets" name="make_scss_customization" context="{'website_id': ref('base.default_website')}">
         <value eval="'/website/static/src/scss/options/colors/user_theme_color_palette.scss'"/>
         <value eval="{
             'success': 'null',
@@ -32,7 +32,7 @@
     </function>
 
     <function model="ir.ui.view" name="write">
-        <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('website.default_website').id).viewref('website.homepage').id"/>
+        <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('base.default_website').id).viewref('website.homepage').id"/>
         <value model="ir.ui.view" eval="{'arch': obj().env.ref('photography.homepage').arch}"/>
     </function>
 
@@ -41,7 +41,7 @@
         <value eval="{'active': False}"/>
     </function>
     <function model="ir.ui.view" name="write">
-        <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('website.default_website').id).viewref('website.template_footer_centered').id"/>
+        <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('base.default_website').id).viewref('website.template_footer_centered').id"/>
         <value model="ir.ui.view" eval="{
             'arch': obj().env.ref('photography.customfooter_view').arch,
             'active': True

--- a/photography/demo/website_view.xml
+++ b/photography/demo/website_view.xml
@@ -6,7 +6,7 @@
     <field name="inherit_id" ref="website.layout"/>
     <field name="mode">extension</field>
     <field name="type">qweb</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
     <field name="arch" type="xml">
         <data inherit_id="website.layout" name="Centered">
             <xpath expr="//div[@id='footer']" position="replace">
@@ -61,7 +61,7 @@
     <field name="name">Corporate Events</field>
     <field name="key">photography.corporate-events</field>
     <field name="type">qweb</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
     <field name="arch" type="xml">
       <t t-name="website.corporate-events">
         <t t-call="website.layout">
@@ -128,13 +128,13 @@
     <field name="mode">extension</field>
     <field name="name">Header Call to Action</field>
     <field name="type">qweb</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
   </record>
   <record id="homepage" model="ir.ui.view">
     <field name="name">Home</field>
     <field name="key">photography.homepage</field>
     <field name="type">qweb</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
     <field name="arch" type="xml">
       <t name="Home" t-name="photography.homepage">
         <t t-call="website.layout" pageName.f="homepage">
@@ -230,7 +230,7 @@
     <field name="name">Studio Sessions</field>
     <field name="key">photography.studio-sessions</field>
     <field name="type">qweb</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
     <field name="arch" type="xml">
       <t t-name="website.studio-sessions">
         <t t-call="website.layout">
@@ -286,7 +286,7 @@
     <field name="name">Weddings</field>
     <field name="key">photography.weddings</field>
     <field name="type">qweb</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
     <field name="arch" type="xml">
       <t t-name="website.weddings">
         <t t-call="website.layout">
@@ -437,6 +437,6 @@
     <field name="mode">extension</field>
     <field name="name">footer_copyright_remove_class</field>
     <field name="type">qweb</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
   </record>
 </odoo>

--- a/real_estate/data/website.xml
+++ b/real_estate/data/website.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-    <record id="website.default_website" model="website" forcecreate="1">
+    <record id="base.default_website" model="website" forcecreate="1">
         <field name="name">Real Estate Agency</field>
         <field name="prevent_sale">True</field>
         <field name="prevent_sale_for">specific_categories</field>

--- a/real_estate/data/website_menu.xml
+++ b/real_estate/data/website_menu.xml
@@ -5,9 +5,9 @@
     <field name="page_id" ref="website_page_7"/>
     <field name="url">/matchmaking</field>
     <field name="sequence">20</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
     <field name="parent_id" model="website.menu" eval="obj().search([
-                ('website_id', '=', ref('website.default_website')),
+                ('website_id', '=', ref('base.default_website')),
                 ('url', '=', '#'),
     ], limit=1).id"/>
   </record>

--- a/real_estate/data/website_page.xml
+++ b/real_estate/data/website_page.xml
@@ -2,19 +2,19 @@
 <odoo noupdate="1">
   <record id="website_page_7" model="website.page">
     <field name="view_id" ref="matchmaking"/>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
     <field name="is_published" eval="True"/>
     <field name="url">/matchmaking</field>
   </record>
   <record id="website_page_6" model="website.page">
     <field name="view_id" ref="contactus"/>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
     <field name="is_published" eval="True"/>
     <field name="url">/contactus</field>
   </record>
   <record id="website_page_8" model="website.page">
     <field name="view_id" ref="information_request"/>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
     <field name="is_published" eval="True"/>
     <field name="url">/information-request</field>
   </record>

--- a/real_estate/data/website_theme_apply.xml
+++ b/real_estate/data/website_theme_apply.xml
@@ -3,14 +3,14 @@
     <data noupdate="1">
         <function model="website.menu" name="write">
             <value model="website.menu" eval="obj().search([
-                ('website_id', '=', ref('website.default_website')),
+                ('website_id', '=', ref('base.default_website')),
                 ('url', '=', '/shop'),
             ], limit=1).id"/>
             <value eval="{'name': 'Properties'}"/>
         </function>
         <function model="website.menu" name="write">
             <value model="website.menu" eval="obj().search([
-                ('website_id', '=', ref('website.default_website')),
+                ('website_id', '=', ref('base.default_website')),
                 ('url', '=', '/contactus'),
             ], limit=1).id"/>
             <value eval="{'name': 'Free estimate'}"/>

--- a/real_estate/data/website_view.xml
+++ b/real_estate/data/website_view.xml
@@ -5,7 +5,7 @@
     <field name="key">real_estate.contactus</field>
     <field name="active" eval="True"/>
     <field name="type">qweb</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
     <field name="arch" type="xml">
       <t name="Contact Us" t-name="website.contactus">
         <t t-call="website.layout"
@@ -156,7 +156,7 @@
     <field name="key">real_estate.matchmaking</field>
     <field name="type">qweb</field>
     <field name="active" eval="True"/>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
     <field name="arch" type="xml">
       <t t-name="website.matchmaking">
         <t t-call="website.layout">
@@ -294,7 +294,7 @@
     <field name="active" eval="True"/>
     <field name="type">qweb</field>
     <field name="inherit_id" ref="website_sale.cta_wrapper"/>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
     <field name="arch" type="xml">
       <xpath expr="//div[@id='contact_us_wrapper']/a" position="replace">
         <a t-attf-href="/information-request?product_id=#{product.id}"
@@ -309,7 +309,7 @@
     <field name="key">real_estate.information_request</field>
     <field name="active" eval="True"/>
     <field name="type">qweb</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
     <field name="arch" type="xml">
       <t name="Information Request" t-name="website.information_request">
         <t t-call="website.layout" logged_partner="request.env['ir.http']._get_visitor_from_request().partner_id">
@@ -404,7 +404,7 @@
     <field name="active" eval="True"/>
     <field name="name">Header Hide Empty Cart link</field>
     <field name="type">qweb</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
     <field name="arch" type="xml">
       <xpath expr="//t[@t-set='show_cart']" position="after">
         <t t-set="show_cart" t-value="website_sale_cart_quantity"/>

--- a/real_estate/demo/ir_attachment_post.xml
+++ b/real_estate/demo/ir_attachment_post.xml
@@ -5,7 +5,7 @@
         <field name="raw" type="bytes" file="real_estate/static/src/binary/ir_attachment/1235-peb-a.png"/>
         <field name="res_id" ref="product_template_3"/>
         <field name="res_model">product.template</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
     </record>
     <record id="ir_attachment_1141" model="ir.attachment">
@@ -13,7 +13,7 @@
         <field name="raw" type="bytes" file="real_estate/static/src/binary/ir_attachment/1141-unsplash_XpbtQfr9Skg_houseinterior.jpg"/>
         <field name="url">/unsplash/XpbtQfr9Skg/house interior.jpg</field>
         <field name="res_model">ir.ui.view</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
     </record>
     <record id="ir_attachment_1470" model="ir.attachment">
@@ -25,77 +25,77 @@
         <field name="raw" type="bytes" file="real_estate/static/src/binary/ir_attachment/1507-unsplash_kI9X3L3zlw4_homeentry.jpg"/>
         <field name="url">/unsplash/kI9X3L3zlw4/home entry.jpg</field>
         <field name="res_model">ir.ui.view</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
     </record>
     <record id="configurator_1_s_key_images_default_image_4" model="ir.attachment">
         <field name="name">website.s_key_images_default_image_4</field>
         <field name="raw" type="bytes" file="real_estate/static/src/binary/ir_attachment/900-website.s_key_images_default_image_4"/>
         <field name="key">website.s_key_images_default_image_4</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
     </record>
     <record id="configurator_1_s_key_images_default_image_3" model="ir.attachment">
         <field name="name">website.s_key_images_default_image_3</field>
         <field name="raw" type="bytes" file="real_estate/static/src/binary/ir_attachment/899-website.s_key_images_default_image_3"/>
         <field name="key">website.s_key_images_default_image_3</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
     </record>
     <record id="configurator_1_s_key_images_default_image_2" model="ir.attachment">
         <field name="name">website.s_key_images_default_image_2</field>
         <field name="raw" type="bytes" file="real_estate/static/src/binary/ir_attachment/898-website.s_key_images_default_image_2"/>
         <field name="key">website.s_key_images_default_image_2</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
     </record>
     <record id="configurator_1_s_key_images_default_image_1" model="ir.attachment">
         <field name="name">website.s_key_images_default_image_1</field>
         <field name="raw" type="bytes" file="real_estate/static/src/binary/ir_attachment/897-website.s_key_images_default_image_1"/>
         <field name="key">website.s_key_images_default_image_1</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
     </record>
     <record id="configurator_1_library_image_16" model="ir.attachment">
         <field name="name">website.library_image_16</field>
         <field name="raw" type="bytes" file="real_estate/static/src/binary/ir_attachment/883-website.library_image_16"/>
         <field name="key">website.library_image_16</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
     </record>
     <record id="configurator_1_library_image_14" model="ir.attachment">
         <field name="name">website.library_image_14</field>
         <field name="raw" type="bytes" file="real_estate/static/src/binary/ir_attachment/882-website.library_image_14"/>
         <field name="key">website.library_image_14</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
     </record>
     <record id="configurator_1_library_image_05" model="ir.attachment">
         <field name="name">website.library_image_05</field>
         <field name="raw" type="bytes" file="real_estate/static/src/binary/ir_attachment/881-website.library_image_05"/>
         <field name="key">website.library_image_05</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
     </record>
     <record id="configurator_1_library_image_13" model="ir.attachment">
         <field name="name">website.library_image_13</field>
         <field name="raw" type="bytes" file="real_estate/static/src/binary/ir_attachment/880-website.library_image_13"/>
         <field name="key">website.library_image_13</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
     </record>
     <record id="configurator_1_library_image_10" model="ir.attachment">
         <field name="name">website.library_image_10</field>
         <field name="raw" type="bytes" file="real_estate/static/src/binary/ir_attachment/879-website.library_image_10"/>
         <field name="key">website.library_image_10</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
     </record>
     <record id="configurator_1_library_image_03" model="ir.attachment">
         <field name="name">website.library_image_03</field>
         <field name="raw" type="bytes" file="real_estate/static/src/binary/ir_attachment/878-website.library_image_03"/>
         <field name="key">website.library_image_03</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
     </record>
     <record id="old_farm_to_renovate_attachment_1" model="ir.attachment">
@@ -103,7 +103,7 @@
         <field name="raw" type="bytes" file="real_estate/static/src/binary/ir_attachment/plan.jpg"/>
         <field name="res_id" ref="product_template_16"/>
         <field name="res_model">product.template</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
     </record>
     <record id="old_farm_to_renovate_attachment_2" model="ir.attachment">
@@ -111,7 +111,7 @@
         <field name="raw" type="bytes" file="real_estate/static/src/binary/ir_attachment/first_floor_plan.jpg"/>
         <field name="res_id" ref="product_template_16"/>
         <field name="res_model">product.template</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
     </record>
     <record id="old_farm_to_renovate_attachment_3" model="ir.attachment">
@@ -119,7 +119,7 @@
         <field name="raw" type="bytes" file="real_estate/static/src/binary/ir_attachment/daily_meeting_notes_today.txt"/>
         <field name="res_id" ref="product_template_16"/>
         <field name="res_model">product.template</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
     </record>
 </odoo>

--- a/real_estate/demo/website.xml
+++ b/real_estate/demo/website.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-    <record id="website.default_website" model="website" forcecreate="0">
+    <record id="base.default_website" model="website" forcecreate="0">
         <field name="name">Real Estate Agency</field>
         <field name="configurator_done" eval="True"/>
         <field name="logo" type="bytes" file="real_estate/static/description/icon.png"/>

--- a/real_estate/demo/website_page.xml
+++ b/real_estate/demo/website_page.xml
@@ -4,7 +4,7 @@
     <field name="view_id" ref="homepage"/>
     <field name="header_overlay" eval="True"/>
     <field name="header_text_color">text-o-color-3</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
     <field name="is_published" eval="True"/>
     <field name="url">/</field>
   </record>

--- a/real_estate/demo/website_theme_apply.xml
+++ b/real_estate/demo/website_theme_apply.xml
@@ -57,14 +57,14 @@
   </function>
 
   <function model="ir.ui.view" name="write">
-    <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('website.default_website').id).viewref('website.homepage').id"/>
+    <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('base.default_website').id).viewref('website.homepage').id"/>
     <value model="ir.ui.view" eval="{'arch': obj().env.ref('real_estate.homepage').arch.replace(
       '*filter_newest_products_real_estate*', str(obj().env.ref('website_sale.dynamic_filter_newest_products').id)
     )}"/>
   </function>
 
   <function model="ir.ui.view" name="write">
-    <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('website.default_website').id).viewref('website.template_footer_descriptive').id"/>
+    <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('base.default_website').id).viewref('website.template_footer_descriptive').id"/>
     <value model="ir.ui.view" eval="{'arch': obj().env.ref('real_estate.ir_ui_view_3154').arch}"/>
   </function>
 
@@ -72,26 +72,26 @@
   
     <function model="website.menu" name="unlink">
         <value model="website.menu" eval="obj().search([
-            ('website_id', '=', ref('website.default_website')),
+            ('website_id', '=', ref('base.default_website')),
             ('url', '=', '/appointment'),
         ]).ids"/>
     </function>
     <function model="website.menu" name="unlink">
         <value model="website.menu" eval="obj().search([
-            ('website_id', '=', ref('website.default_website')),
+            ('website_id', '=', ref('base.default_website')),
             ('url', '=', '/contactus'),
         ]).ids"/>
     </function>
     <function model="website.page" name="write">
         <value model="website.page" eval="obj().search([
-            ('website_id', '=', ref('website.default_website')),
+            ('website_id', '=', ref('base.default_website')),
             ('url', '=', '/'),
         ], limit=1).id"/>
         <value eval="{'header_overlay': True}"/>
     </function>
     <function model="website" name="write">
-        <value model="website" eval="[ref('website.default_website')]"/>
-        <value model="website" eval="{'shop_opt_products_design_classes': obj().env.ref('website.default_website').shop_opt_products_design_classes.replace('o_wsale_products_opt_has_cta', '')}"/>
+        <value model="website" eval="[ref('base.default_website')]"/>
+        <value model="website" eval="{'shop_opt_products_design_classes': obj().env.ref('base.default_website').shop_opt_products_design_classes.replace('o_wsale_products_opt_has_cta', '')}"/>
     </function>
   
   </data>

--- a/real_estate/demo/website_view.xml
+++ b/real_estate/demo/website_view.xml
@@ -4,7 +4,7 @@
     <field name="name">Home</field>
     <field name="key">real_estate.homepage</field>
     <field name="type">qweb</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
     <field name="arch" type="xml">
       <t name="Homepage" t-name="website.homepage">
         <t t-call="website.layout" pageName.f="homepage">
@@ -303,7 +303,7 @@
     <field name="inherit_id" ref="website.layout"/>
     <field name="mode">extension</field>
     <field name="type">qweb</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
     <field name="arch" type="xml">
       <data inherit_id="website.layout" name="Descriptive" active="False">
         <xpath expr="//div[@id='footer']" position="replace">
@@ -382,7 +382,7 @@
     <field name="mode">extension</field>
     <field name="name">Header Call to Action</field>
     <field name="type">qweb</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
   </record>
   <record id="ir_ui_view_3169" model="ir.ui.view">
     <field name="arch" type="xml">
@@ -452,7 +452,7 @@
     <field name="mode">extension</field>
     <field name="name">Header Text element</field>
     <field name="type">qweb</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
   </record>
   <record id="ir_ui_view_3166" model="ir.ui.view">
     <field name="arch" type="xml">
@@ -476,7 +476,7 @@
     <field name="mode">extension</field>
     <field name="name">Products (oe_structure_website_sale_products_1)</field>
     <field name="type">qweb</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
   </record>
   <record id="ir_ui_view_3177" model="ir.ui.view">
     <field name="arch" type="xml">
@@ -491,14 +491,14 @@
     <field name="mode">extension</field>
     <field name="name">Products (oe_structure_website_sale_products_2)</field>
     <field name="type">qweb</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
   </record>
   <record id="ir_ui_view_thumbnails_design" model="ir.ui.view">
     <field name="name">Thumbnails Design</field>
     <field name="key">website_sale.products_design_thumbs</field>
     <field name="inherit_id" ref="website_sale.products"/>
     <field name="mode">extension</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
     <field name="type">qweb</field>
     <field name="arch" type="xml">
       <xpath expr="//section[@id='o_wsale_products_grid']" position="attributes">
@@ -511,7 +511,7 @@
     <field name="key">website_sale.products_thumb_4_3</field>
     <field name="inherit_id" ref="website_sale.products"/>
     <field name="mode">extension</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
     <field name="type">qweb</field>
     <field name="arch" type="xml">
       <xpath expr="//section[@id='o_wsale_products_grid']" position="attributes">
@@ -524,7 +524,7 @@
     <field name="key">website.header_visibility_fixed</field>
     <field name="inherit_id" ref="website.layout"/>
     <field name="mode">extension</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
     <field name="type">qweb</field>
     <field name="arch" type="xml">
       <xpath expr="//header" position="attributes">

--- a/solar_installation/data/website_menu.xml
+++ b/solar_installation/data/website_menu.xml
@@ -4,15 +4,15 @@
         <field name="name">Request a Quote</field>
         <field name="page_id" ref="website_page_1"/>
         <field name="url">/get-a-quote</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="parent_id" model="website.menu" eval="obj().search([
-                ('website_id', '=', ref('website.default_website')),
+                ('website_id', '=', ref('base.default_website')),
                 ('url', '=', '#'),
         ], limit=1).id"/>
     </record>
     <function name="write" model="website.menu">
         <value model="website.menu" eval="obj().search([
-            ('website_id', '=', ref('website.default_website')),
+            ('website_id', '=', ref('base.default_website')),
             ('url', '=', '/contactus'),
         ], limit=1).id"/>
         <value model="website.menu" eval="{'website_id': False}"/>

--- a/solar_installation/data/website_page.xml
+++ b/solar_installation/data/website_page.xml
@@ -4,6 +4,6 @@
         <field name="is_published" eval="True"/>
         <field name="view_id" ref="get_a_quote"/>
         <field name="url">/get-a-quote</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
     </record>
 </odoo>

--- a/solar_installation/data/website_view.xml
+++ b/solar_installation/data/website_view.xml
@@ -5,7 +5,7 @@
         <field name="key">solar_installation.get-a-quote</field>
         <field name="type">qweb</field>
         <field name="active" eval="True"/>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="arch" type="xml">
             <t t-name="website.get-a-quote">
                 <t t-call="website.layout">

--- a/solar_installation/demo/ir_attachment_post.xml
+++ b/solar_installation/demo/ir_attachment_post.xml
@@ -3,19 +3,19 @@
     <record id="ir_attachment_516" model="ir.attachment">
         <field name="name">sunpower.jpeg</field>
         <field name="raw" type="bytes" file="solar_installation/static/src/binary/ir_attachment/516-sunpower.jpeg"/>
-        <field name="res_id" ref="website.default_website"/>
+        <field name="res_id" ref="base.default_website"/>
         <field name="res_model">website</field>
     </record>
     <record id="ir_attachment_517" model="ir.attachment">
         <field name="name">sunpower.webp</field>
         <field name="raw" type="bytes" file="solar_installation/static/src/binary/ir_attachment/517-sunpower.webp"/>
-        <field name="res_id" ref="website.default_website"/>
+        <field name="res_id" ref="base.default_website"/>
         <field name="res_model">website</field>
     </record>
     <record id="ir_attachment_731" model="ir.attachment">
         <field name="name">landing 5.webp</field>
         <field name="raw" type="bytes" file="solar_installation/static/src/binary/ir_attachment/731-landing5.webp"/>
-        <field name="res_id" ref="website.default_website"/>
+        <field name="res_id" ref="base.default_website"/>
         <field name="res_model">website</field>
     </record>
 </odoo>

--- a/solar_installation/demo/website.xml
+++ b/solar_installation/demo/website.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-    <record id="website.default_website" model="website" forcecreate="1">
+    <record id="base.default_website" model="website" forcecreate="1">
         <field name="name">My Website</field>
         <field name="logo" type="bytes" file="solar_installation/static/description/icon.png"/>
         <field name="configurator_done" eval="True"/>

--- a/solar_installation/demo/website_theme_apply.xml
+++ b/solar_installation/demo/website_theme_apply.xml
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo>
     <function name="write" model="ir.ui.view">
-        <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=ref('website.default_website')).viewref('website.homepage').id"/>
+        <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=ref('base.default_website')).viewref('website.homepage').id"/>
         <value model="ir.ui.view" eval="{'arch': obj().env.ref('solar_installation.homepage').arch}"/>
     </function>
 
     <data noupdate="1">
         <function model="website.menu" name="unlink">
             <value model="website.menu" eval="obj().search([
-                ('website_id', '=', ref('website.default_website')),
+                ('website_id', '=', ref('base.default_website')),
                 ('url', '=', '/contactus'),
             ]).ids"/>
         </function>

--- a/solar_installation/demo/website_view.xml
+++ b/solar_installation/demo/website_view.xml
@@ -4,7 +4,7 @@
         <field name="name">Home</field>
         <field name="key">solar_installation.homepage</field>
         <field name="type">qweb</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="arch" type="xml">
             <t name="Homepage" t-name="website.homepage">
                 <t t-call="website.layout" pageName.f="homepage">
@@ -79,7 +79,7 @@
         <field name="key">website.header_call_to_action</field>
         <field name="mode">extension</field>
         <field name="type">qweb</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="arch" type="xml">
             <data inherit_id="website.placeholder_header_call_to_action" name="Header Call to Action" active="True">
                 <xpath expr="." position="inside">
@@ -103,7 +103,7 @@
         <field name="key">website.footer_custom</field>
         <field name="mode">extension</field>
         <field name="type">qweb</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="arch" type="xml">
             <data inherit_id="website.layout" name="Default" active="True">
                 <xpath expr="//div[@id='footer']" position="replace">
@@ -178,7 +178,7 @@
         <field name="key">website.footer_copyright_company_name</field>
         <field name="mode">extension</field>
         <field name="type">qweb</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="arch" type="xml">
             <data inherit_id="website.layout">
                 <xpath expr="//footer//span[hasclass('o_footer_copyright_name')]" position="replace">
@@ -193,7 +193,7 @@
         <field name="key">website_helpdesk.team_oe_structure_website_helpdesk_team_3</field>
         <field name="mode">extension</field>
         <field name="type">qweb</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="arch" type="xml">
             <data>
                 <xpath expr="//*[hasclass('oe_structure')][@id='oe_structure_website_helpdesk_team_3']" position="replace">

--- a/spa_resort/demo/website.xml
+++ b/spa_resort/demo/website.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-  <record id="website.default_website" model="website" forcecreate="1">
+  <record id="base.default_website" model="website" forcecreate="1">
     <field name="name">Spa Resort</field>
     <field name="configurator_done" eval="True"/>
     <field name="logo" type="bytes" file="spa_resort/static/description/icon.png"/>

--- a/spa_resort/demo/website_menu.xml
+++ b/spa_resort/demo/website_menu.xml
@@ -6,10 +6,10 @@
       <field name="sequence">30</field>
       <field name="page_id" ref="website_page_6"/>
       <field name="parent_id" model="website.menu" eval="obj().search([
-          ('website_id', '=', ref('website.default_website')),
+          ('website_id', '=', ref('base.default_website')),
           ('url', '=', '#'),
       ], limit=1).id"/>
-      <field name="website_id" ref="website.default_website"/>
+      <field name="website_id" ref="base.default_website"/>
   </record>
   <record id="website_menu_2" model="website.menu">
       <field name="name">Massages &amp; Treatments</field>
@@ -17,9 +17,9 @@
       <field name="sequence">40</field>
       <field name="page_id" ref="website_page_7"/>
       <field name="parent_id" model="website.menu" eval="obj().search([
-          ('website_id', '=', ref('website.default_website')),
+          ('website_id', '=', ref('base.default_website')),
           ('url', '=', '#'),
       ], limit=1).id"/>
-      <field name="website_id" ref="website.default_website"/>
+      <field name="website_id" ref="base.default_website"/>
   </record>
 </odoo>

--- a/spa_resort/demo/website_page.xml
+++ b/spa_resort/demo/website_page.xml
@@ -2,13 +2,13 @@
 <odoo noupdate="1">
   <record id="website_page_6" model="website.page">
     <field name="view_id" ref="wellness_access"/>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
     <field name="is_published" eval="True"/>
     <field name="url">/wellness-access</field>
   </record>
   <record id="website_page_7" model="website.page">
     <field name="view_id" ref="massages_treatments"/>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
     <field name="is_published" eval="True"/>
     <field name="url">/massages-treatments</field>
   </record>

--- a/spa_resort/demo/website_theme_apply.xml
+++ b/spa_resort/demo/website_theme_apply.xml
@@ -44,7 +44,7 @@
   </function>
 
   <function model="ir.ui.view" name="write">
-    <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('website.default_website').id).viewref('website.homepage').id"/>
+    <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('base.default_website').id).viewref('website.homepage').id"/>
     <value model="ir.ui.view" eval="{'arch': obj().env.ref('spa_resort.homepage').arch.replace(
         '*gift_card_product*', str(obj().env.ref('loyalty.gift_card_product_50').website_url))
     }"/>
@@ -71,10 +71,10 @@
 
   <data noupdate="1">
     <function model="website.menu" name="unlink">
-      <value model="website.menu" search="[('website_id', '=', ref('website.default_website')), ('url', '=', '/appointment')]"/>
+      <value model="website.menu" search="[('website_id', '=', ref('base.default_website')), ('url', '=', '/appointment')]"/>
     </function>
     <function model="website.menu" name="unlink">
-      <value model="website.menu" search="[('website_id', '=', ref('website.default_website')), ('url', '=', '/shop')]"/>
+      <value model="website.menu" search="[('website_id', '=', ref('base.default_website')), ('url', '=', '/shop')]"/>
     </function>
   </data>
 

--- a/spa_resort/demo/website_view.xml
+++ b/spa_resort/demo/website_view.xml
@@ -4,7 +4,7 @@
     <field name="key">spa_resort.homepage</field>
     <field name="name">Home</field>
     <field name="type">qweb</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
     <field name="arch" type="xml">
       <t name="Homepage" t-name="website.homepage">
         <t t-call="website.layout" pageName.f="homepage">
@@ -123,7 +123,7 @@
     <field name="key">spa_resort.massages-treatments</field>
     <field name="name">Massages &amp; Treatments</field>
     <field name="type">qweb</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
     <field name="arch" type="xml">
       <t t-name="website.massages-treatments">
         <t t-call="website.layout">
@@ -199,7 +199,7 @@
     <field name="key">spa_resort.wellness-access</field>
     <field name="name">Wellness Access</field>
     <field name="type">qweb</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
     <field name="arch" type="xml">
       <t t-name="website.wellness-access">
         <t t-call="website.layout">
@@ -302,7 +302,7 @@
     <field name="mode">extension</field>
     <field name="name">Contact Us Banner Image</field>
     <field name="type">qweb</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
     <field name="arch" type="xml">
       <xpath expr="//t[@t-name='website.contactus']//div[hasclass('col-lg-5')]/img" position="replace">
         <img src="/web/image/spa_resort.ir_attachment_1139" class="img img-fluid rounded" alt=""/>

--- a/sports_club/demo/sale_order.xml
+++ b/sports_club/demo/sale_order.xml
@@ -3,14 +3,14 @@
     <record id="sale_order_1" model="sale.order">
         <field name="carrier_id" ref="website_sale_collect.carrier_pick_up_in_store"/>
         <field name="partner_shipping_id" ref="base.main_partner"/>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="partner_id" ref="base.partner_admin"/>
         <field name="user_id" ref="base.user_admin"/>
     </record>
     <record id="sale_order_2" model="sale.order">
         <field name="carrier_id" ref="website_sale_collect.carrier_pick_up_in_store"/>
         <field name="partner_shipping_id" ref="base.main_partner"/>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="partner_id" ref="base.partner_admin"/>
         <field name="user_id" ref="base.user_admin"/>
     </record>

--- a/sports_club/demo/website.xml
+++ b/sports_club/demo/website.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-    <record id="website.default_website" model="website" forcecreate="1">
+    <record id="base.default_website" model="website" forcecreate="1">
         <field name="name">Padel-club</field>
         <field name="add_to_cart_action">stay</field>
         <field name="configurator_done" eval="True"/>

--- a/sports_club/demo/website.xml
+++ b/sports_club/demo/website.xml
@@ -2,7 +2,6 @@
 <odoo noupdate="1">
     <record id="base.default_website" model="website" forcecreate="1">
         <field name="name">Padel-club</field>
-        <field name="add_to_cart_action">stay</field>
         <field name="configurator_done" eval="True"/>
         <field name="logo" type="bytes" file="sports_club/static/description/icon.png"/>
         <field name="favicon" type="bytes" file="sports_club/static/description/icon.png"/>

--- a/sports_club/demo/website_ir_attachments.xml
+++ b/sports_club/demo/website_ir_attachments.xml
@@ -4,21 +4,21 @@
         <field name="name">unsplash_M2x3A8Q4JbY_.jpg</field>
         <field name="raw" type="bytes" file="sports_club/static/src/binary/ir_attachment/498-unsplash_M2x3A8Q4JbY_.jpg"/>
         <field name="res_model">ir.ui.view</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
     </record>
     <record id="ir_attachment_593" model="ir.attachment">
         <field name="name">unsplash_Z4Sxy1_3wdY_padel.jpg</field>
         <field name="raw" type="bytes" file="sports_club/static/src/binary/ir_attachment/593-unsplash_Z4Sxy1_3wdY_padel.jpg"/>
         <field name="res_model">ir.ui.view</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
     </record>
     <record id="ir_attachment_598" model="ir.attachment">
         <field name="name">unsplash_Z4Sxy1_3wdY_padel.webp</field>
         <field name="raw" type="bytes" file="sports_club/static/src/binary/ir_attachment/598-unsplash_Z4Sxy1_3wdY_padel.webp"/>
         <field name="res_model">ir.ui.view</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
     </record>
     <record id="ir_attachment_636" model="ir.attachment">
@@ -26,257 +26,257 @@
         <field name="raw" type="bytes" file="sports_club/static/src/binary/ir_attachment/636-vincenzo-morelli-7JAzrUT8450-unsplash2.png"/>
         <field name="res_id" ref="product_template_20"/>
         <field name="res_model">product.template</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
     </record>
     <record id="ir_attachment_655" model="ir.attachment">
         <field name="name">invitation.ics</field>
         <field name="raw" type="bytes" file="sports_club/static/src/binary/ir_attachment/655-invitation.ics"/>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
     </record>
     <record id="ir_attachment_656" model="ir.attachment">
         <field name="name">invitation.ics</field>
         <field name="raw" type="bytes" file="sports_club/static/src/binary/ir_attachment/656-invitation.ics"/>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
     </record>
     <record id="configurator_1_library_image_02" model="ir.attachment">
         <field name="name">website.library_image_02</field>
         <field name="raw" type="bytes" file="sports_club/static/src/binary/ir_attachment/469-website.library_image_02"/>
         <field name="key">sports_club.library_image_02</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
     </record>
     <record id="configurator_1_library_image_03" model="ir.attachment">
         <field name="name">website.library_image_03</field>
         <field name="raw" type="bytes" file="sports_club/static/src/binary/ir_attachment/462-website.library_image_03"/>
         <field name="key">sports_club.library_image_03</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
     </record>
     <record id="configurator_1_library_image_05" model="ir.attachment">
         <field name="name">website.library_image_05</field>
         <field name="raw" type="bytes" file="sports_club/static/src/binary/ir_attachment/465-website.library_image_05"/>
         <field name="key">sports_club.library_image_05</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
     </record>
     <record id="configurator_1_library_image_08" model="ir.attachment">
         <field name="name">website.library_image_08</field>
         <field name="raw" type="bytes" file="sports_club/static/src/binary/ir_attachment/468-website.library_image_08"/>
         <field name="key">sports_club.library_image_08</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
     </record>
     <record id="configurator_1_library_image_10" model="ir.attachment">
         <field name="name">website.library_image_10</field>
         <field name="raw" type="bytes" file="sports_club/static/src/binary/ir_attachment/463-website.library_image_10"/>
         <field name="key">sports_club.library_image_10</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
     </record>
     <record id="configurator_1_library_image_13" model="ir.attachment">
         <field name="name">website.library_image_13</field>
         <field name="raw" type="bytes" file="sports_club/static/src/binary/ir_attachment/464-website.library_image_13"/>
         <field name="key">sports_club.library_image_13</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
     </record>
     <record id="configurator_1_library_image_14" model="ir.attachment">
         <field name="name">website.library_image_14</field>
         <field name="raw" type="bytes" file="sports_club/static/src/binary/ir_attachment/466-website.library_image_14"/>
         <field name="key">sports_club.library_image_14</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
     </record>
     <record id="configurator_1_library_image_16" model="ir.attachment">
         <field name="name">website.library_image_16</field>
         <field name="raw" type="bytes" file="sports_club/static/src/binary/ir_attachment/467-website.library_image_16"/>
         <field name="key">sports_club.library_image_16</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
     </record>
     <record id="configurator_1_s_banner_default_image" model="ir.attachment">
         <field name="name">website.s_banner_default_image</field>
         <field name="raw" type="bytes" file="sports_club/static/src/binary/ir_attachment/446-website.s_banner_default_image"/>
         <field name="key">sports_club.s_banner_default_image</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
     </record>
     <record id="configurator_1_s_carousel_default_image_1" model="ir.attachment">
         <field name="name">website.s_carousel_default_image_1</field>
         <field name="raw" type="bytes" file="sports_club/static/src/binary/ir_attachment/443-website.s_carousel_default_image_1"/>
         <field name="key">sports_club.s_carousel_default_image_1</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
     </record>
     <record id="configurator_1_s_carousel_default_image_2" model="ir.attachment">
         <field name="name">website.s_carousel_default_image_2</field>
         <field name="raw" type="bytes" file="sports_club/static/src/binary/ir_attachment/444-website.s_carousel_default_image_2"/>
         <field name="key">sports_club.s_carousel_default_image_2</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
     </record>
     <record id="configurator_1_s_carousel_default_image_3" model="ir.attachment">
         <field name="name">website.s_carousel_default_image_3</field>
         <field name="raw" type="bytes" file="sports_club/static/src/binary/ir_attachment/445-website.s_carousel_default_image_3"/>
         <field name="key">sports_club.s_carousel_default_image_3</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
     </record>
     <record id="configurator_1_s_cover_default_image" model="ir.attachment">
         <field name="name">website.s_cover_default_image</field>
         <field name="raw" type="bytes" file="sports_club/static/src/binary/ir_attachment/436-website.s_cover_default_image"/>
         <field name="key">sports_club.s_cover_default_image</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
     </record>
     <record id="configurator_1_s_image_text_default_image" model="ir.attachment">
         <field name="name">website.s_image_text_default_image</field>
         <field name="raw" type="bytes" file="sports_club/static/src/binary/ir_attachment/456-website.s_image_text_default_image"/>
         <field name="key">sports_club.s_image_text_default_image</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
     </record>
     <record id="configurator_1_s_masonry_block_default_image_1" model="ir.attachment">
         <field name="name">website.s_masonry_block_default_image_1</field>
         <field name="raw" type="bytes" file="sports_club/static/src/binary/ir_attachment/437-website.s_masonry_block_default_image_1"/>
         <field name="key">sports_club.s_masonry_block_default_image_1</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
     </record>
     <record id="configurator_1_s_media_list_default_image_1" model="ir.attachment">
         <field name="name">website.s_media_list_default_image_1</field>
         <field name="raw" type="bytes" file="sports_club/static/src/binary/ir_attachment/438-website.s_media_list_default_image_1"/>
         <field name="key">sports_club.s_media_list_default_image_1</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
     </record>
     <record id="configurator_1_s_media_list_default_image_2" model="ir.attachment">
         <field name="name">website.s_media_list_default_image_2</field>
         <field name="raw" type="bytes" file="sports_club/static/src/binary/ir_attachment/439-website.s_media_list_default_image_2"/>
         <field name="key">sports_club.s_media_list_default_image_2</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
     </record>
     <record id="configurator_1_s_media_list_default_image_3" model="ir.attachment">
         <field name="name">website.s_media_list_default_image_3</field>
         <field name="raw" type="bytes" file="sports_club/static/src/binary/ir_attachment/440-website.s_media_list_default_image_3"/>
         <field name="key">sports_club.s_media_list_default_image_3</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
     </record>
     <record id="configurator_1_s_parallax_default_image" model="ir.attachment">
         <field name="name">website.s_parallax_default_image</field>
         <field name="raw" type="bytes" file="sports_club/static/src/binary/ir_attachment/447-website.s_parallax_default_image"/>
         <field name="key">sports_club.s_parallax_default_image</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
     </record>
     <record id="configurator_1_s_picture_default_image" model="ir.attachment">
         <field name="name">website.s_picture_default_image</field>
         <field name="raw" type="bytes" file="sports_club/static/src/binary/ir_attachment/455-website.s_picture_default_image"/>
         <field name="key">sports_club.s_picture_default_image</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
     </record>
     <record id="configurator_1_s_product_catalog_default_image" model="ir.attachment">
         <field name="name">website.s_product_catalog_default_image</field>
         <field name="raw" type="bytes" file="sports_club/static/src/binary/ir_attachment/448-website.s_product_catalog_default_image"/>
         <field name="key">sports_club.s_product_catalog_default_image</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
     </record>
     <record id="configurator_1_s_product_list_default_image_1" model="ir.attachment">
         <field name="name">website.s_product_list_default_image_1</field>
         <field name="raw" type="bytes" file="sports_club/static/src/binary/ir_attachment/449-website.s_product_list_default_image_1"/>
         <field name="key">sports_club.s_product_list_default_image_1</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
     </record>
     <record id="configurator_1_s_product_list_default_image_2" model="ir.attachment">
         <field name="name">website.s_product_list_default_image_2</field>
         <field name="raw" type="bytes" file="sports_club/static/src/binary/ir_attachment/450-website.s_product_list_default_image_2"/>
         <field name="key">sports_club.s_product_list_default_image_2</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
     </record>
     <record id="configurator_1_s_product_list_default_image_3" model="ir.attachment">
         <field name="name">website.s_product_list_default_image_3</field>
         <field name="raw" type="bytes" file="sports_club/static/src/binary/ir_attachment/451-website.s_product_list_default_image_3"/>
         <field name="key">sports_club.s_product_list_default_image_3</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
     </record>
     <record id="configurator_1_s_product_list_default_image_4" model="ir.attachment">
         <field name="name">website.s_product_list_default_image_4</field>
         <field name="raw" type="bytes" file="sports_club/static/src/binary/ir_attachment/452-website.s_product_list_default_image_4"/>
         <field name="key">sports_club.s_product_list_default_image_4</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
     </record>
     <record id="configurator_1_s_product_list_default_image_5" model="ir.attachment">
         <field name="name">website.s_product_list_default_image_5</field>
         <field name="raw" type="bytes" file="sports_club/static/src/binary/ir_attachment/453-website.s_product_list_default_image_5"/>
         <field name="key">sports_club.s_product_list_default_image_5</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
     </record>
     <record id="configurator_1_s_product_list_default_image_6" model="ir.attachment">
         <field name="name">website.s_product_list_default_image_6</field>
         <field name="raw" type="bytes" file="sports_club/static/src/binary/ir_attachment/454-website.s_product_list_default_image_6"/>
         <field name="key">sports_club.s_product_list_default_image_6</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
     </record>
     <record id="configurator_1_s_quotes_carousel_demo_image_0" model="ir.attachment">
         <field name="name">website.s_quotes_carousel_demo_image_0</field>
         <field name="raw" type="bytes" file="sports_club/static/src/binary/ir_attachment/461-website.s_quotes_carousel_demo_image_0"/>
         <field name="key">sports_club.s_quotes_carousel_demo_image_0</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
     </record>
     <record id="configurator_1_s_quotes_carousel_demo_image_1" model="ir.attachment">
         <field name="name">website.s_quotes_carousel_demo_image_1</field>
         <field name="raw" type="bytes" file="sports_club/static/src/binary/ir_attachment/441-website.s_quotes_carousel_demo_image_1"/>
         <field name="key">sports_club.s_quotes_carousel_demo_image_1</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
     </record>
     <record id="configurator_1_s_quotes_carousel_demo_image_2" model="ir.attachment">
         <field name="name">website.s_quotes_carousel_demo_image_2</field>
         <field name="raw" type="bytes" file="sports_club/static/src/binary/ir_attachment/442-website.s_quotes_carousel_demo_image_2"/>
         <field name="key">sports_club.s_quotes_carousel_demo_image_2</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
     </record>
     <record id="configurator_1_s_text_image_default_image" model="ir.attachment">
         <field name="name">website.s_text_image_default_image</field>
         <field name="raw" type="bytes" file="sports_club/static/src/binary/ir_attachment/457-website.s_text_image_default_image"/>
         <field name="key">sports_club.s_text_image_default_image</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
     </record>
     <record id="configurator_1_s_three_columns_default_image_1" model="ir.attachment">
         <field name="name">website.s_three_columns_default_image_1</field>
         <field name="raw" type="bytes" file="sports_club/static/src/binary/ir_attachment/458-website.s_three_columns_default_image_1"/>
         <field name="key">sports_club.s_three_columns_default_image_1</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
     </record>
     <record id="configurator_1_s_three_columns_default_image_2" model="ir.attachment">
         <field name="name">website.s_three_columns_default_image_2</field>
         <field name="raw" type="bytes" file="sports_club/static/src/binary/ir_attachment/459-website.s_three_columns_default_image_2"/>
         <field name="key">sports_club.s_three_columns_default_image_2</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
     </record>
     <record id="configurator_1_s_three_columns_default_image_3" model="ir.attachment">
         <field name="name">website.s_three_columns_default_image_3</field>
         <field name="raw" type="bytes" file="sports_club/static/src/binary/ir_attachment/460-website.s_three_columns_default_image_3"/>
         <field name="key">sports_club.s_three_columns_default_image_3</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
     </record>
 </odoo>

--- a/sports_club/demo/website_menu.xml
+++ b/sports_club/demo/website_menu.xml
@@ -4,10 +4,10 @@
         <field name="name">The Club</field>
         <field name="url">/about-us</field>
         <field name="sequence">57</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="page_id" ref="website_page_5"/>
         <field name="parent_id" model="website.menu" eval="obj().search([
-                ('website_id', '=', ref('website.default_website')),
+                ('website_id', '=', ref('base.default_website')),
                 ('url', '=', '#'),
         ], limit=1).id"/>
     </record>
@@ -15,9 +15,9 @@
         <field name="name">Play</field>
         <field name="url">#</field>
         <field name="sequence">56</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="parent_id" model="website.menu" eval="obj().search([
-                ('website_id', '=', ref('website.default_website')),
+                ('website_id', '=', ref('base.default_website')),
                 ('url', '=', '#'),
         ], limit=1).id"/>
     </record>
@@ -25,20 +25,20 @@
         <field name="name">Book a Court</field>
         <field name="url">/book/court</field>
         <field name="sequence">1</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="parent_id" ref="website_menu_7"/>
     </record>
     <record id="website_menu_13" model="website.menu">
         <field name="name">Friday Free Play</field>
         <field name="url">/book/friday-night-free-play</field>
         <field name="sequence">2</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="parent_id" ref="website_menu_7"/>
     </record>
 
     <function model="website.menu" name="unlink">
         <value model="website.menu" eval="obj().search([
-            ('website_id', '=', ref('website.default_website')),
+            ('website_id', '=', ref('base.default_website')),
             ('url', '=', '/appointment'),
         ]).ids"/>
     </function>

--- a/sports_club/demo/website_page.xml
+++ b/sports_club/demo/website_page.xml
@@ -3,7 +3,7 @@
     <record id="website_page_5" model="website.page">
         <field name="is_published" eval="True"/>
         <field name="url">/about-us</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="view_id" ref="about-us"/>
     </record>
 </odoo>

--- a/sports_club/demo/website_theme_apply.xml
+++ b/sports_club/demo/website_theme_apply.xml
@@ -12,13 +12,13 @@
         <value model="ir.ui.view" eval="{'active': False}"/>
     </function>
 
-    <function model="website.assets" name="make_scss_customization" context="{'website_id': ref('website.default_website')}">
+    <function model="website.assets" name="make_scss_customization" context="{'website_id': ref('base.default_website')}">
         <value eval="'/website/static/src/scss/options/colors/user_color_palette.scss'"/>
         <value eval="{'o-color-1': '#fab803','o-color-2': '#1A1423','o-color-4': '#FFFFFF','o-color-5': '#1A1423', 'menu': 3}"/>
     </function>
 
     <function model="ir.ui.view" name="write">
-        <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('website.default_website').id).viewref('website.homepage').id"/>
+        <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('base.default_website').id).viewref('website.homepage').id"/>
         <value model="ir.ui.view" eval="{'arch': obj().env.ref('sports_club.homepage').arch.replace(
             '*filter_newest_products_sports_club*', str(obj().env.ref('website_sale.dynamic_filter_newest_products').id)
         )}"/>
@@ -27,7 +27,7 @@
     <data noupdate="1">
         <function model="website.menu" name="write">
             <value model="website.menu" eval="obj().search([
-                ('website_id', '=', ref('website.default_website')),
+                ('website_id', '=', ref('base.default_website')),
                 ('url', '=', '/shop'),
             ], limit=1).id"/>
             <value eval="{'name': 'Gear'}"/>

--- a/sports_club/demo/website_view.xml
+++ b/sports_club/demo/website_view.xml
@@ -4,7 +4,7 @@
         <field name="name">Home</field>
         <field name="key">sports_club.homepage</field>
         <field name="type">qweb</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="arch" type="xml">
             <t name="Homepage" t-name="website.homepage">
                 <t t-call="website.layout" pageName.f="homepage">
@@ -187,7 +187,7 @@
         <field name="key">sports_club.footer_custom</field>
         <field name="mode">extension</field>
         <field name="type">qweb</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="arch" type="xml">
             <data inherit_id="website.layout" name="Default" active="True">
                 <xpath expr="//div[@id='footer']" position="replace">
@@ -264,7 +264,7 @@
         <field name="name">About Us</field>
         <field name="key">sports_club.about-us</field>
         <field name="type">qweb</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="arch" type="xml">
             <t name="About Us" t-name="website.about-us">
                 <t t-call="website.layout">

--- a/student_organization/demo/ir_attachment_post.xml
+++ b/student_organization/demo/ir_attachment_post.xml
@@ -15,13 +15,13 @@
     <field name="raw" type="bytes" file="student_organization/static/src/binary/ir_attachment/972-website.s_image_text_default_image"/>
     <field name="key">website.s_image_text_default_image</field>
     <field name="public" eval="True" />
-    <field name="website_id" ref="website.default_website" />
+    <field name="website_id" ref="base.default_website" />
   </record>
   <record id="configurator_1_s_parallax_default_image" model="ir.attachment">
     <field name="name">website.s_parallax_default_image</field>
     <field name="raw" type="bytes" file="student_organization/static/src/binary/ir_attachment/963-website.s_parallax_default_image"/>
     <field name="key">website.s_parallax_default_image</field>
     <field name="public" eval="True" />
-    <field name="website_id" ref="website.default_website" />
+    <field name="website_id" ref="base.default_website" />
   </record>
 </odoo>

--- a/student_organization/demo/website.xml
+++ b/student_organization/demo/website.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-  <record id="website.default_website" model="website" forcecreate="1">
+  <record id="base.default_website" model="website" forcecreate="1">
     <field name="name">studentorganizationindustry</field>
     <field name="configurator_done" eval="True"/>
     <field name="theme_id" search="[('id', '=', ref('base.module_theme_clean', raise_if_not_found=False))]"/>

--- a/student_organization/demo/website_theme_apply.xml
+++ b/student_organization/demo/website_theme_apply.xml
@@ -4,12 +4,12 @@
   <function name="button_choose_theme" model="ir.module.module" eval="[ref('base.module_theme_clean', raise_if_not_found=False) or ref('base.module_theme_default')]"/>
 
   <function model="ir.ui.view" name="write">
-    <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('website.default_website').id).viewref('website.homepage').id" />
+    <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('base.default_website').id).viewref('website.homepage').id" />
     <value model="ir.ui.view" eval="{'arch': obj().env.ref('student_organization.homepage').arch}" />
   </function>
 
   <function model="ir.ui.view" name="write">
-    <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('website.default_website').id).viewref('website.template_footer_centered').id" />
+    <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('base.default_website').id).viewref('website.template_footer_centered').id" />
     <value model="ir.ui.view" eval="{'arch': obj().env.ref('student_organization.ir_ui_view_4382').arch}" />
   </function>
 
@@ -18,7 +18,7 @@
     <function model="website.menu" name="unlink">
         <value model="website.menu"
         eval="obj().search([
-                ('website_id', '=', ref('website.default_website')),
+                ('website_id', '=', ref('base.default_website')),
                 ('url', '=', '/appointment'),
             ]).ids" />
     </function>

--- a/student_organization/demo/website_view.xml
+++ b/student_organization/demo/website_view.xml
@@ -6,7 +6,7 @@
     <field name="mode">extension</field>
     <field name="name">Centered</field>
     <field name="type">qweb</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
     <field name="arch" type="xml">
       <data inherit_id="website.layout" name="Centered" active="False">
         <xpath expr="//div[@id='footer']" position="replace">
@@ -56,7 +56,7 @@
     <field name="key">student_organization.homepage</field>
     <field name="name">Home</field>
     <field name="type">qweb</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
     <field name="arch" type="xml">
       <t name="Homepage" t-name="website.homepage">
         <t t-call="website.layout" pageName.f="homepage">

--- a/summer_camps/data/ir_attachment.xml
+++ b/summer_camps/data/ir_attachment.xml
@@ -28,7 +28,7 @@
   <record id="ir_attachment_1125" model="ir.attachment">
     <field name="name">Parental Consent.pdf</field>
     <field name="raw" type="bytes" file="summer_camps/static/src/binary/ir_attachment/1125-ParentalConsent.pdf"/>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
   </record>
   <record id="ir_attachment_1124" model="ir.attachment">
     <field name="name">unsplash_f7b6WX_p1N0_.jpg</field>
@@ -49,7 +49,7 @@
     <field name="name">Styled_Adventure_Summer_Camp_Packing_List.pdf</field>
     <field name="raw" type="bytes" file="summer_camps/static/src/binary/ir_attachment/1120-Styled_Adventure_Summer_Camp_Packing_List.pdf"/>
     <field name="res_model">mail.message</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
   </record>
   <record id="ir_attachment_1093" model="ir.attachment">
     <field name="name">Event'SummerCamp-2025'coverimage.webp</field>

--- a/summer_camps/data/website_menu.xml
+++ b/summer_camps/data/website_menu.xml
@@ -2,14 +2,14 @@
 <odoo noupdate="1">
     <function model="website.menu" name="write">
         <value model="website.menu" search="[
-            ('website_id', '=', ref('website.default_website')),
+            ('website_id', '=', ref('base.default_website')),
             ('url', '=', '/event'),
         ]"/>
         <value eval="{'name': 'Summer Camps'}"/>
     </function>
     <function model="website.menu" name="write">
         <value model="website.menu" search="[
-            ('website_id', '=', ref('website.default_website')),
+            ('website_id', '=', ref('base.default_website')),
             ('url', '=', '/appointment'),
         ]"/>
         <value eval="{'name': 'Meet a Counsellor'}"/>

--- a/summer_camps/demo/sale_order.xml
+++ b/summer_camps/demo/sale_order.xml
@@ -3,6 +3,6 @@
   <record id="sale_order_1" model="sale.order">
     <field name="partner_id" ref="res_partner_11"/>
     <field name="user_id" ref="base.user_admin"/>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
   </record>
 </odoo>

--- a/summer_camps/demo/website.xml
+++ b/summer_camps/demo/website.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-  <record id="website.default_website" model="website" forcecreate="1">
+  <record id="base.default_website" model="website" forcecreate="1">
     <field name="name">Summer Camps</field>
     <field name="theme_id" search="[('id', '=', ref('base.module_theme_kiddo', raise_if_not_found=False))]"/>
     <field name="configurator_done" eval="True"/>

--- a/summer_camps/demo/website_menu.xml
+++ b/summer_camps/demo/website_menu.xml
@@ -2,13 +2,13 @@
 <odoo noupdate="1">
     <function model="website.menu" name="unlink">
         <value model="website.menu" search="[
-            ('website_id', '=', ref('website.default_website')),
+            ('website_id', '=', ref('base.default_website')),
             ('url', '=', '/shop'),
         ]"/>
     </function>
         <function model="website.menu" name="unlink">
         <value model="website.menu" search="[
-            ('website_id', '=', ref('website.default_website')),
+            ('website_id', '=', ref('base.default_website')),
             ('url', '=', '/contactus'),
         ]"/>
     </function>

--- a/summer_camps/demo/website_theme_apply.xml
+++ b/summer_camps/demo/website_theme_apply.xml
@@ -2,7 +2,7 @@
 <odoo>
     <function name="button_choose_theme" model="ir.module.module" eval="[ref('base.module_theme_kiddo', raise_if_not_found=False) or ref('base.module_theme_default')]"/>
 
-    <function model="website.assets" name="make_scss_customization" context="{'website_id': ref('website.default_website')}">
+    <function model="website.assets" name="make_scss_customization" context="{'website_id': ref('base.default_website')}">
         <value eval="'/website/static/src/scss/options/colors/user_color_palette.scss'" />
         <value eval="{
             'menu': 3,
@@ -10,7 +10,7 @@
         }"/>
     </function>
 
-    <function model="website.assets" name="make_scss_customization" context="{'website_id': ref('website.default_website')}">
+    <function model="website.assets" name="make_scss_customization" context="{'website_id': ref('base.default_website')}">
         <value eval="'/website/static/src/scss/options/user_values.scss'" />
         <value eval="{
             'menu-gradient': 'null',
@@ -38,7 +38,7 @@
         }"/>
     </function>
 
-    <function model="website.assets" name="make_scss_customization" context="{'website_id': ref('website.default_website')}">
+    <function model="website.assets" name="make_scss_customization" context="{'website_id': ref('base.default_website')}">
         <value eval="'/website/static/src/scss/options/colors/user_theme_color_palette.scss'"/>
         <value eval="{
             'success': 'null',

--- a/summer_camps/demo/website_view.xml
+++ b/summer_camps/demo/website_view.xml
@@ -140,7 +140,7 @@
         <field name="key">summer_camps.homepage</field>
         <field name="name">Home</field>
         <field name="type">qweb</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
     </record>
     <template id="custom_event_index_heading" inherit_id="website_event.index_topbar">
         <xpath expr="//section[hasclass('o_wevent_index_topbar_filters')]/h1[hasclass('me-auto')]" position="replace">
@@ -148,7 +148,7 @@
         </xpath>
     </template>
     <function model="ir.ui.view" name="write">
-        <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('website.default_website').id).viewref('website.homepage').id"/>
+        <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('base.default_website').id).viewref('website.homepage').id"/>
         <value model="ir.ui.view" eval="{'arch': obj().env.ref('summer_camps.ir_ui_view_916').arch}"/>
     </function>
 </odoo>

--- a/surveyor/data/website_view.xml
+++ b/surveyor/data/website_view.xml
@@ -5,7 +5,7 @@
         <field name="name">Contact Us</field>
         <field name="type">qweb</field>
         <field name="active" eval="True"/>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="arch" type="xml">
             <t name="Contact Us" t-name="website.contactus">
                 <t t-call="website.layout"
@@ -170,7 +170,7 @@
         </field>
     </record>
     <function model="ir.ui.view" name="write">
-        <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('website.default_website').id).viewref('website.contactus').id"/>
+        <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('base.default_website').id).viewref('website.contactus').id"/>
         <value model="ir.ui.view" eval="{'arch': obj().env.ref('surveyor.contactus').arch.replace(
         '*sales_team_team_sales_department*', str(obj().env.ref('sales_team.team_sales_department').id)).replace(
         '*base_user_admin*', str(obj().env.ref('base.user_admin').id))

--- a/surveyor/demo/website.xml
+++ b/surveyor/demo/website.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-    <record id="website.default_website" model="website" forcecreate="1">
+    <record id="base.default_website" model="website" forcecreate="1">
         <field name="name">industry-surveyor</field>
         <field name="configurator_done" eval="True"/>
         <field name="logo" type="bytes" file="surveyor/static/description/icon.png"/>

--- a/surveyor/demo/website_ir_attachment.xml
+++ b/surveyor/demo/website_ir_attachment.xml
@@ -4,277 +4,277 @@
         <field name="name">image.png</field>
         <field name="raw" type="bytes" file="surveyor/static/src/binary/ir_attachment/615-image.png"/>
         <field name="res_model">knowledge.article</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
     </record>
     <record id="ir_attachment_616" model="ir.attachment">
         <field name="name">image.png</field>
         <field name="raw" type="bytes" file="surveyor/static/src/binary/ir_attachment/616-image.png"/>
         <field name="res_model">knowledge.article</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
     </record>
     <record id="configurator_1_library_image_02" model="ir.attachment">
         <field name="name">website.library_image_02</field>
         <field name="raw" type="bytes" file="surveyor/static/src/binary/ir_attachment/419-website.library_image_02.jpg"/>
         <field name="key">surveyor.library_image_02</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
     </record>
     <record id="configurator_1_library_image_03" model="ir.attachment">
         <field name="name">website.library_image_03</field>
         <field name="raw" type="bytes" file="surveyor/static/src/binary/ir_attachment/412-website.library_image_03.jpg"/>
         <field name="key">surveyor.library_image_03</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
     </record>
     <record id="configurator_1_library_image_05" model="ir.attachment">
         <field name="name">website.library_image_05</field>
         <field name="raw" type="bytes" file="surveyor/static/src/binary/ir_attachment/415-website.library_image_05.jpg"/>
         <field name="key">surveyor.library_image_05</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
     </record>
     <record id="configurator_1_library_image_08" model="ir.attachment">
         <field name="name">website.library_image_08</field>
         <field name="raw" type="bytes" file="surveyor/static/src/binary/ir_attachment/418-website.library_image_08.jpg"/>
         <field name="key">surveyor.library_image_08</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
     </record>
     <record id="configurator_1_library_image_10" model="ir.attachment">
         <field name="name">website.library_image_10</field>
         <field name="raw" type="bytes" file="surveyor/static/src/binary/ir_attachment/413-website.library_image_10.jpg"/>
         <field name="key">surveyor.library_image_10</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
     </record>
     <record id="configurator_1_library_image_13" model="ir.attachment">
         <field name="name">website.library_image_13</field>
         <field name="raw" type="bytes" file="surveyor/static/src/binary/ir_attachment/414-website.library_image_13.jpg"/>
         <field name="key">surveyor.library_image_13</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
     </record>
     <record id="configurator_1_library_image_14" model="ir.attachment">
         <field name="name">website.library_image_14</field>
         <field name="raw" type="bytes" file="surveyor/static/src/binary/ir_attachment/416-website.library_image_14.jpg"/>
         <field name="key">surveyor.library_image_14</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
     </record>
     <record id="configurator_1_library_image_16" model="ir.attachment">
         <field name="name">website.library_image_16</field>
         <field name="raw" type="bytes" file="surveyor/static/src/binary/ir_attachment/417-website.library_image_16.jpg"/>
         <field name="key">surveyor.library_image_16</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
     </record>
     <record id="configurator_1_s_banner_default_image" model="ir.attachment">
         <field name="name">website.s_banner_default_image</field>
         <field name="raw" type="bytes" file="surveyor/static/src/binary/ir_attachment/396-website.s_banner_default_image.jpg"/>
         <field name="key">surveyor.s_banner_default_image</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
     </record>
     <record id="configurator_1_s_carousel_default_image_1" model="ir.attachment">
         <field name="name">website.s_carousel_default_image_1</field>
         <field name="raw" type="bytes" file="surveyor/static/src/binary/ir_attachment/393-website.s_carousel_default_image_1.jpg"/>
         <field name="key">surveyor.s_carousel_default_image_1</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
     </record>
     <record id="configurator_1_s_carousel_default_image_2" model="ir.attachment">
         <field name="name">website.s_carousel_default_image_2</field>
         <field name="raw" type="bytes" file="surveyor/static/src/binary/ir_attachment/394-website.s_carousel_default_image_2.jpg"/>
         <field name="key">surveyor.s_carousel_default_image_2</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
     </record>
     <record id="configurator_1_s_carousel_default_image_3" model="ir.attachment">
         <field name="name">website.s_carousel_default_image_3</field>
         <field name="raw" type="bytes" file="surveyor/static/src/binary/ir_attachment/395-website.s_carousel_default_image_3.jpg"/>
         <field name="key">surveyor.s_carousel_default_image_3</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
     </record>
     <record id="configurator_1_s_cover_default_image" model="ir.attachment">
         <field name="name">website.s_cover_default_image</field>
         <field name="raw" type="bytes" file="surveyor/static/src/binary/ir_attachment/386-website.s_cover_default_image.jpg"/>
         <field name="key">surveyor.s_cover_default_image</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
     </record>
     <record id="configurator_1_s_image_text_default_image" model="ir.attachment">
         <field name="name">website.s_image_text_default_image</field>
         <field name="raw" type="bytes" file="surveyor/static/src/binary/ir_attachment/406-website.s_image_text_default_image.jpg"/>
         <field name="key">surveyor.s_image_text_default_image</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
     </record>
     <record id="configurator_1_s_masonry_block_default_image_1" model="ir.attachment">
         <field name="name">website.s_masonry_block_default_image_1</field>
         <field name="raw" type="bytes" file="surveyor/static/src/binary/ir_attachment/387-website.s_masonry_block_default_image_1.jpg"/>
         <field name="key">surveyor.s_masonry_block_default_image_1</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
     </record>
     <record id="configurator_1_s_media_list_default_image_1" model="ir.attachment">
         <field name="name">website.s_media_list_default_image_1</field>
         <field name="raw" type="bytes" file="surveyor/static/src/binary/ir_attachment/388-website.s_media_list_default_image_1.jpg"/>
         <field name="key">surveyor.s_media_list_default_image_1</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
     </record>
     <record id="configurator_1_s_media_list_default_image_2" model="ir.attachment">
         <field name="name">website.s_media_list_default_image_2</field>
         <field name="raw" type="bytes" file="surveyor/static/src/binary/ir_attachment/389-website.s_media_list_default_image_2.jpg"/>
         <field name="key">surveyor.s_media_list_default_image_2</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
     </record>
     <record id="configurator_1_s_media_list_default_image_3" model="ir.attachment">
         <field name="name">website.s_media_list_default_image_3</field>
         <field name="raw" type="bytes" file="surveyor/static/src/binary/ir_attachment/390-website.s_media_list_default_image_3.jpg"/>
         <field name="key">surveyor.s_media_list_default_image_3</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
     </record>
     <record id="configurator_1_s_parallax_default_image" model="ir.attachment">
         <field name="name">website.s_parallax_default_image</field>
         <field name="raw" type="bytes" file="surveyor/static/src/binary/ir_attachment/397-website.s_parallax_default_image.jpg"/>
         <field name="key">surveyor.s_parallax_default_image</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
     </record>
     <record id="configurator_1_s_picture_default_image" model="ir.attachment">
         <field name="name">website.s_picture_default_image</field>
         <field name="raw" type="bytes" file="surveyor/static/src/binary/ir_attachment/405-website.s_picture_default_image.jpg"/>
         <field name="key">surveyor.s_picture_default_image</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
     </record>
     <record id="configurator_1_s_product_catalog_default_image" model="ir.attachment">
         <field name="name">website.s_product_catalog_default_image</field>
         <field name="raw" type="bytes" file="surveyor/static/src/binary/ir_attachment/398-website.s_product_catalog_default_image.jpg"/>
         <field name="key">surveyor.s_product_catalog_default_image</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
     </record>
     <record id="configurator_1_s_product_list_default_image_1" model="ir.attachment">
         <field name="name">website.s_product_list_default_image_1</field>
         <field name="raw" type="bytes" file="surveyor/static/src/binary/ir_attachment/399-website.s_product_list_default_image_1.jpg"/>
         <field name="key">surveyor.s_product_list_default_image_1</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
     </record>
     <record id="configurator_1_s_product_list_default_image_2" model="ir.attachment">
         <field name="name">website.s_product_list_default_image_2</field>
         <field name="raw" type="bytes" file="surveyor/static/src/binary/ir_attachment/400-website.s_product_list_default_image_2.jpg"/>
         <field name="key">surveyor.s_product_list_default_image_2</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
     </record>
     <record id="configurator_1_s_product_list_default_image_3" model="ir.attachment">
         <field name="name">website.s_product_list_default_image_3</field>
         <field name="raw" type="bytes" file="surveyor/static/src/binary/ir_attachment/401-website.s_product_list_default_image_3.jpg"/>
         <field name="key">surveyor.s_product_list_default_image_3</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
     </record>
     <record id="configurator_1_s_product_list_default_image_4" model="ir.attachment">
         <field name="name">website.s_product_list_default_image_4</field>
         <field name="raw" type="bytes" file="surveyor/static/src/binary/ir_attachment/402-website.s_product_list_default_image_4.jpg"/>
         <field name="key">surveyor.s_product_list_default_image_4</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
     </record>
     <record id="configurator_1_s_product_list_default_image_5" model="ir.attachment">
         <field name="name">website.s_product_list_default_image_5</field>
         <field name="raw" type="bytes" file="surveyor/static/src/binary/ir_attachment/403-website.s_product_list_default_image_5.jpg"/>
         <field name="key">surveyor.s_product_list_default_image_5</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
     </record>
     <record id="configurator_1_s_product_list_default_image_6" model="ir.attachment">
         <field name="name">website.s_product_list_default_image_6</field>
         <field name="raw" type="bytes" file="surveyor/static/src/binary/ir_attachment/404-website.s_product_list_default_image_6.jpg"/>
         <field name="key">surveyor.s_product_list_default_image_6</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
     </record>
     <record id="configurator_1_s_quotes_carousel_demo_image_0" model="ir.attachment">
         <field name="name">website.s_quotes_carousel_demo_image_0</field>
         <field name="raw" type="bytes" file="surveyor/static/src/binary/ir_attachment/411-website.s_quotes_carousel_demo_image_0.jpg"/>
         <field name="key">surveyor.s_quotes_carousel_demo_image_0</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
     </record>
     <record id="configurator_1_s_quotes_carousel_demo_image_1" model="ir.attachment">
         <field name="name">website.s_quotes_carousel_demo_image_1</field>
         <field name="raw" type="bytes" file="surveyor/static/src/binary/ir_attachment/391-website.s_quotes_carousel_demo_image_1.jpg"/>
         <field name="key">surveyor.s_quotes_carousel_demo_image_1</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
     </record>
     <record id="configurator_1_s_quotes_carousel_demo_image_2" model="ir.attachment">
         <field name="name">website.s_quotes_carousel_demo_image_2</field>
         <field name="raw" type="bytes" file="surveyor/static/src/binary/ir_attachment/392-website.s_quotes_carousel_demo_image_2.jpg"/>
         <field name="key">surveyor.s_quotes_carousel_demo_image_2</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
     </record>
     <record id="configurator_1_s_text_image_default_image" model="ir.attachment">
         <field name="name">website.s_text_image_default_image</field>
         <field name="raw" type="bytes" file="surveyor/static/src/binary/ir_attachment/407-website.s_text_image_default_image.jpg"/>
         <field name="key">surveyor.s_text_image_default_image</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
     </record>
     <record id="configurator_1_s_three_columns_default_image_1" model="ir.attachment">
         <field name="name">website.s_three_columns_default_image_1</field>
         <field name="raw" type="bytes" file="surveyor/static/src/binary/ir_attachment/408-website.s_three_columns_default_image_1.jpg"/>
         <field name="key">surveyor.s_three_columns_default_image_1</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
     </record>
     <record id="configurator_1_s_three_columns_default_image_2" model="ir.attachment">
         <field name="name">website.s_three_columns_default_image_2</field>
         <field name="raw" type="bytes" file="surveyor/static/src/binary/ir_attachment/409-website.s_three_columns_default_image_2.jpg"/>
         <field name="key">surveyor.s_three_columns_default_image_2</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
     </record>
     <record id="configurator_1_s_three_columns_default_image_3" model="ir.attachment">
         <field name="name">website.s_three_columns_default_image_3</field>
         <field name="raw" type="bytes" file="surveyor/static/src/binary/ir_attachment/410-website.s_three_columns_default_image_3.jpg"/>
         <field name="key">surveyor.s_three_columns_default_image_3</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
     </record>
     <record id="ir_attachment_601" model="ir.attachment">
         <field name="name">Team Member 1.jpg</field>
         <field name="key">surveyor.s_company_team_image_1</field>
-        <field name="website_id" ref="website.default_website" />
+        <field name="website_id" ref="base.default_website" />
         <field name="raw" type="bytes" file="surveyor/static/src/binary/ir_attachment/601-team_team_member_1.jpg" />
         <field name="public" eval="True"/>
     </record>
     <record id="ir_attachment_602" model="ir.attachment">
         <field name="name">Team Member 2.jpg</field>
         <field name="key">surveyor.s_company_team_image_2</field>
-        <field name="website_id" ref="website.default_website" />
+        <field name="website_id" ref="base.default_website" />
         <field name="raw" type="bytes" file="surveyor/static/src/binary/ir_attachment/602-team_team_member_2.jpg" />
         <field name="public" eval="True"/>
     </record>
     <record id="ir_attachment_603" model="ir.attachment">
         <field name="name">Team Member 3.jpg</field>
         <field name="key">surveyor.s_company_team_image_3</field>
-        <field name="website_id" ref="website.default_website" />
+        <field name="website_id" ref="base.default_website" />
         <field name="raw" type="bytes" file="surveyor/static/src/binary/ir_attachment/603-team_team_member_3.jpg" />
         <field name="public" eval="True"/>
     </record>
     <record id="ir_attachment_604" model="ir.attachment">
         <field name="name">Team Member 4.jpg</field>
         <field name="key">surveyor.s_company_team_image_4</field>
-        <field name="website_id" ref="website.default_website" />
+        <field name="website_id" ref="base.default_website" />
         <field name="raw" type="bytes" file="surveyor/static/src/binary/ir_attachment/604-team_team_member_4.jpg" />
         <field name="public" eval="True"/>
     </record>

--- a/surveyor/demo/website_menu.xml
+++ b/surveyor/demo/website_menu.xml
@@ -5,7 +5,7 @@
         <field name="name">Services</field>
         <field name="url">/our-services</field>
         <field name="parent_id" model="website.menu" eval="obj().search([
-            ('website_id', '=', ref('website.default_website')),
+            ('website_id', '=', ref('base.default_website')),
             ('url', '=', '#'),
         ], limit=1).id"/>
     </record>
@@ -14,7 +14,7 @@
         <field name="name">About Us</field>
         <field name="url">/about-us</field>
         <field name="parent_id" model="website.menu" eval="obj().search([
-            ('website_id', '=', ref('website.default_website')),
+            ('website_id', '=', ref('base.default_website')),
             ('url', '=', '#'),
         ], limit=1).id"/>
     </record>

--- a/surveyor/demo/website_page.xml
+++ b/surveyor/demo/website_page.xml
@@ -2,7 +2,7 @@
 <odoo noupdate="1">
     <record id="website_page_5" model="website.page">
         <field name="is_published" eval="True"/>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="url">/about-us</field>
         <field name="view_id" ref="about-us"/>
     </record>

--- a/surveyor/demo/website_theme_apply.xml
+++ b/surveyor/demo/website_theme_apply.xml
@@ -1,12 +1,12 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo>
     <function name="button_choose_theme" model="ir.module.module" eval="[ref('base.module_theme_treehouse', raise_if_not_found=False) or ref('base.module_theme_default')]"/>
-    <function model="website.assets" name="make_scss_customization" context="{'website_id': ref('website.default_website')}">
+    <function model="website.assets" name="make_scss_customization" context="{'website_id': ref('base.default_website')}">
         <value eval="'/website/static/src/scss/options/colors/user_color_palette.scss'"/>
         <value eval="{'o-color-1': '#1a1a18','o-color-2': '#484846','o-color-3': '#EDEDED','o-color-4': '#FFFFFF','o-color-5': '#141412'}"/>
     </function>
     <function model="ir.ui.view" name="write">
-        <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('website.default_website').id).viewref('website.homepage').id"/>
+        <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('base.default_website').id).viewref('website.homepage').id"/>
         <value model="ir.ui.view" eval="{'arch': obj().env.ref('surveyor.homepage').arch}"/>
     </function>
 </odoo>

--- a/surveyor/demo/website_view.xml
+++ b/surveyor/demo/website_view.xml
@@ -4,7 +4,7 @@
         <field name="key">surveyor.homepage</field>
         <field name="name">Home</field>
         <field name="type">qweb</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="arch" type="xml">
             <t name="Homepage" t-name="website.homepage">
                 <t t-call="website.layout" pageName.f="homepage">
@@ -98,7 +98,7 @@
         <field name="key">surveyor.about-us</field>
         <field name="name">About Us</field>
         <field name="type">qweb</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="arch" type="xml">
             <t name="About Us" t-name="website.about-us">
                 <t t-call="website.layout">
@@ -224,7 +224,7 @@
         <field name="key">surveyor.services</field>
         <field name="name">Services</field>
         <field name="type">qweb</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="arch" type="xml">
             <t name="Services" t-name="website.services">
                 <t t-call="website.layout">

--- a/takeaway_restaurant/demo/website.xml
+++ b/takeaway_restaurant/demo/website.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-    <record id="website.default_website" model="website" forcecreate="1">
+    <record id="base.default_website" model="website" forcecreate="1">
         <field name="name">takeaway-industry</field>
         <field name="configurator_done" eval="True"/>
         <field name="user_id" ref="base.public_user"/>

--- a/takeaway_restaurant/demo/website_menu.xml
+++ b/takeaway_restaurant/demo/website_menu.xml
@@ -4,9 +4,9 @@
     <field name="name">Menu</field>
     <field name="url" eval="'/pos-self/%s' % ref('takeaway_restaurant.pos_config_1')"/>
     <field name="new_window" eval="1"/>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
     <field name="parent_id" model="website.menu" eval="obj().search([
-                ('website_id', '=', ref('website.default_website')),
+                ('website_id', '=', ref('base.default_website')),
                 ('url', '=', '#'),
     ], limit=1).id"/>
   </record>

--- a/takeaway_restaurant/demo/website_theme_apply.xml
+++ b/takeaway_restaurant/demo/website_theme_apply.xml
@@ -2,7 +2,7 @@
 <odoo>
 	<function name="button_choose_theme" model="ir.module.module" eval="[ref('base.module_theme_orchid', raise_if_not_found=False) or ref('base.module_theme_default')]"/>
 
-  <function model="website.assets" name="make_scss_customization" context="{'website_id': ref('website.default_website')}">
+  <function model="website.assets" name="make_scss_customization" context="{'website_id': ref('base.default_website')}">
       <value eval="'/website/static/src/scss/options/colors/user_color_palette.scss'"/>
       <value eval="{
         'menu-custom': '#FFFFFF',
@@ -52,18 +52,18 @@
   </function>
 
   <function model="ir.ui.view" name="write">
-    <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('website.default_website').id).viewref('website.homepage').id"/>
+    <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('base.default_website').id).viewref('website.homepage').id"/>
     <value model="ir.ui.view" eval="{'arch': obj().env.ref('takeaway_restaurant.homepage').arch}"/>
   </function>
 
   <function model="ir.ui.view" name="write">
-    <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('website.default_website').id).viewref('website.template_footer_descriptive').id"/>
+    <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('base.default_website').id).viewref('website.template_footer_descriptive').id"/>
     <value model="ir.ui.view" eval="{'arch': obj().env.ref('takeaway_restaurant.ir_ui_view_3205').arch}"/>
   </function>
 
   <data noupdate="1">
     <function model="website.menu" name="unlink">
-      <value model="website.menu" eval="obj().search([('website_id', '=', ref('website.default_website')), ('url', '=', '/contactus')]).ids" />
+      <value model="website.menu" eval="obj().search([('website_id', '=', ref('base.default_website')), ('url', '=', '/contactus')]).ids" />
     </function>
   </data>
 

--- a/takeaway_restaurant/demo/website_view.xml
+++ b/takeaway_restaurant/demo/website_view.xml
@@ -6,7 +6,7 @@
     <field name="key">takeaway_restaurant.template_footer_descriptive</field>
     <field name="mode">extension</field>
     <field name="type">qweb</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
     <field name="arch" type="xml">
       <data inherit_id="website.layout" name="Descriptive" active="False">
         <xpath expr="//div[@id='footer']" position="replace">
@@ -66,7 +66,7 @@
     <field name="name">Home</field>
     <field name="key">takeaway_restaurant.homepage</field>
     <field name="type">qweb</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
     <field name="arch" type="xml">
       <t name="Homepage" t-name="website.homepage">
         <t t-call="website.layout" pageName.f="homepage">

--- a/tattoo_shop/demo/ir_attachment_post.xml
+++ b/tattoo_shop/demo/ir_attachment_post.xml
@@ -4,7 +4,7 @@
         <field name="name">website.library_image_03</field>
         <field name="raw" type="bytes" file="tattoo_shop/static/src/binary/ir_attachment/1049-website.library_image_03"/>
         <field name="key">website.library_image_03</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="public" eval="True"/>
     </record>
     <record id="configurator_1_library_image_05" model="ir.attachment" forcecreate="1">
@@ -12,76 +12,76 @@
         <field name="raw" type="bytes" file="tattoo_shop/static/src/binary/ir_attachment/1052-website.library_image_05"/>
         <field name="key">website.library_image_05</field>
         <field name="public" eval="True"/>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
     </record>
     <record id="configurator_1_library_image_10" model="ir.attachment" forcecreate="1">
         <field name="name">website.library_image_10</field>
         <field name="raw" type="bytes" file="tattoo_shop/static/src/binary/ir_attachment/1050-website.library_image_10"/>
         <field name="key">website.library_image_10</field>
         <field name="public" eval="True"/>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
     </record>
     <record id="configurator_1_library_image_13" model="ir.attachment" forcecreate="1">
         <field name="name">website.library_image_13</field>
         <field name="raw" type="bytes" file="tattoo_shop/static/src/binary/ir_attachment/1051-website.library_image_13"/>
         <field name="key">website.library_image_13</field>
         <field name="public" eval="True"/>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
     </record>
     <record id="configurator_1_library_image_14" model="ir.attachment" forcecreate="1">
         <field name="name">website.library_image_14</field>
         <field name="raw" type="bytes" file="tattoo_shop/static/src/binary/ir_attachment/1053-website.library_image_14"/>
         <field name="key">website.library_image_14</field>
         <field name="public" eval="True"/>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
     </record>
     <record id="configurator_1_library_image_16" model="ir.attachment" forcecreate="1">
         <field name="name">website.library_image_16</field>
         <field name="raw" type="bytes" file="tattoo_shop/static/src/binary/ir_attachment/1054-website.library_image_16"/>
         <field name="key">website.library_image_16</field>
         <field name="public" eval="True"/>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
     </record>
     <record id="configurator_1_s_parallax_default_image" model="ir.attachment" forcecreate="1">
         <field name="name">website.s_parallax_default_image</field>
         <field name="raw" type="bytes" file="tattoo_shop/static/src/binary/ir_attachment/1034-website.s_parallax_default_image"/>
         <field name="key">website.s_parallax_default_image</field>
         <field name="public" eval="True"/>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
     </record>
     <record id="configurator_1_s_key_images_default_image_4" model="ir.attachment" forcecreate="1">
         <field name="name">website.s_key_images_default_image_4</field>
         <field name="raw" type="bytes" file="tattoo_shop/static/src/binary/ir_attachment/1071-website.s_key_images_default_image_4"/>
         <field name="key">website.s_key_images_default_image_4</field>
         <field name="public" eval="True"/>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
     </record>
     <record id="configurator_1_s_key_images_default_image_3" model="ir.attachment" forcecreate="1">
         <field name="name">website.s_key_images_default_image_3</field>
         <field name="raw" type="bytes" file="tattoo_shop/static/src/binary/ir_attachment/1070-website.s_key_images_default_image_3"/>
         <field name="key">website.s_key_images_default_image_3</field>
         <field name="public" eval="True"/>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
     </record>
     <record id="configurator_1_s_key_images_default_image_2" model="ir.attachment" forcecreate="1">
         <field name="name">website.s_key_images_default_image_2</field>
         <field name="raw" type="bytes" file="tattoo_shop/static/src/binary/ir_attachment/1069-website.s_key_images_default_image_2"/>
         <field name="key">website.s_key_images_default_image_2</field>
         <field name="public" eval="True"/>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
     </record>
     <record id="configurator_1_s_key_images_default_image_1" model="ir.attachment" forcecreate="1">
         <field name="name">website.s_key_images_default_image_1</field>
         <field name="raw" type="bytes" file="tattoo_shop/static/src/binary/ir_attachment/1068-website.s_key_images_default_image_1"/>
         <field name="key">website.s_key_images_default_image_1</field>
         <field name="public" eval="True"/>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
     </record>
     <record id="ir_attachment_1179" model="ir.attachment">
         <field name="name">kristian-angelo-xyJZvUL4_TY-unsplash.jpg</field>
         <field name="raw" type="bytes" file="tattoo_shop/static/src/binary/ir_attachment/1179-kristian-angelo-xyJZvUL4_TY-unsplash.jpg"/>
         <field name="res_model">ir.ui.view</field>
         <field name="public" eval="True"/>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
     </record>
 </odoo>

--- a/tattoo_shop/demo/website.xml
+++ b/tattoo_shop/demo/website.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-  <record id="website.default_website" model="website" forcecreate="1">
+  <record id="base.default_website" model="website" forcecreate="1">
     <field name="name">My Website</field>
     <field name="configurator_done" eval="True"/>
     <field name="logo" type="bytes" file="tattoo_shop/static/description/icon.png"/>

--- a/tattoo_shop/demo/website_menu.xml
+++ b/tattoo_shop/demo/website_menu.xml
@@ -2,40 +2,40 @@
 <odoo noupdate="1">
 
   <function model="website.menu" name="unlink">
-    <value model="website.menu" eval="obj().search([('website_id', '=', ref('website.default_website')), ('url', '=', '/default-main-menu')]).ids"/>
+    <value model="website.menu" eval="obj().search([('website_id', '=', ref('base.default_website')), ('url', '=', '/default-main-menu')]).ids"/>
   </function>
   <record id="website_menu_4" model="website.menu">
     <field name="name">Top Menu for Website 1</field>
     <field name="url">/default-main-menu</field>
     <field name="sequence" eval="False"/>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
   </record>
   <record id="website_menu_5" model="website.menu">
     <field name="name">Home</field>
     <field name="url">/</field>
     <field name="page_id" ref="website_page_4"/>
     <field name="sequence" eval="False"/>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
     <field name="parent_id" ref="website_menu_4"/>
   </record>
   <record id="website_menu_10" model="website.menu">
     <field name="name">Flash Tattoos</field>
     <field name="url">/flash-tattoos</field>
     <field name="page_id" ref="website_page_8"/>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
     <field name="parent_id" ref="website_menu_4"/>
   </record>
   <record id="website_menu_11" model="website.menu">
     <field name="name">Piercings</field>
     <field name="url">/appointment/2?</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
     <field name="parent_id" ref="website_menu_4"/>
   </record>
   <record id="website_menu_6" model="website.menu">
     <field name="name">Discuss your project</field>
     <field name="url">/contactus</field>
     <field name="page_id" ref="website_page_7"/>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
     <field name="parent_id" ref="website_menu_4"/>
   </record>
 </odoo>

--- a/tattoo_shop/demo/website_page.xml
+++ b/tattoo_shop/demo/website_page.xml
@@ -2,25 +2,25 @@
 <odoo noupdate="1">
   <record id="website_page_8" model="website.page">
     <field name="view_id" ref="flash_tattoos"/>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
     <field name="is_published" eval="True"/>
     <field name="url">/flash-tattoos</field>
   </record>
   <record id="website_page_4" model="website.page">
     <field name="view_id" ref="homepage"/>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
     <field name="is_published" eval="True"/>
     <field name="url">/</field>
   </record>
   <record id="website_page_6" model="website.page">
     <field name="view_id" ref="about_us"/>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
     <field name="is_published" eval="True"/>
     <field name="url">/about-us</field>
   </record>
   <record id="website_page_7" model="website.page">
     <field name="view_id" ref="contact_us"/>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
     <field name="is_published" eval="True"/>
     <field name="url">/contactus</field>
   </record>

--- a/tattoo_shop/demo/website_theme_apply.xml
+++ b/tattoo_shop/demo/website_theme_apply.xml
@@ -2,7 +2,7 @@
 <odoo>
     <function name="button_choose_theme" model="ir.module.module" eval="[ref('base.module_theme_orchid', raise_if_not_found=False) or ref('base.module_theme_default')]"/>
     <function model="ir.ui.view" name="write">
-        <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('website.default_website').id).viewref('website.homepage').id"/>
+        <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('base.default_website').id).viewref('website.homepage').id"/>
         <value model="ir.ui.view" eval="{'arch': obj().env.ref('tattoo_shop.homepage').arch.replace(
             '*flash_tattoo_appointment*', str(obj().env.ref('tattoo_shop.appointment_type_1').id)).replace(
             '*piercing_appointment*', str(obj().env.ref('tattoo_shop.appointment_type_2').id))

--- a/tattoo_shop/demo/website_views.xml
+++ b/tattoo_shop/demo/website_views.xml
@@ -135,7 +135,7 @@
     <field name="key">tattoo_shop.about-us</field>
     <field name="name">About Us</field>
     <field name="type">qweb</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
   </record>
   <record id="ir_ui_view_2945" model="ir.ui.view">
     <field name="arch" type="xml">
@@ -173,7 +173,7 @@
     <field name="key">tattoo_shop.appointments_cards_layout</field>
     <field name="name">Appointment Types</field>
     <field name="type">qweb</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
   </record>
   <record id="contact_us" model="ir.ui.view">
     <field name="arch" type="xml">
@@ -358,7 +358,7 @@
     <field name="key">tattoo_shop.contactus</field>
     <field name="name">Contact Us</field>
     <field name="type">qweb</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
   </record>
   <record id="ir_ui_view_2930" model="ir.ui.view">
     <field name="arch" type="xml">
@@ -381,7 +381,7 @@
     <field name="mode">extension</field>
     <field name="name">Header Call to Action</field>
     <field name="type">qweb</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
   </record>
   <record id="homepage" model="ir.ui.view">
     <field name="arch" type="xml">
@@ -600,7 +600,7 @@
     <field name="key">tattoo_shop.homepage</field>
     <field name="name">Home</field>
     <field name="type">qweb</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
   </record>
   <record id="flash_tattoos" model="ir.ui.view">
     <field name="arch" type="xml">
@@ -649,7 +649,7 @@
     <field name="key">tattoo_shop.portfolio</field>
     <field name="name">Portfolio</field>
     <field name="type">qweb</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
   </record>
   <record id="ir_ui_view_2944" model="ir.ui.view">
     <field name="arch" type="xml">
@@ -689,7 +689,7 @@
     <field name="key">tattoo_shop.website_calendar_index_topbar</field>
     <field name="name">Topbar</field>
     <field name="type">qweb</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
   </record>
   <function model="ir.model.fields" name="formbuilder_whitelist">
     <value eval="'crm.lead'"/>

--- a/team_sports_club/data/website_menu.xml
+++ b/team_sports_club/data/website_menu.xml
@@ -2,14 +2,14 @@
 <odoo noupdate="1">
     <function model="website.menu" name="write">
         <value model="website.menu" eval="obj().search([
-            ('website_id', '=', ref('website.default_website')),
+            ('website_id', '=', ref('base.default_website')),
             ('name', '=', 'Home'),
         ], limit=1).id"/>
         <value eval="{'sequence': 0}"/>
     </function>
     <function model="website.menu" name="write">
         <value model="website.menu" eval="obj().search([
-            ('website_id', '=', ref('website.default_website')),
+            ('website_id', '=', ref('base.default_website')),
             ('url', '=', '/event'),
         ], limit=1).id"/>
         <value eval="{
@@ -19,7 +19,7 @@
     </function>
     <function model="website.menu" name="write">
         <value model="website.menu" eval="obj().search([
-            ('website_id', '=', ref('website.default_website')),
+            ('website_id', '=', ref('base.default_website')),
             ('url', '=', '/shop'),
         ], limit=1).id"/>
         <value eval="{
@@ -31,22 +31,22 @@
         <field name="name">Teams</field>
         <field name="url">/partners</field>
         <field name="sequence">3</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="parent_id"  model="website.menu" eval="obj().search([
-            ('website_id', '=', ref('website.default_website')),
+            ('website_id', '=', ref('base.default_website')),
             ('url', '=', '#'),
         ], limit=1).id"/>
     </record>
     <function model="website.menu" name="write">
         <value model="website.menu" eval="obj().search([
-            ('website_id', '=', ref('website.default_website')),
+            ('website_id', '=', ref('base.default_website')),
             ('url', '=', '/appointment'),
         ], limit=1).id"/>
         <value eval="{'name': 'Enrollment'}"/>
     </function>
     <function model="website.menu" name="unlink">
         <value model="website.menu" eval="obj().search([
-            ('website_id', '=', ref('website.default_website')),
+            ('website_id', '=', ref('base.default_website')),
             ('url', '=', '/appointment')
         ]).ids"/>
     </function>

--- a/team_sports_club/demo/website.xml
+++ b/team_sports_club/demo/website.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-  <record id="website.default_website" model="website" forcecreate="1">
+  <record id="base.default_website" model="website" forcecreate="1">
     <field name="name">football-clubs</field>
     <field name="configurator_done" eval="True"/>
     <field name="logo" type="bytes" file="team_sports_club/static/description/icon.png"/>

--- a/team_sports_club/demo/website_view.xml
+++ b/team_sports_club/demo/website_view.xml
@@ -175,7 +175,7 @@
     <field name="key">team_sports_club.homepage</field>
     <field name="name">Home</field>
     <field name="type">qweb</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
   </record>
   <template inherit_id='website_sale.products' id="products" name="products_view">
     <xpath expr="//div[@id='wrap']" position="before">
@@ -188,7 +188,7 @@
     </xpath>
   </template>
   <function model="ir.ui.view" name="write">
-    <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('website.default_website').id).viewref('website.homepage').id"/>
+    <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('base.default_website').id).viewref('website.homepage').id"/>
     <value model="ir.ui.view" eval="{'arch': obj().env.ref('team_sports_club.ir_ui_view_2179').arch.replace(
       '*filter_newest_products_team_sports_club*', str(obj().env.ref('website_sale.dynamic_filter_newest_products').id)
     )}"/>

--- a/tests/test_booking_engine/tests/test_action_server.py
+++ b/tests/test_booking_engine/tests/test_action_server.py
@@ -14,7 +14,7 @@ class BookingEngineAutomationsTestCase(TransactionCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        cls.website = cls.env.ref('website.default_website')
+        cls.website = cls.env.ref('base.default_website')
         cls.website.tz = 'UTC'
         cls.partner = cls.env['res.partner'].create({'name': 'Test partner'})
         cls.resource = cls.env['resource.resource'].create({

--- a/tests/test_generic/tests/test_xml.py
+++ b/tests/test_generic/tests/test_xml.py
@@ -571,6 +571,12 @@ class TestEnv(IndustryCase):
     def _check_res_config_setting(self, root):
         if root.xpath("//record[@model='res.config.settings']/field[@name='account_price_include']"):
             _logger.warning("This setting needs extra care, see examples on how to deal with account_price_include.")
+        for field in root.xpath("//record[@model='res.config.settings']/field[starts-with(@name, 'module_')]"):
+            if field.get('eval') in ('1', 'True'):
+                _logger.warning(
+                    "You should not install modules in res.config.settings data. "
+                    "Move %s installation to manifest instead", field.get('name')[7:]
+                )
 
     def _check_user_is_set(self, root, previous_records):
         records = previous_records

--- a/textile_manufacturing/demo/website.xml
+++ b/textile_manufacturing/demo/website.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-  <record id="website.default_website" model="website" forcecreate="1">
+  <record id="base.default_website" model="website" forcecreate="1">
     <field name="name">Textile Manufacturing</field>
     <field name="configurator_done" eval="True"/>
     <field name="logo" type="bytes" file="textile_manufacturing/static/description/icon.png"/>

--- a/textile_manufacturing/demo/website_theme_apply.xml
+++ b/textile_manufacturing/demo/website_theme_apply.xml
@@ -39,11 +39,11 @@
   </function>
 
   <function model="ir.ui.view" name="write">
-        <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('website.default_website').id).viewref('website.homepage').id"/>
+        <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('base.default_website').id).viewref('website.homepage').id"/>
         <value model="ir.ui.view" eval="{'arch': obj().env.ref('textile_manufacturing.homepage').arch}"/>
   </function>
   <function name="write" model="ir.ui.view">
-        <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=ref('website.default_website')).viewref('website.contactus').id"/>
+        <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=ref('base.default_website')).viewref('website.contactus').id"/>
         <value model="ir.ui.view" eval="{'arch': obj().env.ref('textile_manufacturing.contactus').arch}"/>
   </function>
   <function model="ir.ui.view" name="write">
@@ -56,7 +56,7 @@
   </function>
   <data noupdate="1">
     <function model="website.menu" name="unlink">
-        <value model="website.menu" eval="obj().search([('website_id', '=', ref('website.default_website')), ('url', '=', '/shop')]).ids"/>
+        <value model="website.menu" eval="obj().search([('website_id', '=', ref('base.default_website')), ('url', '=', '/shop')]).ids"/>
     </function>
   </data>
 </odoo>

--- a/textile_manufacturing/demo/website_view.xml
+++ b/textile_manufacturing/demo/website_view.xml
@@ -4,7 +4,7 @@
     <field name="name">Contact Us</field>
     <field name="key">textile_manufacturing.contactus</field>
     <field name="type">qweb</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
     <field name="arch" type="xml">
       <t name="Contact Us" t-name="website.contactus">
         <t t-call="website.layout"
@@ -119,7 +119,7 @@
     <field name="name">Home</field>
     <field name="key">textile_manufacturing.homepage</field>
     <field name="type">qweb</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
     <field name="arch" type="xml">
       <t name="Homepage" t-name="website.homepage">
         <t t-call="website.layout" pageName.f="homepage">

--- a/theater/demo/website.xml
+++ b/theater/demo/website.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-  <record id="website.default_website" model="website" forcecreate="1">
+  <record id="base.default_website" model="website" forcecreate="1">
     <field name="name">Theater</field>
     <field name="logo" type="bytes" file="theater/static/description/icon.png"/>
     <field name="favicon" type="bytes" file="theater/static/description/icon.png"/>

--- a/theater/demo/website_theme_apply.xml
+++ b/theater/demo/website_theme_apply.xml
@@ -6,7 +6,7 @@
   <!-- <function model="theme.utils" name="enable_view" eval="['website.template_header_sales_one']"/> -->
 
   <function model="ir.ui.view" name="write">
-    <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('website.default_website').id).viewref('website.homepage').id"/>
+    <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('base.default_website').id).viewref('website.homepage').id"/>
     <value model="ir.ui.view" eval="{'arch': obj().env.ref('theater.homepage').arch}"/>
   </function>
 
@@ -70,7 +70,7 @@
     <function model="website.menu" name="unlink">
       <value model="website.menu"
         eval="obj().search([
-              ('website_id', '=', ref('website.default_website')),
+              ('website_id', '=', ref('base.default_website')),
               ('url', '=', '/event'),
           ]).ids" />
     </function>

--- a/theater/demo/website_view.xml
+++ b/theater/demo/website_view.xml
@@ -6,7 +6,7 @@
     <field name="mode">extension</field>
     <field name="name">Header Call to Action</field>
     <field name="type">qweb</field>
-    <field name="website_id" ref="website.default_website" />
+    <field name="website_id" ref="base.default_website" />
     <field name="arch" type="xml">
       <data inherit_id="website.placeholder_header_call_to_action" name="Header Call to Action"
         active="True">
@@ -32,7 +32,7 @@
     <field name="mode">extension</field>
     <field name="name">Headline</field>
     <field name="type">qweb</field>
-    <field name="website_id" ref="website.default_website" />
+    <field name="website_id" ref="base.default_website" />
     <field name="arch" type="xml">
       <data inherit_id="website.layout" name="Headline" active="False">
         <xpath expr="//div[@id='footer']" position="replace">
@@ -83,7 +83,7 @@
     <field name="key">theater.homepage</field>
     <field name="name">Home</field>
     <field name="type">qweb</field>
-    <field name="website_id" ref="website.default_website" />
+    <field name="website_id" ref="base.default_website" />
     <field name="arch" type="xml">
       <t name="Homepage" t-name="website.homepage">
         <t t-call="website.layout" pageName.f="homepage">

--- a/toy_store/demo/website.xml
+++ b/toy_store/demo/website.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-    <record id="website.default_website" model="website" forcecreate="1">
+    <record id="base.default_website" model="website" forcecreate="1">
         <field name="name">Toy Store</field>
         <field name="logo" type="bytes" file="toy_store/static/src/binary/website/1-logo"/>
         <field name="theme_id" search="[('id', '=', ref('base.module_theme_kiddo', raise_if_not_found=False))]"/>

--- a/toy_store/demo/website_theme_apply.xml
+++ b/toy_store/demo/website_theme_apply.xml
@@ -2,13 +2,13 @@
 <odoo>
     <function name="button_choose_theme" model="ir.module.module" eval="[ref('base.module_theme_kiddo', raise_if_not_found=False) or ref('base.module_theme_default')]"/>
 
-    <function name="make_scss_customization" model="website.assets" context="{'website_id': ref('website.default_website')}">
+    <function name="make_scss_customization" model="website.assets" context="{'website_id': ref('base.default_website')}">
         <value eval="'/website/static/src/scss/options/colors/user_color_palette.scss'"/>
         <value eval="{'o-color-1': '#D15C01','o-color-2': '#6ED4FF','o-color-3': '#FBE8DA','o-color-4': '#FFFFFF','o-color-5': '#2e1d14','menu': 1}"/>
     </function>
 
     <function model="ir.ui.view" name="write">
-        <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('website.default_website').id).viewref('website.homepage').id"/>
+        <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('base.default_website').id).viewref('website.homepage').id"/>
         <value model="ir.ui.view" eval="{'arch': obj().env.ref('toy_store.homepage').arch.replace(
             '*filter_newest_products_toy_store*', str(obj().env.ref('website_sale.dynamic_filter_newest_products').id)
         )}"/>

--- a/toy_store/demo/website_view.xml
+++ b/toy_store/demo/website_view.xml
@@ -4,7 +4,7 @@
         <field name="name">Home</field>
         <field name="key">toy_store.homepage</field>
         <field name="type">qweb</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="arch" type="xml">
             <t name="Homepage" t-name="website.homepage">
                 <t t-call="website.layout" pageName.f="homepage">
@@ -62,7 +62,7 @@
         <field name="inherit_id" ref="website.layout"/>
         <field name="mode">extension</field>
         <field name="type">qweb</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="arch" type="xml">
             <data inherit_id="website.layout" name="Centered" active="False">
                 <xpath expr="//div[@id='footer']" position="replace">
@@ -125,6 +125,6 @@
         <field name="mode">extension</field>
         <field name="name">Navbar Links Style</field>
         <field name="type">qweb</field>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
     </record>
 </odoo>

--- a/veterinary_clinic/demo/ir_attachment_post.xml
+++ b/veterinary_clinic/demo/ir_attachment_post.xml
@@ -4,42 +4,42 @@
     <field name="name">website.s_image_frame_default_image</field>
     <field name="raw" type="bytes" file="veterinary_clinic/static/src/binary/ir_attachment/1264-website.s_image_frame_default_image"/>
     <field name="key">website.s_image_frame_default_image</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
     <field name="public" eval="True"/>
   </record>
   <record id="configurator_1_s_pricelist_boxed_default_background" model="ir.attachment">
     <field name="name">website.s_pricelist_boxed_default_background</field>
     <field name="raw" type="bytes" file="veterinary_clinic/static/src/binary/ir_attachment/1247-website.s_pricelist_boxed_default_background.jpg"/>
     <field name="key">website.s_pricelist_boxed_default_background</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
     <field name="public" eval="True"/>
   </record>
   <record id="configurator_1_s_text_cover_default_image" model="ir.attachment">
     <field name="name">website.s_text_cover_default_image</field>
     <field name="raw" type="bytes" file="veterinary_clinic/static/src/binary/ir_attachment/1322-veterinary.png"/>
     <field name="key">website.s_text_cover_default_image</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
     <field name="public" eval="True"/>
   </record>
   <record id="configurator_1_s_text_image_default_image" model="ir.attachment">
     <field name="name">website.s_text_image_default_image</field>
     <field name="raw" type="bytes" file="veterinary_clinic/static/src/binary/ir_attachment/1225-website.s_text_image_default_image.jpg"/>
     <field name="key">website.s_text_image_default_image</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
     <field name="public" eval="True"/>
   </record>
   <record id="configurator_1_s_parallax_default_image" model="ir.attachment">
     <field name="name">website.s_parallax_default_image</field>
     <field name="raw" type="bytes" file="veterinary_clinic/static/src/binary/ir_attachment/1215-website.s_parallax_default_image"/>
     <field name="key">website.s_parallax_default_image</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
     <field name="public" eval="True"/>
   </record>
   <record id="configurator_1_s_masonry_block_default_image_1" model="ir.attachment">
     <field name="name">website.s_masonry_block_default_image_1</field>
     <field name="raw" type="bytes" file="veterinary_clinic/static/src/binary/ir_attachment/1205-website.s_masonry_block_default_image_1.jpg"/>
     <field name="key">website.s_masonry_block_default_image_1</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
     <field name="public" eval="True"/>
   </record>
 </odoo>

--- a/veterinary_clinic/demo/website.xml
+++ b/veterinary_clinic/demo/website.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-  <record id="website.default_website" model="website" forcecreate="1">
+  <record id="base.default_website" model="website" forcecreate="1">
     <field name="name">My Website</field>
     <field name="configurator_done" eval="True"/>
     <field name="logo" type="bytes" file="veterinary_clinic/static/description/icon.png"/>

--- a/veterinary_clinic/demo/website_theme_apply.xml
+++ b/veterinary_clinic/demo/website_theme_apply.xml
@@ -38,11 +38,11 @@
   </function>
 
   <function model="ir.ui.view" name="write">
-    <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('website.default_website').id).viewref('website.homepage').id"/>
+    <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('base.default_website').id).viewref('website.homepage').id"/>
     <value model="ir.ui.view" eval="{'arch': obj().env.ref('veterinary_clinic.homepage').arch}"/>
   </function>
   <function model="ir.ui.view" name="write">
-    <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('website.default_website').id).viewref('website.contactus').id"/>
+    <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('base.default_website').id).viewref('website.contactus').id"/>
     <value model="ir.ui.view" eval="{'arch': obj().env.ref('veterinary_clinic.contactus').arch.replace(
         '*surgery_tag*', str(obj().env.ref('veterinary_clinic.crm_tag_1').id)).replace(
         '*first_visit_tag*', str(obj().env.ref('veterinary_clinic.crm_tag_2').id)).replace(

--- a/veterinary_clinic/demo/website_view.xml
+++ b/veterinary_clinic/demo/website_view.xml
@@ -4,7 +4,7 @@
     <field name="name">Home</field>
     <field name="key">veterinary_clinic.homepage</field>
     <field name="type">qweb</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
     <field name="arch" type="xml">
       <t name="Homepage" t-name="website.homepage">
         <t t-call="website.layout" pageName.f="homepage">
@@ -136,7 +136,7 @@
         <field name="key">veterinary_clinic.contactus</field>
         <field name="type">qweb</field>
         <field name="active" eval="True"/>
-        <field name="website_id" ref="website.default_website"/>
+        <field name="website_id" ref="base.default_website"/>
         <field name="arch" type="xml">
           <t name="Contact Us" t-name="website.contactus">
             <t t-call="website.layout"

--- a/vineyard/data/res_config_setting.xml
+++ b/vineyard/data/res_config_setting.xml
@@ -3,7 +3,6 @@
     <record id="res_config_setting_vineyard" model="res.config.settings">
         <field name="group_stock_production_lot" eval="True"/>
         <field name="group_stock_multi_locations" eval="True"/>
-        <field name="module_product_expiry" eval="True"/>
         <field name="group_mrp_byproducts" eval="True"/>
         <field name="group_stock_adv_location" eval="True"/>
         <field name="group_stock_tracking_lot" eval="True"/>

--- a/vineyard/demo/website.xml
+++ b/vineyard/demo/website.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-  <record id="website.default_website" model="website" forcecreate="1">
+  <record id="base.default_website" model="website" forcecreate="1">
     <field name="name">My Website</field>
     <field name="configurator_done" eval="True"/>
     <field name="user_id" ref="base.public_user"/>

--- a/vineyard/demo/website_theme_apply.xml
+++ b/vineyard/demo/website_theme_apply.xml
@@ -11,7 +11,7 @@
   <data noupdate="1">
     <function model="website.menu" name="write">
       <value model="website.menu" search="([
-          ('website_id', '=', ref('website.default_website')),
+          ('website_id', '=', ref('base.default_website')),
           ('url', '=', '/appointment'),
       ])"/>
       <value eval="{'name': 'Winery Tour'}"/>

--- a/vineyard/demo/website_view.xml
+++ b/vineyard/demo/website_view.xml
@@ -40,7 +40,7 @@
     <field name="mode">extension</field>
     <field name="name">Appointment: Appointment Info</field>
     <field name="type">qweb</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
   </record>
   <record id="ir_ui_view_4040" model="ir.ui.view">
     <field name="arch" type="xml">
@@ -63,7 +63,7 @@
     <field name="mode">extension</field>
     <field name="name">Header Call to Action</field>
     <field name="type">qweb</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
   </record>
   <record id="ir_ui_view_3070" model="ir.ui.view">
     <field name="arch" type="xml">
@@ -203,7 +203,7 @@
     <field name="key">vineyard.homepage</field>
     <field name="name">Home</field>
     <field name="type">qweb</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
   </record>
   <record id="view_product_attribute_filters_form_inherit" model="ir.ui.view">
     <field name="arch" type="xml">
@@ -216,10 +216,10 @@
     <field name="mode">extension</field>
     <field name="name">replace Tags to Taste</field>
     <field name="type">qweb</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
   </record>
   <function model="ir.ui.view" name="write">
-    <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('website.default_website').id).viewref('website.homepage').id"/>
+    <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('base.default_website').id).viewref('website.homepage').id"/>
     <value model="ir.ui.view" eval="{'arch': obj().env.ref('vineyard.ir_ui_view_3070').arch.replace(
       '*filter_newest_products_vineyard*', str(obj().env.ref('website_sale.dynamic_filter_newest_products').id)
     )}"/>

--- a/wine_merchant/demo/sale_order.xml
+++ b/wine_merchant/demo/sale_order.xml
@@ -15,7 +15,7 @@
     <field name="partner_id" ref="base.partner_admin"/>
     <field name="pricelist_id" ref="product_pricelist_1"/>
     <field name="carrier_id" ref="delivery.free_delivery_carrier"/>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
     <field name="user_id" ref="base.user_admin"/>
   </record>
   <record id="sale_order_6" model="sale.order">

--- a/wine_merchant/demo/website.xml
+++ b/wine_merchant/demo/website.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-  <record id="website.default_website" model="website" forcecreate="1">
+  <record id="base.default_website" model="website" forcecreate="1">
     <field name="name">winemerchantindustry</field>
     <field name="configurator_done" eval="True"/>
     <field name="logo" type="bytes" file="wine_merchant/static/description/icon.png"/>

--- a/wine_merchant/demo/website_menu.xml
+++ b/wine_merchant/demo/website_menu.xml
@@ -2,29 +2,29 @@
 <odoo noupdate="1">
   <function model="website.menu" name="unlink">
     <value model="website.menu"
-        eval="obj().search([('website_id', '=', ref('website.default_website')), ('url', '=', '#')]).ids"
+        eval="obj().search([('website_id', '=', ref('base.default_website')), ('url', '=', '#')]).ids"
     />
   </function>
   <record id="website_menu_4" model="website.menu">
     <field name="name">Top Menu for Website 1</field>
-    <field name="website_id" ref="website.default_website" />
+    <field name="website_id" ref="base.default_website" />
   </record>
   <record id="website_menu_5" model="website.menu">
     <field name="name">Home</field>
     <field name="page_id" ref="website_page_4" />
     <field name="url">/</field>
-    <field name="website_id" ref="website.default_website" />
+    <field name="website_id" ref="base.default_website" />
     <field name="parent_id" ref="website_menu_4" />
   </record>
   <record id="website_menu_11" model="website.menu">
     <field name="name">Events</field>
     <field name="url">/event</field>
-    <field name="website_id" ref="website.default_website" />
+    <field name="website_id" ref="base.default_website" />
     <field name="parent_id" ref="website_menu_4" />
   </record>
   <record id="website_menu_15" model="website.menu">
     <field name="name">Shop</field>
-    <field name="website_id" ref="website.default_website" />
+    <field name="website_id" ref="base.default_website" />
     <field name="parent_id" ref="website_menu_4" />
     <field name="is_mega_menu" eval="1" />
     <field name="mega_menu_content"><![CDATA[
@@ -101,7 +101,7 @@
     <field name="name">Contact us</field>
     <field name="page_id" ref="website_page_8" />
     <field name="url">/contactus</field>
-    <field name="website_id" ref="website.default_website" />
+    <field name="website_id" ref="base.default_website" />
     <field name="parent_id" ref="website_menu_4" />
   </record>
 </odoo>

--- a/wine_merchant/demo/website_page.xml
+++ b/wine_merchant/demo/website_page.xml
@@ -2,13 +2,13 @@
 <odoo noupdate="1">
   <record id="website_page_8" model="website.page">
     <field name="view_id" ref="contactus"/>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
     <field name="is_published" eval="True"/>
     <field name="url">/contactus</field>
   </record>
   <record id="website_page_4" model="website.page">
     <field name="view_id" ref="homepage"/>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
     <field name="is_published" eval="True"/>
     <field name="url">/</field>
   </record>

--- a/wine_merchant/demo/website_theme_apply.xml
+++ b/wine_merchant/demo/website_theme_apply.xml
@@ -36,17 +36,17 @@
       }"/>
   </function>
   <function model="ir.ui.view" name="write">
-    <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=ref('website.default_website')).viewref('website.homepage').id"/>
+    <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=ref('base.default_website')).viewref('website.homepage').id"/>
     <value model="ir.ui.view" eval="{'arch': obj().env.ref('wine_merchant.homepage').arch.replace(
       '*filter_newest_products_wine_merchant*', str(obj().env.ref('website_sale.dynamic_filter_newest_products').id)
     )}"/>
   </function>
   <function model="ir.ui.view" name="write">
-      <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=ref('website.default_website')).viewref('website.template_footer_descriptive').id"/>
+      <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=ref('base.default_website')).viewref('website.template_footer_descriptive').id"/>
       <value model="ir.ui.view" eval="{'arch': obj().env.ref('wine_merchant.ir_ui_view_3281').arch}"/>
   </function>
   <function model="ir.ui.view" name="write">
-      <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=ref('website.default_website')).viewref('website.contactus').id"/>
+      <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=ref('base.default_website')).viewref('website.contactus').id"/>
       <value model="ir.ui.view" eval="{'arch': obj().env.ref('wine_merchant.contactus').arch}"/>
   </function>
 </odoo>

--- a/wine_merchant/demo/website_view.xml
+++ b/wine_merchant/demo/website_view.xml
@@ -4,7 +4,7 @@
     <field name="name">Contact Us</field>
     <field name="key">wine_merchant.contactus</field>
     <field name="type">qweb</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
     <field name="arch" type="xml">
       <t name="Contact Us" t-name="website.contactus">
         <t t-call="website.layout"
@@ -134,7 +134,7 @@
     <field name="key">wine_merchant.template_footer_descriptive</field>
     <field name="mode">extension</field>
     <field name="type">qweb</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
     <field name="arch" type="xml">
       <data inherit_id="website.layout" name="Descriptive" active="False">
         <xpath expr="//div[@id='footer']" position="replace">
@@ -194,7 +194,7 @@
     <field name="name">Home</field>
     <field name="key">wine_merchant.homepage</field>
     <field name="type">qweb</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
     <field name="arch" type="xml">
       <t name="Homepage" t-name="website.homepage">
         <t t-call="website.layout" pageName.f="homepage">
@@ -298,14 +298,14 @@
     <field name="key">website.record_cover</field>
     <field name="name">record_cover</field>
     <field name="type">qweb</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
   </record>
   <function model="ir.ui.view" name="write">
-    <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('website.default_website').id).viewref('website.template_footer_descriptive').id"/>
+    <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('base.default_website').id).viewref('website.template_footer_descriptive').id"/>
     <value model="ir.ui.view" eval="{'arch': obj().env.ref('wine_merchant.ir_ui_view_3281').arch}"/>
   </function>
   <function model="ir.ui.view" name="write">
-    <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('website.default_website').id).viewref('website.homepage').id"/>
+    <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('base.default_website').id).viewref('website.homepage').id"/>
     <value model="ir.ui.view" eval="{'arch': obj().env.ref('wine_merchant.homepage').arch}"/>
   </function>
 </odoo>

--- a/yoga_pilates/data/product_pricelist.xml
+++ b/yoga_pilates/data/product_pricelist.xml
@@ -2,7 +2,7 @@
 <odoo noupdate="1">
   <function model="product.pricelist" name="write">
     <value model="product.pricelist" eval="obj().search([('name', '=', 'Default')], limit=1).id"/>
-    <value eval="{'selectable': True, 'website_id': ref('website.default_website')}"/>
+    <value eval="{'selectable': True, 'website_id': ref('base.default_website')}"/>
   </function>
   <record id="product_pricelist_2" model="product.pricelist">
     <field name="name">The Flow Membership</field>

--- a/yoga_pilates/demo/website.xml
+++ b/yoga_pilates/demo/website.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-  <record id="website.default_website" model="website" forcecreate="1">
+  <record id="base.default_website" model="website" forcecreate="1">
     <field name="name">Yoga &amp; Pilates Studio</field>
     <field name="configurator_done" eval="True"/>
     <field name="logo" type="bytes" file="yoga_pilates/static/description/icon.png"/>

--- a/yoga_pilates/demo/website_menu.xml
+++ b/yoga_pilates/demo/website_menu.xml
@@ -5,9 +5,9 @@
     <field name="url">/pricing</field>
     <field name="sequence">12</field>
     <field name="page_id" ref="website_page_8"/>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
     <field name="parent_id" model="website.menu" eval="obj().search([
-                ('website_id', '=', ref('website.default_website')),
+                ('website_id', '=', ref('base.default_website')),
                 ('url', '=', '#'),
     ], limit=1).id"/>
   </record>

--- a/yoga_pilates/demo/website_page.xml
+++ b/yoga_pilates/demo/website_page.xml
@@ -2,19 +2,19 @@
 <odoo noupdate="1">
   <record id="website_page_4" model="website.page">
     <field name="view_id" ref="homepage"/>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
     <field name="is_published" eval="True"/>
     <field name="url">/</field>
   </record>
   <record id="website_page_7" model="website.page">
     <field name="view_id" ref="contactus"/>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
     <field name="is_published" eval="True"/>
     <field name="url">/contactus</field>
   </record>
   <record id="website_page_8" model="website.page">
     <field name="view_id" ref="ir_ui_view_3322"/>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
     <field name="url">/pricing</field>
     <field name="is_published" eval="True"/>
   </record>

--- a/yoga_pilates/demo/website_theme_apply.xml
+++ b/yoga_pilates/demo/website_theme_apply.xml
@@ -2,7 +2,7 @@
 <odoo>
   <function name="button_choose_theme" model="ir.module.module" eval="[ref('base.module_theme_orchid', raise_if_not_found=False) or ref('base.module_theme_default')]"/>
 
-  <function model="website.assets" name="make_scss_customization" context="{'website_id': ref('website.default_website')}">
+  <function model="website.assets" name="make_scss_customization" context="{'website_id': ref('base.default_website')}">
     <value eval="'/website/static/src/scss/options/colors/user_theme_color_palette.scss'"/>
     <value eval="{
         'success': 'null',
@@ -12,7 +12,7 @@
     }"/>
   </function>
 
-  <function model="website.assets" name="make_scss_customization" context="{'website_id': ref('website.default_website')}">
+  <function model="website.assets" name="make_scss_customization" context="{'website_id': ref('base.default_website')}">
     <value eval="'/website/static/src/scss/options/user_values.scss'"/>
     <value eval="{
       'menu-gradient': 'null',
@@ -38,31 +38,31 @@
   </function>
 
   <function name="write" model="ir.ui.view">
-    <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('website.default_website').id).viewref('website.homepage').id"/>
+    <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=obj().env.ref('base.default_website').id).viewref('website.homepage').id"/>
     <value model="ir.ui.view" eval="{'arch': obj().env.ref('yoga_pilates.homepage').arch}"/>
   </function>
   <function name="write" model="ir.ui.view">
-    <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=ref('website.default_website')).viewref('website.contactus').id"/>
+    <value model="ir.ui.view" eval="obj().env['website'].with_context(website_id=ref('base.default_website')).viewref('website.contactus').id"/>
     <value model="ir.ui.view" eval="{'arch': obj().env.ref('yoga_pilates.contactus').arch}"/>
   </function>
   <data noupdate="1">
       <function model="website.menu" name="write">
         <value model="website.menu" eval="obj().search([
-            ('website_id', '=', ref('website.default_website')),
+            ('website_id', '=', ref('base.default_website')),
             ('url', '=', '/appointment'),
         ], limit=1).id"/>
         <value eval="{'name': 'Schedule'}"/>
       </function>
       <function model="website.menu" name="write">
         <value model="website.menu" eval="obj().search([
-            ('website_id', '=', ref('website.default_website')),
+            ('website_id', '=', ref('base.default_website')),
             ('url', '=', '/event'),
         ], limit=1).id"/>
         <value eval="{'name': 'Wellbeing Events'}"/>
       </function>
       <function model="website.menu" name="unlink">
         <value model="website.menu" eval="obj().search([
-            ('website_id', '=', ref('website.default_website')),
+            ('website_id', '=', ref('base.default_website')),
             ('url', '=', '/shop'),
         ]).ids"/>
       </function>

--- a/yoga_pilates/demo/website_view.xml
+++ b/yoga_pilates/demo/website_view.xml
@@ -4,7 +4,7 @@
     <field name="name">Home</field>
     <field name="key">yoga_pilates.homepage</field>
     <field name="type">qweb</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
     <field name="arch" type="xml">
       <t name="Homepage" t-name="website.homepage">
         <t t-call="website.layout" pageName.f="homepage">
@@ -203,7 +203,7 @@
     <field name="name">Contact Us</field>
     <field name="key">yoga_pilates.contactus</field>
     <field name="type">qweb</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
     <field name="arch" type="xml">
       <t name="Contact Us" t-name="website.contactus">
         <t t-call="website.layout"
@@ -314,7 +314,7 @@
     <field name="name">Pricing</field>
     <field name="key">website.pricing-2</field>
     <field name="type">qweb</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
     <field name="arch" type="xml">
       <t t-name="website.pricing-2">
         <t t-call="website.layout">
@@ -532,7 +532,7 @@
     <field name="key">yoga_pilates.website_event.index_topbar</field>
     <field name="name">Topbar</field>
     <field name="type">qweb</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
   </record>
   <record id="ir_ui_view_3934" model="ir.ui.view">
     <field name="arch" type="xml">
@@ -552,14 +552,14 @@
     <field name="key">yoga_pilates.website.record_cover</field>
     <field name="name">record_cover</field>
     <field name="type">qweb</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
   </record>
   <record id="ir_ui_view_2998" model="ir.ui.view">
     <field name="name">Header Call to Action</field>
     <field name="inherit_id" ref="website.placeholder_header_call_to_action"/>
     <field name="key">yoga_pilates.website.header_call_to_action</field>
     <field name="mode">extension</field>
-    <field name="website_id" ref="website.default_website"/>
+    <field name="website_id" ref="base.default_website"/>
     <field name="type">qweb</field>
     <field name="arch" type="xml">
       <data inherit_id="website.placeholder_header_call_to_action" name="Header Call to Action" active="True">


### PR DESCRIPTION
## [FIX] *: change default_website module

This commit replaces the module of `default_website` from website to base
follow-up for standard commit: https://github.com/odoo/odoo/pull/252766/changes/77c8a3541905c42cd32c49676ce6df43627b3520

## [FIX] *: adapt res configs and website settings

- Remove `add_to_cart_action` following: https://github.com/odoo/odoo/pull/258873
- Remove `company_so_template_id` following: https://github.com/odoo/odoo/pull/258679
- Remove `predict_bill_product` following: https://github.com/odoo/enterprise/commit/d1bce1f8a4971c076e48733135987752bab8107b
- Move `module_*` import settings to manifest and add test to prevent them from being added to the future