### PR TITLE
[IMP] booking_engine: add setting for steering

### DIFF
--- a/booking_engine/__manifest__.py
+++ b/booking_engine/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Booking',
-    'version': '1.15',
+    'version': '1.16',
     'category': 'Hospitality',
     'author': 'Odoo S.A.',
     'depends': [

--- a/booking_engine/data/ir_ui_menu.xml
+++ b/booking_engine/data/ir_ui_menu.xml
@@ -7,7 +7,7 @@
       <menuitem id="menu_board_house_keeping" name="Board" action="act_window_board"/>
       <menuitem id="menu_tasks_house_keeping" name="Tasks" action="act_window_house_keeping_project_tasks"/>
     </menuitem>
-    <menuitem id="menu_availability_steering" name="Steering">
+    <menuitem id="menu_availability_steering" name="Steering" groups="group_steering">
       <menuitem id="menu_availability_occupancy" name="Occupancy" action="action_window_availability_occupancy"/>
       <menuitem id="menu_availability_availability" name="Availability" action="action_window_availability_availability"/>
     </menuitem>

--- a/booking_engine/data/res_config_settings.xml
+++ b/booking_engine/data/res_config_settings.xml
@@ -150,6 +150,95 @@ self['x_setting_approvers'] = self.env['ir.config_parameter'].get_param('booking
         <field name="name">x_setting_related_approver_users_ids</field>
     </record>
 
+    <!-- Steering Settings-->
+    <record id="x_setting_field_steering" model="ir.model.fields">
+        <field name="ttype">boolean</field>
+        <field name="field_description">Steering</field>
+        <field name="model_id" ref="base_setup.model_res_config_settings"/>
+        <field name="name">x_setting_steering</field>
+        <field name="store" eval="True"/>
+        <field name="compute"><![CDATA[
+self['x_setting_steering'] = (self.env['ir.config_parameter'].get_param('booking_engine.x_steering_setting', '0') != '0')
+]]></field>
+    </record>
+    <record id="server_action_set_x_setting_steering" model="ir.actions.server">
+        <field name="name">Set Steering setting</field>
+        <field name="code"><![CDATA[
+records_archive = [
+    'ir_cron_create_500_days_availability',
+    'ir_cron_send_survey',
+    'automation_on_planning_slot_change',
+    'automation_on_planning_slot_delete',
+    'automation_on_resource_calendar_leaves_change',
+    'automation_on_resource_calendar_leaves_delete',
+    'automation_on_resource_resource_change',
+    'automation_on_resource_resource_delete',
+    'automation_on_product_template_change',
+    'automation_on_product_template_delete',
+    'automation_to_archive_existing_surveys',
+]
+cloc_entries = [
+    'x_availability_color_field_x_availability',
+    'x_available_field_x_availability',
+    'x_availability_field_x_availability',
+    'x_occupancy_field_x_availability',
+    'x_occupancy_color_field_x_availability',
+    'x_availability_color_field_x_availability',
+    'server_action_update_availabilities',
+    'server_action_create_500_days_availability',
+    'server_action_helper_compute_new_avails_to_recompute',
+    'server_action_update_availability_for_planning_slot_delete',
+    'server_action_update_availability_for_resource_calendar_leaves_delete',
+    'server_action_update_availability_for_resource_resource_delete',
+    'server_action_update_availability_for_product_template_delete',
+    'server_action_update_availability_for_planning_slot',
+    'server_action_update_availability_for_resource_calendar_leaves',
+    'server_action_update_availability_for_resource_resource',
+    'server_action_update_availability_for_product_template',
+    'server_action_to_archive_surveys',
+    'ir_actions_server_send_survey',
+]
+env['ir.config_parameter'].set_param('booking_engine.x_steering_setting', ('1' if record.x_setting_steering else '0'))
+if record.x_setting_steering:
+    env.ref('base.group_user')._apply_group(env.ref('booking_engine.group_steering'))
+    for to_unarchive in records_archive:
+        env.ref(f'booking_engine.{to_unarchive}')['active'] = True
+    for cloc_entry in cloc_entries:
+        if (cloc_entry_id := env.ref(f'__cloc_exclude__.booking_engine_{cloc_entry}', raise_if_not_found=False)):
+            entry_model = 'ir.actions.server' if cloc_entry.startswith('server_action') else 'ir.model.fields'
+            env['ir.model.data'].search([
+                ('name', '=', f'booking_engine_{cloc_entry}'),
+                ('model', '=', entry_model),
+                ('module', '=', '__cloc_exclude__'),
+                ('res_id', '=', cloc_entry_id.id),
+            ], limit=1).unlink()
+else:
+    env.ref('base.group_user')._remove_group(env.ref('booking_engine.group_steering'))
+    for to_archive in records_archive:
+        env.ref(f'booking_engine.{to_archive}')['active'] = False
+    for cloc_entry in cloc_entries:
+        cloc_exclude_id = f'booking_engine_{cloc_entry}'
+        entry_model = 'ir.actions.server' if cloc_entry.startswith('server_action') else 'ir.model.fields'
+        if (cloc_entry_id := env.ref(f'booking_engine.{cloc_entry}', raise_if_not_found=False)) and not env.ref(f'__cloc_exclude__.{cloc_exclude_id}', raise_if_not_found=False):
+            env['ir.model.data'].create({
+                'name': cloc_exclude_id,
+                'model': entry_model,
+                'module': '__cloc_exclude__',
+                'res_id': cloc_entry_id.id,
+            })
+]]></field>
+        <field name="model_id" ref="base_setup.model_res_config_settings"/>
+        <field name="state">code</field>
+    </record>
+    <record id="automation_on_x_setting_steering_set" model="base.automation">
+        <field name="name">On Steering setting set</field>
+        <field name="model_id" ref="base_setup.model_res_config_settings"/>
+        <field name="action_server_ids" eval="[(6, 0, [ref('server_action_set_x_setting_steering')])]"/>
+        <field name="trigger">on_create_or_write</field>
+        <field name="trigger_field_ids" eval="[(6, 0, [ref('x_setting_field_steering')])]"/>
+    </record>
+
+
     <record id="server_action_set_x_setting_approvers" model="ir.actions.server">
         <field name="name">HouseKeeping: Set approvers setting</field>
         <field name="code"><![CDATA[
@@ -175,7 +264,7 @@ env['ir.config_parameter'].set_param('booking_engine.x_approvers_setting', ('1' 
         <field name="arch" type="xml">
             <xpath expr="//form" position="inside">
                 <app string="Accomodation" name="accomodation">
-                    <block title="House Keeping" name="house_keeping_config_block">
+                    <block title="Operations" name="booking_operations_config_block">
                         <setting id="booking_engine_house_keeping_setting" help="Access cleanness state and manage tasks.">
                             <field name="x_module_house_keeping"/>
                             <div class="row mt-2" invisible="not x_module_house_keeping">
@@ -191,12 +280,13 @@ env['ir.config_parameter'].set_param('booking_engine.x_approvers_setting', ('1' 
                             </div>
                         </setting>
                     </block>
+                    <block title="Management" name="booking_management_config_block">
+                        <setting id="booking_engine_steering_setting" help="Monitor availability, occupancy, average daily rate, revenue per available unit and pick-ups.">
+                            <field name="x_setting_steering"/>
+                        </setting>
+                    </block>
                 </app>
             </xpath>
         </field>
     </record>
-
-    <function name="run" model="ir.actions.server" context="{'active_model': 'res.config.settings', 'active_id': ref('res_config_settings_enable')}">
-        <value eval="[ref('x_action_activate_house_keeping')]"/>
-    </function>
 </odoo>

--- a/booking_engine/data/res_groups.xml
+++ b/booking_engine/data/res_groups.xml
@@ -3,4 +3,7 @@
     <record id="group_house_keeping" model="res.groups">
         <field name="name">House Keeping</field>
     </record>
+    <record id="group_steering" model="res.groups">
+        <field name="name">Steering</field>
+    </record>
 </odoo>

--- a/campsite/data/knowledge_article.xml
+++ b/campsite/data/knowledge_article.xml
@@ -276,6 +276,12 @@
         <h3>🚀 Strategic Oversight</h3>
         <hr/>
         <p>Beyond daily operations, the Steering menu serves as the "Captain’s Bridge" of your campsite. It provides a 500-day horizon to anticipate market trends, manage risks, and optimize your revenue.</p>
+        <div class="o_editor_banner user-select-none o-contenteditable-false lh-1 d-flex align-items-center alert alert-info pb-0 pt-3" data-oe-role="status">
+            <i class="o_editor_banner_icon mb-3 fst-normal" data-oe-aria-label="Banner Info">💡</i>
+            <div class="o_editor_banner_content o-contenteditable-true w-100 px-3">
+                <p>This capability is enabled by a setting you can set/unset.</p>
+            </div>
+        </div>
         <h4>Monitoring success with occupancy</h4>
         <p>The Occupancy view allows you to visualize your "Sales Success". It answers one simple question: <i>How well am I filling my campsite?</i></p>
         <ul>

--- a/campsite/data/res_config_settings.xml
+++ b/campsite/data/res_config_settings.xml
@@ -13,4 +13,11 @@
             </xpath>
         </field>
     </record>
+    <data noupdate="1">
+        <record model="res.config.settings" id="res_config_settings_enable">
+            <field name="x_module_house_keeping" eval="1"/>
+            <field name="x_setting_steering" eval="1"/>
+        </record>
+        <function model="res.config.settings" name="execute" eval="[ref('res_config_settings_enable')]"/>
+    </data>
 </odoo>

--- a/guest_house/data/knowledge_article.xml
+++ b/guest_house/data/knowledge_article.xml
@@ -321,6 +321,12 @@
         <h3>🚀 Strategic Oversight</h3>
         <hr/>
         <p>Beyond daily operations, the Steering menu serves as the "Captain’s Bridge" of your guest house. It provides a 500-day horizon to anticipate market trends, manage risks, and optimize your revenue.</p>
+        <div class="o_editor_banner user-select-none o-contenteditable-false lh-1 d-flex align-items-center alert alert-info pb-0 pt-3" data-oe-role="status">
+            <i class="o_editor_banner_icon mb-3 fst-normal" data-oe-aria-label="Banner Info">💡</i>
+            <div class="o_editor_banner_content o-contenteditable-true w-100 px-3">
+                <p>This capability is enabled by a setting you can set/unset.</p>
+            </div>
+        </div>
         <h4>Monitoring success with occupancy</h4>
         <p>The Occupancy view allows you to visualize your "Sales Success". It answers one simple question: <i>How well am I filling my guest house?</i></p>
         <ul>

--- a/guest_house/data/res_config_settings.xml
+++ b/guest_house/data/res_config_settings.xml
@@ -13,4 +13,10 @@
             </xpath>
         </field>
     </record>
+    <data noupdate="1">
+        <record model="res.config.settings" id="res_config_settings_enable">
+            <field name="x_module_house_keeping" eval="1"/>
+        </record>
+        <function model="res.config.settings" name="execute" eval="[ref('res_config_settings_enable')]"/>
+    </data>
 </odoo>

--- a/holiday_house/data/knowledge_article.xml
+++ b/holiday_house/data/knowledge_article.xml
@@ -268,6 +268,12 @@ The Holiday House App relies on the Rental and Planning Apps binding, with a few
     <h3>🚀 Strategic Oversight</h3>
     <hr/>
     <p>Beyond daily operations, the Steering menu serves as the "Captain’s Bridge" of your holiday houses. It provides a 500-day horizon to anticipate market trends, manage risks, and optimize your revenue.</p>
+    <div class="o_editor_banner user-select-none o-contenteditable-false lh-1 d-flex align-items-center alert alert-info pb-0 pt-3" data-oe-role="status">
+        <i class="o_editor_banner_icon mb-3 fst-normal" data-oe-aria-label="Banner Info">💡</i>
+        <div class="o_editor_banner_content o-contenteditable-true w-100 px-3">
+            <p>This capability is enabled by a setting you can set/unset.</p>
+        </div>
+    </div>
     <h4>Monitoring success with occupancy</h4>
     <p>The Occupancy view allows you to visualize your "Sales Success". It answers one simple question: <i>How well am I filling my holiday houses?</i></p>
     <ul>

--- a/holiday_house/data/res_config_settings.xml
+++ b/holiday_house/data/res_config_settings.xml
@@ -13,4 +13,10 @@
             </xpath>
         </field>
     </record>
+    <data noupdate="1">
+        <record model="res.config.settings" id="res_config_settings_enable">
+            <field name="x_module_house_keeping" eval="1"/>
+        </record>
+        <function model="res.config.settings" name="execute" eval="[ref('res_config_settings_enable')]"/>
+    </data>
 </odoo>

--- a/hotel/data/knowledge_article.xml
+++ b/hotel/data/knowledge_article.xml
@@ -393,6 +393,12 @@
         <h3>🚀 Strategic Oversight</h3>
         <hr/>
         <p>Beyond daily operations, the Steering menu serves as the "Captain’s Bridge" of your hotel. It provides a 500-day horizon to anticipate market trends, manage risks, and optimize your revenue.</p>
+        <div class="o_editor_banner user-select-none o-contenteditable-false lh-1 d-flex align-items-center alert alert-info pb-0 pt-3" data-oe-role="status">
+            <i class="o_editor_banner_icon mb-3 fst-normal" data-oe-aria-label="Banner Info">💡</i>
+            <div class="o_editor_banner_content o-contenteditable-true w-100 px-3">
+                <p>This capability is enabled by a setting you can set/unset.</p>
+            </div>
+        </div>
         <h4>Monitoring success with occupancy</h4>
         <p>The Occupancy view allows you to visualize your "Sales Success". It answers one simple question: <i>How well am I filling my hotel?</i></p>
         <ul>

--- a/hotel/data/res_config_settings.xml
+++ b/hotel/data/res_config_settings.xml
@@ -13,4 +13,11 @@
             </xpath>
         </field>
     </record>
+    <data noupdate="1">
+        <record model="res.config.settings" id="res_config_settings_enable">
+            <field name="x_module_house_keeping" eval="1"/>
+            <field name="x_setting_steering" eval="1"/>
+        </record>
+        <function model="res.config.settings" name="execute" eval="[ref('res_config_settings_enable')]"/>
+    </data>
 </odoo>

--- a/tests/test_booking_engine/tests/test_action_server.py
+++ b/tests/test_booking_engine/tests/test_action_server.py
@@ -52,6 +52,10 @@ class BookingEngineAutomationsTestCase(TransactionCase):
         cls.stage_clean = cls.env.ref('booking_engine.project_task_type_17')
         cls.stage_ready = cls.env.ref('booking_engine.project_task_type_18')
         cls.today = Datetime.today()
+        cls.env["res.config.settings"].create({
+            'x_module_house_keeping': True,
+            'x_setting_steering': True,
+        }).execute()
 
     def _create_sale_line(self, product):
         order = self.env['sale.order'].with_context(in_rental_app=True).create({


### PR DESCRIPTION
This commit adds a setting for the steering menu
of booking engine, allowing for customers to choose if they need the occupancy and availability.

Backport of 2443