### PR TITLE
[FIX] booking_engine: fix navigation to the guest view

### DIFF
--- a/booking_engine/__manifest__.py
+++ b/booking_engine/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Booking',
-    'version': '1.15',
+    'version': '1.16',
     'category': 'Hospitality',
     'author': 'Odoo S.A.',
     'depends': [

--- a/booking_engine/data/ir_ui_view.xml
+++ b/booking_engine/data/ir_ui_view.xml
@@ -61,7 +61,7 @@
             <field name="x_guest_line_ids">
               <list default_order="x_sequence asc,id desc" editable="bottom">
                 <field name="x_sequence" widget="handle"/>
-                <field optional="show" name="x_guest_partner_id" widget="many2one_avatar" required="1"/>
+                <field optional="show" name="x_guest_partner_id" required="1"/>
                 <field optional="show" name="x_guest_identity_check" widget="badge" readonly="True" decoration-success="x_guest_identity_check == 'ok'" decoration-warning="x_guest_identity_check == 'na'" decoration-danger="x_guest_identity_check == 'invalid'"/>
                 <field optional="show" name="x_room_resource_id" domain="[('default_role_id.x_is_a_room_offer', '!=', False), ('id', 'in', x_sol_resource_ids)]" options="{'no_create': True, 'no_create_edit': True}"/>
               </list>


### PR DESCRIPTION
This PR removes the **many2one_avatar** widget, which prevented users from navigating to the guest view and modifying guest data.

Task-6273305