### PR TITLE
[FIX] industry_real_estate: fix traceback when saving custom Contact us fields

### DIFF
--- a/industry_real_estate/__manifest__.py
+++ b/industry_real_estate/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Property Management',
-    'version': '1.3',
+    'version': '1.4',
     'category': 'Services',
     'depends': [
         'base_automation',

--- a/industry_real_estate/data/website_view.xml
+++ b/industry_real_estate/data/website_view.xml
@@ -88,7 +88,7 @@
                                                                     <span class="s_website_form_label_content">Property</span>
                                                                 </label>
                                                                 <div class="col-sm">
-                                                                    <input type="text" class="form-control s_website_form_input" name="Property" id="property_text" />
+                                                                    <input type="text" class="form-control s_website_form_input" name="x_property_id" id="property_text" />
                                                                 </div>
                                                             </div>
                                                         </div>


### PR DESCRIPTION
Before this PR, adding a field to the Contact Us form through the website editor and saving the page would trigger a traceback.

The issue was caused by an incorrect input name in the form. The field was defined as `property` instead of the actual field name **`x_property_id`,** causing the whitelisting validation to fail with: Unable to whitelist field(s) ['Property']

This PR updates the input name to use the correct field, allowing the form to be saved successfully.

Task-6323839