### PR TITLE
[FIX] 3pl, headhunter: fix portal no access rights and add tests

### DIFF
--- a/3pl_logistic_company/data/portal_templates.xml
+++ b/3pl_logistic_company/data/portal_templates.xml
@@ -11,7 +11,7 @@
     <template id="portal_products" name="Your Products">
         <t t-call="portal.portal_layout">
             <t t-set="logged_user" t-value="request.env.user"/>
-            <t t-set="user_products" t-value="request.env['stock.quant'].sudo().search([('owner_id', '!=', False), ('owner_id', 'parent_of', logged_user.partner_id), ('location_id.usage', '=', 'internal'), ('quantity', '!=', '0')])"/>
+            <t t-set="user_products" t-value="request.env['stock.quant'].sudo().search([('owner_id', '!=', False), ('owner_id', 'parent_of', logged_user.partner_id.id), ('location_id.usage', '=', 'internal'), ('quantity', '!=', '0')])"/>
             <t t-call="portal.portal_searchbar" title.translate="Products"/>
             <div t-if="not user_products" class="alert alert-info">
                 There are currently no products for your account.

--- a/headhunter/__manifest__.py
+++ b/headhunter/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Talent Acquisition',
-    'version': '1.4',
+    'version': '1.5',
     'category': 'Services',
     'depends': [
         'account',

--- a/headhunter/data/ir_actions_server.xml
+++ b/headhunter/data/ir_actions_server.xml
@@ -93,6 +93,7 @@ if env.context.get('x_from_cv_send'):
         <field name="state">code</field>
         <field name="website_published">True</field>
         <field name="website_path">cv_sent_applicants</field>
+        <field name="group_ids" eval="[Command.link(ref('base.group_portal'))]"/>
         <field name="code"><![CDATA[
 response = request.render('headhunter.portal_cv_sent_applicants')
 ]]></field>

--- a/tests/test_3pl_logistic_company/tests/__init__.py
+++ b/tests/test_3pl_logistic_company/tests/__init__.py
@@ -2,3 +2,4 @@
 
 from . import test_action_server
 from . import test_computed_fields
+from . import test_website_urls

--- a/tests/test_3pl_logistic_company/tests/test_website_urls.py
+++ b/tests/test_3pl_logistic_company/tests/test_website_urls.py
@@ -1,0 +1,28 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import Command
+from odoo.tests import HttpCase
+
+
+class UrlsWebsiteTestCase(HttpCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.user_1 = cls.env['res.users'].create([{
+            'name': 'Test User 1',
+            'login': 'test_user_1',
+            'partner_id': cls.env['res.partner'].create([{
+                'name': 'Test Partner 1',
+                'email': 'test1@example.com',
+            }]).id,
+            'group_ids': [Command.link(cls.env.ref('base.group_portal').id)],
+        }])
+
+    def test_products_stock_portal_open(self):
+        with self.assertLogs(level="WARNING"):
+            response = self.url_open('/website/action/products')
+        self.assertEqual(response.status_code, 403, 'The request should be forbidden when no user is authenticated.')
+        self.authenticate('test_user_1', '')
+        response = self.url_open('/website/action/products')
+        self.assertEqual(response.status_code, 200, 'The request should be successful for authenticated user.')

--- a/tests/test_headhunter/__init__.py
+++ b/tests/test_headhunter/__init__.py
@@ -1,0 +1,1 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.

--- a/tests/test_headhunter/__manifest__.py
+++ b/tests/test_headhunter/__manifest__.py
@@ -1,0 +1,8 @@
+{
+    'name': 'Test Industry Headhunter',
+    'category': 'Hidden/Tests',
+    'description': """A module to test code in the Headhunter industry module.""",
+    'depends': ['base'],
+    'license': 'LGPL-3',
+    'author': 'Odoo S.A.',
+}

--- a/tests/test_headhunter/tests/__init__.py
+++ b/tests/test_headhunter/tests/__init__.py
@@ -1,0 +1,3 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import test_website_urls

--- a/tests/test_headhunter/tests/test_website_urls.py
+++ b/tests/test_headhunter/tests/test_website_urls.py
@@ -1,0 +1,28 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import Command
+from odoo.tests import HttpCase
+
+
+class UrlsWebsiteTestCase(HttpCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.user_1 = cls.env['res.users'].create([{
+            'name': 'Test User 1',
+            'login': 'test_user_1',
+            'partner_id': cls.env['res.partner'].create([{
+                'name': 'Test Partner 1',
+                'email': 'test1@example.com',
+            }]).id,
+            'group_ids': [Command.link(cls.env.ref('base.group_portal').id)],
+        }])
+
+    def test_cv_sent_applicant_portal_opens(self):
+        with self.assertLogs(level="WARNING"):
+            response = self.url_open('/website/action/cv_sent_applicants')
+        self.assertEqual(response.status_code, 403, 'The request should be forbidden when no user is authenticated.')
+        self.authenticate('test_user_1', '')
+        response = self.url_open('/website/action/cv_sent_applicants')
+        self.assertEqual(response.status_code, 200, 'The request should be successful for authenticated user.')


### PR DESCRIPTION
This PR fixes a "no access rights" error on the portal page. This is caused by the recent change in standard from the commit odoo/odoo@846eb51 that changed how important was the model of a server action used by an url. Now we need the write accesses on the model for triggering a server action, or as we do here have the access through the groups field of the server action.

This also add tests so we can detect when it happens from now on.

Task-6306283