### PR TITLE
[REM] booking_engine: unenforce booking date hours

### DIFF
--- a/booking_engine/__manifest__.py
+++ b/booking_engine/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Booking Engine',
-    'version': '1.19',
+    'version': '1.20',
     'category': 'Hidden/Tools',
     'author': 'Odoo S.A.',
     'depends': [

--- a/booking_engine/data/base_automation.xml
+++ b/booking_engine/data/base_automation.xml
@@ -1,27 +1,11 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo>
-  <record id="industry_on_slot_fix_times" model="base.automation">
-    <field name="model_id" ref="planning.model_planning_slot"/>
-    <field name="action_server_ids" eval="[(6, 0, [ref('industry_fix_slot_times')])]"/>
-    <field name="trigger">on_create_or_write</field>
-    <field name="name">Fix Slot Times</field>
-    <field name="filter_domain">[('sale_line_id', '!=', False)]</field>
-    <field name="trigger_field_ids" eval="[(6, 0, [ref('planning.field_planning_slot__end_datetime'), ref('planning.field_planning_slot__start_datetime'), ref('sale_planning.field_planning_slot__sale_line_id')])]"/>
-  </record>
   <record id="industry_on_slot_fix_resources" model="base.automation">
     <field name="model_id" ref="planning.model_planning_slot"/>
     <field name="action_server_ids" eval="[(6, 0, [ref('industry_limit_slot_resources')])]"/>
     <field name="trigger">on_create_or_write</field>
     <field name="name">Allow only one resource per slot for rooms</field>
     <field name="trigger_field_ids" eval="[(6, 0, [ref('planning.field_planning_slot__resource_ids')])]"/>
-  </record>
-  <record id="industry_on_rental_order_create" model="base.automation">
-    <field name="model_id" ref="sale.model_sale_order"/>
-    <field name="action_server_ids" eval="[(6, 0, [ref('industry_set_rental_hours')])]"/>
-    <field name="trigger">on_create_or_write</field>
-    <field name="name">Set Rental Start/Return Hours on Create</field>
-    <field name="filter_domain">[('rental_start_date', '!=', False), ('rental_return_date', '!=', False)]</field>
-    <field name="trigger_field_ids" eval="[(6, 0, [ref('sale_renting.field_sale_order__rental_start_date'), ref('sale_renting.field_sale_order__rental_return_date')])]"/>
   </record>
   <record id="industry_on_product_template_create" model="base.automation">
     <field name="model_id" ref="product.model_product_template"/>

--- a/booking_engine/data/ir_actions_server.xml
+++ b/booking_engine/data/ir_actions_server.xml
@@ -21,24 +21,6 @@ elif record.x_total > 0:
         <field name="view_mode">form</field>
         <field name="target">new</field>
     </record>
-    <record id="industry_fix_slot_times" model="ir.actions.server">
-        <field name="binding_model_id" ref="planning.model_planning_slot"/>
-        <field name="model_id" ref="planning.model_planning_slot"/>
-        <field name="usage">base_automation</field>
-        <field name="state">code</field>
-        <field name="name">Fix Slot Times</field>
-        <field name="code"><![CDATA[
-for record in (records or []):
-    if not (record.role_id.x_is_a_room_offer and record.start_datetime and record.end_datetime): continue
-    pickup_time = env.context.get('pickup_time', record.sale_line_id.product_id.pickup_time)
-    return_time = env.context.get('return_time', record.sale_line_id.product_id.return_time)
-    start_datetime = record.start_datetime.replace(hour=int(pickup_time), minute=int(pickup_time % 1 * 60)) if pickup_time else record.start_datetime
-    end_datetime = record.end_datetime.replace(hour=int(return_time), minute=int(return_time % 1 * 60)) if return_time else record.end_datetime
-    end_datetime += datetime.timedelta(days=(record.end_datetime - record.start_datetime).days - (end_datetime - start_datetime).days)
-    if record.start_datetime != start_datetime or record.end_datetime != end_datetime:
-        record.write({'start_datetime': start_datetime, 'end_datetime': end_datetime})
-        ]]></field>
-    </record>
     <record id="industry_limit_slot_resources" model="ir.actions.server">
         <field name="model_id" ref="planning.model_planning_slot"/>
         <field name="usage">base_automation</field>
@@ -49,20 +31,6 @@ for slot in records:
     if len(slot.resource_ids) > 1 and any(role.x_is_a_room_offer for role in slot.resource_ids.mapped('role_ids')):
         raise UserError("Only one room can be assigned to a planning slot")
         ]]></field>
-    </record>
-    <record id="industry_set_rental_hours" model="ir.actions.server">
-        <field name="name">Set Rental Start/Return Hours</field>
-        <field name="model_id" ref="sale.model_sale_order"/>
-        <field name="usage">base_automation</field>
-        <field name="state">code</field>
-        <field name="code"><![CDATA[
-server_action = record.env['ir.actions.server'].browse(record.env.ref('booking_engine.industry_fix_slot_times')).id
-for record in records:
-    pickup_time = record.order_line.filtered('product_id.rent_periodicity').mapped('product_id')[:1].pickup_time
-    return_time = record.order_line.filtered('product_id.rent_periodicity').mapped('product_id')[:1].return_time
-    server_action.with_context(active_ids=record.order_line.planning_slot_ids.ids, active_model='planning.slot', pickup_time=pickup_time, return_time=return_time).run()
-    record.action_update_rental_prices()
-]]></field>
     </record>
     <record id="apply_rental_check_out" model="ir.actions.server">
         <field name="name">Apply Rental Checkout</field>

--- a/tests/test_booking_engine/tests/test_action_server.py
+++ b/tests/test_booking_engine/tests/test_action_server.py
@@ -90,31 +90,6 @@ class BookingEngineAutomationsTestCase(TransactionCase):
     def _expected_nights(self, start_datetime, end_datetime):
         return int(((end_datetime - start_datetime).total_seconds() + 86399) // 86400)
 
-    def test_automation_fix_slot_times_on_create_and_write(self):
-        """Test for the industry_fix_slot_times automation."""
-        order, sale_line = self._create_sale_line(self.product)
-        expected_start, expected_end = self._expected_slot_datetimes(order.rental_start_date, order.rental_return_date)
-        order.action_confirm()
-        self.assertEqual(sale_line.planning_slot_ids[0].start_datetime, expected_start,
-                         "The slot start time should be updated based on recurrence pickup time")
-        self.assertEqual(sale_line.planning_slot_ids[0].end_datetime, expected_end,
-                         "The slot end time should be updated with the recurrence return time")
-        self.assertEqual(sale_line.start_date, expected_start,
-                         "The order line start date should be updated based on recurrence pickup time")
-        self.assertEqual(sale_line.return_date, expected_end,
-                         "The order line return date should be updated based on recurrence return time")
-
-    def test_automation_set_rental_hours(self):
-        """Test for the industry_set_rental_hours automation on write."""
-        order, sale_line = self._create_sale_line(self.product)
-        order.action_confirm()
-
-        expected_start_date, expected_end_date = self._expected_slot_datetimes(order.rental_start_date, order.rental_return_date)
-        self.assertEqual(sale_line.planning_slot_ids[0].start_datetime, expected_start_date,
-                         "The automation should align slot start time to the pickup time on write")
-        self.assertEqual(sale_line.planning_slot_ids[0].end_datetime, expected_end_date,
-                         "The automation should align slot end time to the return time on write")
-
     def test_automation_create_role_on_room_offer_create(self):
         room_offer_product_template = self.room_offer_template
         role = room_offer_product_template.planning_role_id


### PR DESCRIPTION
This commit removes the server_action in `booking_engine` that used to force the dates for any stay offer booking to start at product `pickup_time` and end at product `return_time`.

task-6294142