### PR TITLE
[FIX] 3pl_logistic_company: changed barcode value

### DIFF
--- a/3pl_logistic_company/__manifest__.py
+++ b/3pl_logistic_company/__manifest__.py
@@ -1,7 +1,7 @@
 {
     'name': '3PL Logistic Company',
     'author': 'Odoo S.A.',
-    'version': '1.5',
+    'version': '1.6',
     'category': 'Services',
     'depends': [
         'base_industry_data',

--- a/3pl_logistic_company/data/stock_package_type.xml
+++ b/3pl_logistic_company/data/stock_package_type.xml
@@ -4,7 +4,7 @@
     <field name="name">Euro - Pallet</field>
     <field name="width">1200.0</field>
     <field name="packaging_length">800.0</field>
-    <field name="barcode">PAL</field>
+    <field name="barcode">EUROPAL</field>
   </record>
   <record id="stock_package_type_2" model="stock.package.type">
     <field name="name">Custom client box</field>

--- a/3pl_logistic_company/demo/stock_package.xml
+++ b/3pl_logistic_company/demo/stock_package.xml
@@ -13,91 +13,91 @@
         <field name="package_type_id" ref="stock_package_type_3"/>
     </record>
     <record id="stock_package_3" model="stock.package">
-        <field name="name">PAL_0006</field>
+        <field name="name">EUROPAL_0006</field>
         <field name="location_id" ref="import_shelf_0001"/>
         <field name="pack_date" eval="datetime.today().date() + relativedelta(days=-2)"/>
         <field name="package_type_id" ref="stock_package_type_1"/>
     </record>
     <record id="stock_package_4" model="stock.package">
-        <field name="name">PAL_0010</field>
+        <field name="name">EUROPAL_0010</field>
         <field name="location_id" ref="import_shelf_0004"/>
         <field name="pack_date" eval="datetime.today().date() + relativedelta(days=-2)"/>
         <field name="package_type_id" ref="stock_package_type_1"/>
     </record>
     <record id="stock_package_5" model="stock.package">
-        <field name="name">PAL_0011</field>
+        <field name="name">EUROPAL_0011</field>
         <field name="location_id" ref="import_shelf_0004"/>
         <field name="pack_date" eval="datetime.today().date() + relativedelta(days=-2)"/>
         <field name="package_type_id" ref="stock_package_type_1"/>
     </record>
     <record id="stock_package_6" model="stock.package">
-        <field name="name">PAL_0411</field>
+        <field name="name">EUROPAL_0411</field>
         <field name="location_id" ref="import_shelf_0009"/>
         <field name="pack_date" eval="datetime.today().date() + relativedelta(days=-2)"/>
         <field name="package_type_id" ref="stock_package_type_1"/>
     </record>
     <record id="stock_package_22" model="stock.package">
-        <field name="name">PAL_0412</field>
+        <field name="name">EUROPAL_0412</field>
         <field name="location_id" ref="import_shelf_0009"/>
         <field name="pack_date" eval="datetime.today().date()"/>
         <field name="package_type_id" ref="stock_package_type_1"/>
     </record>
     <record id="stock_package_7" model="stock.package">
-        <field name="name">PAL_101</field>
+        <field name="name">EUROPAL_101</field>
         <field name="location_id" ref="stock.stock_location_suppliers"/>
         <field name="pack_date" eval="datetime.today().date() + relativedelta(days=-1)"/>
         <field name="package_type_id" ref="stock_package_type_1"/>
     </record>
     <record id="stock_package_8" model="stock.package">
-        <field name="name">PAL_102</field>
+        <field name="name">EUROPAL_102</field>
         <field name="location_id" ref="stock.stock_location_suppliers"/>
         <field name="pack_date" eval="datetime.today().date() + relativedelta(days=-1)"/>
         <field name="package_type_id" ref="stock_package_type_1"/>
     </record>
     <record id="stock_package_9" model="stock.package">
-        <field name="name">PAL_103</field>
+        <field name="name">EUROPAL_103</field>
         <field name="location_id" ref="stock.stock_location_suppliers"/>
         <field name="pack_date" eval="datetime.today().date() + relativedelta(days=-1)"/>
         <field name="package_type_id" ref="stock_package_type_1"/>
     </record>
     <record id="stock_package_10" model="stock.package">
-        <field name="name">PAL_201</field>
+        <field name="name">EUROPAL_201</field>
         <field name="location_id" ref="import_shelf_0005"/>
         <field name="pack_date" eval="datetime.today().date() + relativedelta(days=-1)"/>
         <field name="package_type_id" ref="stock_package_type_1"/>
     </record>
     <record id="stock_package_11" model="stock.package">
-        <field name="name">PAL_202</field>
+        <field name="name">EUROPAL_202</field>
         <field name="location_id" ref="import_shelf_0005"/>
         <field name="pack_date" eval="datetime.today().date() + relativedelta(days=-1)"/>
         <field name="package_type_id" ref="stock_package_type_1"/>
     </record>
     <record id="stock_package_12" model="stock.package">
-        <field name="name">PAL_2023</field>
+        <field name="name">EUROPAL_2023</field>
         <field name="location_id" ref="import_shelf_0005"/>
         <field name="pack_date" eval="datetime.today().date() + relativedelta(days=-1)"/>
         <field name="package_type_id" ref="stock_package_type_1"/>
     </record>
     <record id="stock_package_14" model="stock.package">
-        <field name="name">PAL_301</field>
+        <field name="name">EUROPAL_301</field>
         <field name="location_id" ref="import_shelf_0005"/>
         <field name="pack_date" eval="datetime.today().date() + relativedelta(days=-1)"/>
         <field name="package_type_id" ref="stock_package_type_1"/>
     </record>
     <record id="stock_package_19" model="stock.package">
-        <field name="name">PAL_401</field>
+        <field name="name">EUROPAL_401</field>
         <field name="location_id" ref="import_shelf_0001"/>
         <field name="pack_date" eval="datetime.today().date() + relativedelta(days=-1)"/>
         <field name="package_type_id" ref="stock_package_type_1"/>
     </record>
     <record id="stock_package_20" model="stock.package">
-        <field name="name">PAL_402</field>
+        <field name="name">EUROPAL_402</field>
         <field name="location_id" ref="import_shelf_0001"/>
         <field name="pack_date" eval="datetime.today().date() + relativedelta(days=-1)"/>
         <field name="package_type_id" ref="stock_package_type_1"/>
     </record>
     <record id="stock_package_21" model="stock.package">
-        <field name="name">PAL_403</field>
+        <field name="name">EUROPAL_403</field>
         <field name="location_id" ref="import_shelf_0001"/>
         <field name="pack_date" eval="datetime.today().date() + relativedelta(days=-1)"/>
         <field name="package_type_id" ref="stock_package_type_1"/>


### PR DESCRIPTION
Currently, an error occurs when user tries to install 3pl_logistic_company.

Steps to replicate:
- Install `stock` with demo.
- Install `3pl_logistic_company`.

Error:
 ```
psycopg2.errors.UniqueViolation: duplicate key value violates unique constraint "stock_package_type_barcode_uniq" DETAIL:  Key (barcode)=(PAL) already exists.
```

Cause:
- [1] and [2] both the records have the same barcode value so the [unique] constraint causes this error.

Solution:
- Changed the barcode value.

[1]: https://github.com/odoo/industry/blob/58e530739f28dc79d97f57cadb39bc778a32ca12/3pl_logistic_company/data/stock_package_type.xml#L7

[2]: https://github.com/odoo/odoo/blob/2d54db3ac0b6d807e580315e2633f3e2b10a700c/addons/stock/data/stock_demo.xml#L24

[unique]: https://github.com/odoo/odoo/blob/2d54db3ac0b6d807e580315e2633f3e2b10a700c/addons/stock/models/stock_package_type.py#L41-L44

No ID