### PR TITLE
[FIX] 3pl_logistic_company: use product template in stock history cron

### DIFF
--- a/3pl_logistic_company/__manifest__.py
+++ b/3pl_logistic_company/__manifest__.py
@@ -1,7 +1,7 @@
 {
     'name': '3PL Logistic Company',
     'author': 'Odoo S.A.',
-    'version': '1.4',
+    'version': '1.5',
     'category': 'Services',
     'depends': [
         'base_industry_data',

--- a/3pl_logistic_company/data/ir_cron.xml
+++ b/3pl_logistic_company/data/ir_cron.xml
@@ -15,7 +15,7 @@ for sq in env['stock.quant'].search([('location_id.usage', '=', 'internal')]):
         'x_history_owner_id': sq.product_tmpl_id.x_owner_id.id,
         'x_location_id': sq.location_id.id,
         'x_history_fee_rate_id': sq.location_id.x_location_fee_rate_id.id,
-        'x_product_id': sq.product_id.id,
+        'x_product_id': sq.product_tmpl_id.id,
         'x_package_id': sq.package_id.id,
         'x_stock_lot_id': sq.lot_id.id,
         'x_quantity': sq.inventory_quantity_auto_apply,


### PR DESCRIPTION
The scheduled action "Stock History - Create Daily Records" stores daily stock snapshots in `x_stock_history`. The `x_product_id` field is a many2one to `product.template`, but the cron was assigning the ID of the corresponding `product.product` record.

This mismatch only works when both records happen to share the same ID. As soon as a product variant ID differs from its template ID, the scheduled action attempts to create a record with an invalid foreign key, causing a `ForeignKeyViolation` error and preventing the stock history from being generated.

Use `sq.product_tmpl_id.id` instead of `sq.product_id.id` so the value matches the target model of the relation and the scheduled action consistently creates stock history records.

Task-6333945