### PR TITLE
[FIX] *: remove deleted settings

### DIFF
--- a/construction/data/res_config_settings.xml
+++ b/construction/data/res_config_settings.xml
@@ -6,9 +6,8 @@
         <field name="group_product_pricelist" eval="1"/>
         <field name="group_warning_sale" eval="1"/>
         <field name="group_warning_purchase" eval="1"/>
-        <field name="invoiced_timesheet" eval="'all'"/> 
-        <field name="group_warning_stock" eval="1"/> 
-        <field name="group_stock_reception_report" eval="1"/> 
+        <field name="invoiced_timesheet" eval="'all'"/>
+        <field name="group_warning_stock" eval="1"/>
         <field name="group_sale_delivery_address" eval="1"/>
         <field name="documents_product_settings" eval="1"/>
         <field name="documents_hr_settings" eval="1"/>

--- a/custom_furniture/data/res_config_settings.xml
+++ b/custom_furniture/data/res_config_settings.xml
@@ -7,7 +7,6 @@
         <field name="group_sale_order_template" eval="1"/>
         <field name="replenish_on_order" eval="1"/>
         <field name="group_project_stages" eval="1"/>
-        <field name="group_mrp_reception_report" eval="1"/>
     </record>
 
     <function name="execute" model="res.config.settings">

--- a/textile_manufacturing/data/res_config_settings.xml
+++ b/textile_manufacturing/data/res_config_settings.xml
@@ -2,7 +2,6 @@
 <odoo noupdate="1">
     <record id="res_config_setting_textile_manufacturing" model="res.config.settings">
         <field name="group_mrp_routings" eval="1"/>
-        <field name="group_mrp_reception_report" eval="1"/>
         <field name="group_project_stages" eval="1"/>
     </record>
     <function name="execute" model="res.config.settings">


### PR DESCRIPTION
*: construction, custom_furniture, textile_manufacturing

Two setting fields (`group_mrp_reception_report` and `group_stock_reception_report`) were deleted in [^1] but weren't removed from industry codebase. This commit removes them.

[^1]: odoo/odoo#264299

task-4894566