### PR TITLE
[FIX] hvac_services: enable serial numbers on invoices

### DIFF
--- a/hvac_services/__manifest__.py
+++ b/hvac_services/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'HVAC Services',
-    'version': '1.4',
+    'version': '1.5',
     'category': 'Services',
     'depends': [
         'appointment_account_payment',

--- a/hvac_services/data/qweb_view.xml
+++ b/hvac_services/data/qweb_view.xml
@@ -124,4 +124,25 @@
             </t>
         </field>
     </record>
+    <template id="report_invoice_document_serials" inherit_id="account.report_invoice_document">
+        <xpath expr="//t[@t-set='display_taxes']" position="after">
+            <t t-set="line_serials_map" t-value="{l.id: l.sale_line_ids.x_maintained_serials_ids for l in o.invoice_line_ids}"/>
+            <t t-set="display_serials" t-value="any(line_serials_map.values())"/>
+        </xpath>
+        <xpath expr="//th[@name='th_description']" position="after">
+            <th name="th_serials" t-if="display_serials" class="text-start" groups="stock_account.group_lot_on_invoice">
+                <span>Serial(s)</span>
+            </th>
+        </xpath>
+        <xpath expr="//td[@name='account_invoice_line_name']" position="after">
+            <t t-set="line_serials" t-value="line_serials_map.get(line.id)"/>
+            <td name="td_serials" t-if="display_serials" class="text-start" groups="stock_account.group_lot_on_invoice">
+                <span t-if="line_serials">
+                    <t t-foreach="line_serials" t-as="lot" t-key="lot.id">
+                        <t t-out="lot.name"/><br/>
+                    </t>
+                </span>
+            </td>
+        </xpath>
+    </template>
 </odoo>

--- a/hvac_services/data/res_config_settings.xml
+++ b/hvac_services/data/res_config_settings.xml
@@ -6,6 +6,7 @@
         <field name="group_uom" eval="True"/>
         <field name="group_product_pricelist" eval="True"/>
         <field name="documents_product_settings" eval="True"/>
+        <field name="group_lot_on_invoice" eval="True"/>
     </record>
     <function model="res.config.settings" name="execute">
         <value eval="[ref('res_config_settings_enable')]"/>


### PR DESCRIPTION
This PR enables the **Display Lots & Serial Numbers on Invoices** setting to ensure serial numbers are displayed on customer invoices.

Task-6329630