### PR TITLE
[IMP] industry_real_estate: update menus, views, and filters

### DIFF
--- a/industry_real_estate/__manifest__.py
+++ b/industry_real_estate/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Property Management',
-    'version': '2.0',
+    'version': '2.1',
     'category': 'Services',
     'depends': [
         'base_automation',

--- a/industry_real_estate/data/ir_actions_act_window.xml
+++ b/industry_real_estate/data/ir_actions_act_window.xml
@@ -9,23 +9,27 @@
         <field name="res_model">sale.order</field>
         <field name="view_mode">kanban,list,form,calendar</field>
         <field name="domain">[('x_property_id', '!=', False)]</field>
+        <field name="search_view_id" ref="sale_subscription.sale_subscription_view_search"/>
         <field name="view_ids" eval="[
             (5, 0, 0),
-            (0, 0, {'view_mode': 'kanban', 'view_id': ref('sale.view_sale_order_kanban')}),
+            (0, 0, {'view_mode': 'kanban', 'view_id': ref('sale_subscription.sale_subscription_view_kanban')}),
             (0, 0, {'view_mode': 'form', 'view_id': ref('rental_form_view')}),
         ]"/>
+        <field name="context">{'search_default_progress': 1, 'search_default_paused': 1, 'search_default_group_by_subscription_state': 1}</field>
     </record>
 
     <record id="action_availability" model="ir.actions.act_window">
-        <field name="name">Availability</field>
+        <field name="name">Schedule</field>
         <field name="res_model">sale.order</field>
         <field name="view_mode">gantt,list,form</field>
         <field name="domain">[('x_property_id', '!=', False)]</field>
+        <field name="search_view_id" ref="sale_subscription.sale_subscription_view_search"/>
         <field name="view_ids" eval="[
             (5, 0, 0),
             (0, 0, {'view_mode': 'gantt', 'view_id': ref('rental_gantt_view')}),
             (0, 0, {'view_mode': 'form', 'view_id': ref('rental_form_view')}),
         ]"/>
+        <field name="context">{'search_default_property': 1}</field>
     </record>
 
     <record id="action_properties" model="ir.actions.act_window">

--- a/industry_real_estate/data/ir_filters.xml
+++ b/industry_real_estate/data/ir_filters.xml
@@ -1,24 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-
-    <record id="filter_default_property_availability" model="ir.filters">
-        <field name="name">Availability</field>
-        <field name="model_id">sale.order</field>
-        <field name="is_default" eval="True"/>
-        <field name="action_id" ref="action_availability"/>
-        <field name="domain">[]</field>
-        <field name="context">{'group_by': ['x_related_buildings_ids', 'x_property_id']}</field>
-        <field name="sort">[]</field>
-    </record>
-
-    <record id="sale_order_user_filter" model="ir.filters">
-        <field name="name">Running contracts</field>
-        <field name="model_id">sale.order</field>
-        <field name="is_default" eval="True"/>
-        <field name="action_id" ref="action_rental_contracts"/>
-        <field name="context" eval="{'group_by': ['x_related_buildings_ids']}"/>
-    </record>
-
     <record id="property_filter_view" model="ir.filters">
         <field name="name">Building</field>
         <field name="model_id">x_property</field>
@@ -26,5 +7,4 @@
         <field name="action_id" ref="action_properties"/>
         <field name="context" eval="{'group_by': ['x_building']}"/>
     </record>
-
 </odoo>

--- a/industry_real_estate/data/ir_ui_views.xml
+++ b/industry_real_estate/data/ir_ui_views.xml
@@ -149,4 +149,27 @@
             </xpath>
         </field>
     </record>
+    <record id="view_sales_order_filter_subscription_inherit_industry_real_estate" model="ir.ui.view">
+        <field name="name">sale.order.filter.subscription.inherit.industry_real_estate</field>
+        <field name="model">sale.order</field>
+        <field name="inherit_id" ref="sale_subscription.view_sales_order_filter_subscription"/>
+        <field name="active" eval="True"/>
+        <field name="mode">extension</field>
+        <field name="arch" type="xml">
+            <filter name="recurring" position="replace"/>
+            <filter name="not_recurring" position="replace"/>
+        </field>
+    </record>
+    <record id="sale_order_subsciption_view_search_inherit_industry_real_estate" model='ir.ui.view'>
+        <field name="name">sale.order.subscription.search.inherit.industry_real_estate</field>
+        <field name="model">sale.order</field>
+        <field name="inherit_id" ref="sale_subscription.sale_subscription_view_search"/>
+        <field name="active" eval="True"/>
+        <field name="mode">extension</field>
+        <field name="arch" type="xml">
+            <xpath expr="//filter[@name='customer']" position="after">
+                <filter string="Property" name="property" context="{'group_by':'x_property_id'}"/>
+            </xpath>
+        </field>
+    </record>
 </odoo>

--- a/industry_real_estate/data/menu_item.xml
+++ b/industry_real_estate/data/menu_item.xml
@@ -6,9 +6,9 @@
 
         <menuitem id="menu_availability" action="action_availability" sequence="20"/>
 
-        <menuitem id="menu_properties_root" name="Properties" sequence="30">
-            <menuitem id="menu_properties_properties" action="action_properties" sequence="10"/>
-            <menuitem id="menu_properties_buildings" action="action_buildings" sequence="15"/>
+        <menuitem id="menu_properties_root" name="Infrastructure" sequence="30">
+            <menuitem id="menu_properties_properties" action="action_properties" sequence="15"/>
+            <menuitem id="menu_properties_buildings" action="action_buildings" sequence="10"/>
             <menuitem id="menu_properties_products" action="action_products" sequence="20"/>
         </menuitem>
 


### PR DESCRIPTION
- Renamed the Properties menu to Infrastructure.
- Reordered menus by moving Buildings above Properties.
- Renamed the Availability menu to Schedule.
- Updated the Rental Contracts view to use the sale_subscription kanban view instead of the  sale.order kanban view.
- Improved the Rental Contracts search view.
- Removed the Recurring and Non-Recurring filters from the Availability Gantt view.

Task-5452411