### PR TITLE
[FIX] beauty_parlor: prevent error when opening the Contact Us page

### DIFF
--- a/beauty_parlor/__manifest__.py
+++ b/beauty_parlor/__manifest__.py
@@ -1,5 +1,6 @@
 {
     'name': 'Beauty Parlor',
+    'version': '1.1',
     'category': 'Retail',
     'author': 'Odoo S.A.',
     'depends': [

--- a/beauty_parlor/demo/website_view.xml
+++ b/beauty_parlor/demo/website_view.xml
@@ -5,8 +5,8 @@
       <xpath expr="//p[hasclass('lead')]" position="replace">
         <p class="lead">Whether you’d like more information about our services, need assistance with your booking, or simply want personalized advice, feel free to reach out. We’ll get back to you as soon as possible.&amp;nbsp;&amp;nbsp;</p>
       </xpath>
-      <xpath expr="//section[@data-snippet='s_title'][1]/span" position="attributes">
-        <attribute name="style">background-image: url('/web/image/beauty_parlor.ir_attachment_1167'); background-position: 50% 0px;</attribute>
+      <xpath expr="//div[hasclass('col-lg-5')]/img" position="replace">
+        <img src="/web/image/beauty_parlor.ir_attachment_1167" class="img img-fluid rounded" alt=""/>
       </xpath>
     </field>
     <field name="inherit_id" ref="website.contactus"/>


### PR DESCRIPTION
Currently, an error occurs when opening the Contact Us page.

**Steps to Reproduce:**

 - Install the `beauty_parlor` with demo data.
 - Go to `Website` > `Contact Us`.

`ValueError: Element '<xpath expr="//section[@data-snippet='s_title'][1]/span">' cannot be located in parent view`

This error started occurring in saas-19.1 after [commit] that reworked the Contact Us page to better 
showcase the capabilities of the website builder. As part of that change, the section was modified, 
but the code still references an XPath [1] that no longer exists in the main view. As a result, opening 
the Contact Us page raises this error.

This commit replaces the default website aside image with a beauty parlor related image, similar to 
what was done [here], since the banner is no longer used in the main view.

[commit]: https://github.com/odoo/odoo/commit/ba8d1f60b82ffeada0b222481706a5c65623020d#diff-409cc7362c7557970ce7506fc9a1097c37c7869b7cd815ce463db38a3b7a8239

[1]- https://github.com/odoo/industry/blob/22cac5a9fc54f33ed99fd924c962b35f4bd5f1f5/beauty_parlor/demo/website_view.xml#L8-L10

[here]: https://github.com/odoo/industry/commit/de71da8c58b89e95d2ac55b277accdc7490cb68f

sentry-7336372498