### PR TITLE
[FIX] 3pl_logistic_company: fix portal products no access rights

### DIFF
--- a/3pl_logistic_company/__manifest__.py
+++ b/3pl_logistic_company/__manifest__.py
@@ -1,7 +1,7 @@
 {
     'name': '3PL Logistic Company',
     'author': 'Odoo S.A.',
-    'version': '1.3',
+    'version': '1.4',
     'category': 'Services',
     'depends': [
         'base_industry_data',

--- a/3pl_logistic_company/data/ir_actions_server.xml
+++ b/3pl_logistic_company/data/ir_actions_server.xml
@@ -6,6 +6,7 @@
         <field name="state">code</field>
         <field name="website_published">True</field>
         <field name="website_path">products</field>
+        <field name="group_ids" eval="[Command.link(ref('base.group_portal'))]"/>
         <field name="code"><![CDATA[
 response = request.render('3pl_logistic_company.portal_products')
 ]]></field>


### PR DESCRIPTION
This commit fixes a new "no access rights" error on the products portal page. This is caused by the recent change in standard from the commit odoo/odoo@846eb51 that changed how important was the model of a server action used by an url. Now we need the write accesses on the mode for triggering a server action, or as we do here have the access through the groups field of the server action.

Task-6306283