### PR TITLE
[FIX] test_industry: fix the size of the registry

### DIFF
--- a/tests/test_industry/cli/test_industry.py
+++ b/tests/test_industry/cli/test_industry.py
@@ -57,7 +57,7 @@ class Test_Industry(Command):
         if test_tags == "+standard" and test_enable:
             test_tags = None
         config['test_tags'] = ''
-        config["registry_lru_size"] = 1  # don't keep all registry in memory, and ensure a single registry when running tests
+        os.environ['ODOO_REGISTRY_LRU_SIZE'] = str(1)  # don't keep all registry in memory, and ensure a single registry when running tests
 
         init_db = config["db_name"]
         registry = None


### PR DESCRIPTION
Since [this commit] it is not possible to define `registry_lru_size` from
the config. This commit fixes the issue by defining it in the os.environ
directly.

[this commit]: https://github.com/odoo/odoo/commit/7ec7048fef7f8cb6b0eb320903d6197c9841fec8