### PR TITLE
[FIX] headhunter: avoid duplicate document creation on demo data

### DIFF
--- a/headhunter/demo/hr_applicant.xml
+++ b/headhunter/demo/hr_applicant.xml
@@ -50,7 +50,7 @@
     <record id="hr_applicant_8" model="hr.applicant">
         <field name="partner_name">Marc Demo</field>
         <field name="partner_id" ref="res_partner_29"/>
-        <field name="attachment_ids" eval="[(6, 0, [ref('ir_attachment_623')])]"/>
+        <field name="attachment_ids" eval="[(6, 0, [ref('ir_attachment_624')])]"/>
         <field name="job_id" ref="hr_job_6"/>
         <field name="stage_id" ref="hr_recruitment.stage_job5"/>
     </record>

--- a/headhunter/demo/website_ir_attachment.xml
+++ b/headhunter/demo/website_ir_attachment.xml
@@ -24,4 +24,9 @@
         <field name="res_model">hr.applicant</field>
         <field name="datas" type="base64" file="headhunter/static/src/binary/ir_attachment/623-Williams_CV(1).doc"/>
     </record>
+    <record id="ir_attachment_624" model="ir.attachment">
+        <field name="name">Williams_CV (1).doc</field>
+        <field name="res_model">hr.applicant</field>
+        <field name="datas" type="base64" file="headhunter/static/src/binary/ir_attachment/623-Williams_CV(1).doc"/>
+    </record>
 </odoo>


### PR DESCRIPTION
The headhunter demo data was linking an attachment already associated with a document record. During applicant creation, Documents attempts to create a document for the attachment, resulting in:

    psycopg2.errors.UniqueViolation:
    duplicate key value violates unique constraint
    "documents_document_attachment_unique"

This behavior was introduced by:
https://github.com/odoo/enterprise/pull/112993

Fix by creating dedicated attachment records for the demo applicants instead of reusing existing attachments already linked to documents.