### PR TITLE
[FIX] custom_industrial_equipment: update _get_visitor_from_request on ir.http

### DIFF
--- a/custom_industrial_equipment/__manifest__.py
+++ b/custom_industrial_equipment/__manifest__.py
@@ -71,6 +71,7 @@
         'demo/website.xml',
     ],
     'license': 'OEEL-1',
+    'version': '1.1',
     'cloc_exclude': [
         'data/knowledge_article.xml',
         'demo/website_view.xml',

--- a/custom_industrial_equipment/demo/website_view.xml
+++ b/custom_industrial_equipment/demo/website_view.xml
@@ -3,7 +3,7 @@
   <record id="contactus" model="ir.ui.view">
     <field name="arch" type="xml">
       <t name="Contact Us" t-name="website.contactus">
-        <t t-call="website.layout" logged_partner="env['website.visitor']._get_visitor_from_request().partner_id">
+        <t t-call="website.layout" logged_partner="env['ir.http']._get_visitor_from_request().partner_id">
           <t t-set="contactus_form_values" t-value="{                 'email_to': res_company.email,                 'name': request.params.get('name', ''),                 'phone': request.params.get('phone', ''),                 'email_from': request.params.get('email_from', ''),                 'company': request.params.get('company', ''),                 'subject': request.params.get('subject', ''),             }"/>
           <span class="hidden" data-for="contactus_form" t-att-data-values="contactus_form_values"/>
           <div id="wrap" class="oe_structure oe_empty">


### PR DESCRIPTION


The method _get_visitor_from_request was moved to the ir.http model. - [1]

[1]: https://github.com/odoo/odoo/pull/247438/commits/bab043f46caf4b09b860def43657305acf046b4d

sentry-7575523420