### PR TITLE
[FIX] booking_engine: Preserve planning slot view for inherited xpaths

### DIFF
--- a/booking_engine/__manifest__.py
+++ b/booking_engine/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Booking',
-    'version': '1.22',
+    'version': '1.23',
     'category': 'Hospitality',
     'author': 'Odoo S.A.',
     'depends': [

--- a/booking_engine/data/ir_ui_view.xml
+++ b/booking_engine/data/ir_ui_view.xml
@@ -249,8 +249,9 @@
   <record id="planning_kanban_view" model="ir.ui.view">
     <field name="active" eval="True"/>
     <field name="arch" type="xml">
-      <xpath expr="//field[@name='sale_line_id']" position="replace"/>
-      <xpath expr="//div[@name='sale']" position="replace"/>
+      <xpath expr="//div[@name='sale']" position="attributes">
+        <attribute name="invisible">1</attribute>
+      </xpath>
       <xpath expr="//footer/div" position="before">
         <field name="sale_order_id" widget="many2one" context="{'form_view_ref': 'booking_engine.rental_order_view', 'in_rental_app': 1}"/>
       </xpath>


### PR DESCRIPTION
The `booking_engine` replaced the `sale` container in the planning view, removing the `sale_line_id_div` element. As a result, modules such as `planning_field_service_sale_timesheet`, which inherit the view and extend `sale_line_id_div`, failed to install with an xpath error.

Instead of replacing the sale container, mark it as invisible. This preserves the original view structure, allowing inherited xpaths to continue working while still hiding the sale information in the booking engine.

Task ID: 6368237