### PR TITLE
[FIX] *: define trigger fields if domain on automation

### DIFF
--- a/art_craft/data/base_automation.xml
+++ b/art_craft/data/base_automation.xml
@@ -4,8 +4,8 @@
     <record id="automation_assign_owner_for_consignement_purchase" model="base.automation">
         <field name="name">Set Vendor Name in Assign Owner</field>
         <field name="trigger">on_create_or_write</field>
-        <field name="filter_pre_domain">[("purchase_id.x_is_consignee", "=", False)]</field>
-        <field name="filter_domain">[("purchase_id.x_is_consignee", "!=", False)]</field>
+        <field name="filter_domain">[("purchase_id.x_is_consignee", "!=", False), ("owner_id", "=", False)]</field>
+        <field name="trigger_field_ids" eval="[(6, 0, [])]"/>
         <field name="model_id" ref="stock.model_stock_picking"/>
     </record>
 

--- a/art_craft/data/ir_actions_server.xml
+++ b/art_craft/data/ir_actions_server.xml
@@ -8,8 +8,7 @@
         <field name="base_automation_id" ref="automation_assign_owner_for_consignement_purchase"/>
         <field name="code"><![CDATA[
 for record in records:
-    if record.purchase_id.x_is_consignee:
-        record.write({'owner_id': record.purchase_id.partner_id.id})
+    record.write({'owner_id': record.purchase_id.partner_id.id})
 ]]></field>
     </record>
 

--- a/automobile/data/base_automation.xml
+++ b/automobile/data/base_automation.xml
@@ -5,6 +5,7 @@
         <field name="model_id" ref="stock.model_stock_move_line"/>
         <field name="filter_domain">[("state", "=", "done"), ("picking_code", "=", "outgoing")]</field>
         <field name="filter_pre_domain">["|", ("state", "!=", "done"), ("picking_code", "!=", "outgoing")]</field>
+        <field name="trigger_field_ids" eval="[(6, 0, [ref('stock.field_stock_move_line__state')])]"/>
         <field name="trigger">on_create_or_write</field>
     </record>
 </odoo>

--- a/bike_leasing/data/base_automation.xml
+++ b/bike_leasing/data/base_automation.xml
@@ -17,7 +17,8 @@
         <field name="name">Set Source SO on Recurring Invoice</field>
         <field name="action_server_ids" eval="[(6, 0, [ref('ir_act_server_731')])]"/>
         <field name="trigger">on_create_or_write</field>
-        <field name="filter_domain" eval="[('sale_order_count', '>', 0), ('x_so_id', '=', False)]"/>
+        <field name="filter_domain" eval="[('line_ids.sale_line_ids', '!=', False), ('x_so_id', '=', False)]"/>
+        <field name="trigger_field_ids" eval="[(6, 0, [])]"/>
         <field name="model_id" ref="account.model_account_move"/>
     </record>
 </odoo>

--- a/bike_leasing/data/ir_actions_server.xml
+++ b/bike_leasing/data/ir_actions_server.xml
@@ -33,7 +33,7 @@ for picking in records:
         <field name="state">code</field>
         <field name="code"><![CDATA[
 for move in records:
-    move['x_so_id'] = move.line_ids.filtered(lambda l: l.sale_line_ids != False)[0].sale_line_ids.order_id.id
+    move['x_so_id'] = move.line_ids.sale_line_ids[0].order_id.id
 ]]></field>
     </record>
 </odoo>

--- a/booking_engine/data/base_automation.xml
+++ b/booking_engine/data/base_automation.xml
@@ -12,6 +12,7 @@
     <field name="action_server_ids" eval="[(6, 0, [ref('industry_create_roles')])]"/>
     <field name="trigger">on_create_or_write</field>
     <field name="filter_domain">[("x_is_a_room_offer", "!=", False), ("planning_role_id", "=", False)]</field>
+    <field name="trigger_field_ids" eval="[(6, 0, [])]"/>
     <field name="name">Create role on stay offer creation</field>
   </record>
   <record id="industry_on_product_template_edit" model="base.automation">
@@ -82,8 +83,8 @@
         <field name="model_id" ref="planning.model_planning_slot"/>
         <field name="trigger">on_create_or_write</field>
         <field name="trigger_field_ids" eval="[(6, 0, [
-            ref('planning.field_planning_slot__start_datetime'), 
-            ref('planning.field_planning_slot__end_datetime'), 
+            ref('planning.field_planning_slot__start_datetime'),
+            ref('planning.field_planning_slot__end_datetime'),
             ref('planning.field_planning_slot__resource_ids')
         ])]"/>
         <field name="action_server_ids" eval="[(6, 0, [ref('booking_engine.server_action_update_availability_for_planning_slot')])]"/>
@@ -101,9 +102,9 @@
         <field name="model_id" ref="resource.model_resource_calendar_leaves"/>
         <field name="trigger">on_create_or_write</field>
         <field name="trigger_field_ids" eval="[(6, 0, [
-            ref('resource.field_resource_calendar_leaves__date_from'), 
-            ref('resource.field_resource_calendar_leaves__date_to'), 
-            ref('resource.field_resource_calendar_leaves__resource_id'), 
+            ref('resource.field_resource_calendar_leaves__date_from'),
+            ref('resource.field_resource_calendar_leaves__date_to'),
+            ref('resource.field_resource_calendar_leaves__resource_id'),
             ref('resource.field_resource_calendar_leaves__calendar_id')
         ])]"/>
         <field name="action_server_ids" eval="[(6, 0, [ref('booking_engine.server_action_update_availability_for_resource_calendar_leaves')])]"/>
@@ -121,7 +122,7 @@
         <field name="model_id" ref="resource.model_resource_resource"/>
         <field name="trigger">on_create_or_write</field>
         <field name="trigger_field_ids" eval="[(6, 0, [
-            ref('resource.field_resource_resource__active'), 
+            ref('resource.field_resource_resource__active'),
             ref('resource.field_resource_resource__calendar_id')
         ])]"/>
         <field name="action_server_ids" eval="[(6, 0, [ref('booking_engine.server_action_update_availability_for_resource_resource')])]"/>
@@ -139,8 +140,8 @@
         <field name="model_id" ref="product.model_product_template"/>
         <field name="trigger">on_create_or_write</field>
         <field name="trigger_field_ids" eval="[(6, 0, [
-            ref('booking_engine.product_model_product_template_x_resource_ids_field'), 
-            ref('booking_engine.product_model_product_template_x_is_a_room_offer_field'), 
+            ref('booking_engine.product_model_product_template_x_resource_ids_field'),
+            ref('booking_engine.product_model_product_template_x_is_a_room_offer_field'),
             ref('product.field_product_template__active')
         ])]"/>
         <field name="action_server_ids" eval="[(6, 0, ref('booking_engine.server_action_update_availability_for_product_template'))]"/>

--- a/booking_engine/data/res_config_settings.xml
+++ b/booking_engine/data/res_config_settings.xml
@@ -108,7 +108,7 @@ for cloc_entry in [
         <field name="name">Activate House Keeping</field>
         <field name="action_server_ids" eval="[(6, 0, [ref('x_action_activate_house_keeping')])]"/>
         <field name="model_id" ref="base_setup.model_res_config_settings"/>
-        <field name="on_change_field_ids" eval="[(6, 0, [ref('x_setting_field_house_keeping')])]"/>
+        <field name="trigger_field_ids" eval="[(6, 0, [ref('x_setting_field_house_keeping')])]"/>
         <field name="filter_domain">[('x_module_house_keeping', '=', True)]</field>
         <field name="trigger">on_create_or_write</field>
     </record>
@@ -116,7 +116,7 @@ for cloc_entry in [
         <field name="name">Deactivate House Keeping</field>
         <field name="action_server_ids" eval="[(6, 0, [ref('x_action_deactivate_house_keeping')])]"/>
         <field name="model_id" ref="base_setup.model_res_config_settings"/>
-        <field name="on_change_field_ids" eval="[(6, 0, [ref('x_setting_field_house_keeping')])]"/>
+        <field name="trigger_field_ids" eval="[(6, 0, [ref('x_setting_field_house_keeping')])]"/>
         <field name="filter_domain">[('x_module_house_keeping', '=', False)]</field>
         <field name="trigger">on_create_or_write</field>
     </record>

--- a/condominium/data/base_automation.xml
+++ b/condominium/data/base_automation.xml
@@ -15,6 +15,9 @@
         <field name="trigger">on_create_or_write</field>
         <field name="filter_domain">[("id", "!=", False)]</field>
         <field name="filter_pre_domain">[("id", "=", False)]</field>
+        <field name="trigger_field_ids" model="ir.model.fields" eval="[(6, 0, obj().search([
+            ('model_id', '=', ref('model_x_motion')), ('name', '=', 'id')
+        ]).ids)]"/>
     </record>
     <record id="automation_call_distribute_costs_on_update" model="base.automation">
         <field name="name">Condominium: On Distribution input update</field>

--- a/construction_developer/data/base_automation.xml
+++ b/construction_developer/data/base_automation.xml
@@ -98,6 +98,7 @@
         <field name="filter_domain">[("x_is_template", "!=", False), ("x_product_id", "!=", False), ("x_active", "!=", False)]</field>
         <field name="trigger">on_create_or_write</field>
         <field name="name">Construction: Work Item - On save</field>
+        <field name="trigger_field_ids" eval="[(6, 0, [])]"/>
     </record>
     <record id="base_automation_sol_on_write" model="base.automation">
         <field name="model_id" ref="sale.model_sale_order_line" />
@@ -106,6 +107,7 @@
         <field name="trigger">on_create_or_write</field>
         <field name="name">Construction: SOL - On save</field>
         <field name="filter_domain">[('x_line_work_item_id', '=', False), ('product_id.x_work_item_template_id', '!=', False)]</field>
+        <field name="trigger_field_ids" eval="[(6, 0, [])]"/>
     </record>
     <record id="base_automation_wi_template_without_product_on_write" model="base.automation">
         <field name="model_id" ref="x_work_item_model" />
@@ -114,6 +116,7 @@
         <field name="trigger">on_create_or_write</field>
         <field name="filter_domain">[('x_is_template', '!=', False), ('x_product_id', '=', False)]</field>
         <field name="name">Construction: Work Item - On save of work item template without product</field>
+        <field name="trigger_field_ids" eval="[(6, 0, [])]"/>
     </record>
     <record id="base_automation_on_write_wi_margin_fixed_to_false" model="base.automation">
         <field name="model_id" ref="x_work_item_model" />
@@ -124,7 +127,7 @@
         <field name="trigger_field_ids" eval="[(6, 0, [ref('x_is_margin_fixed_field_x_work_item')])]"/>
         <field name="filter_domain">[('x_is_margin_fixed', '=', False)]</field>
     </record>
-    <!-- 
+    <!--
     this is needed to set a default stage based on the project's
     -->
     <record id="automation_x_remark_write_remark_stage_on_create_or_write" model="base.automation">
@@ -133,6 +136,7 @@
         <field name="trigger">on_create_or_write</field>
         <field name="filter_domain">[('x_stage_id', '=', False)]</field>
         <field name="action_server_ids" eval="[(6, 0, [ref('action_x_remark_write_remark_stage_on_create_or_write')])]"/>
+        <field name="trigger_field_ids" eval="[(6, 0, [])]"/>
     </record>
     <record id="automation_x_remark_generate_x_reference_on_create" model="base.automation">
         <field name="name">Construction Developer: Generate Remark References on Create</field>

--- a/hair_salon/data/base_automation.xml
+++ b/hair_salon/data/base_automation.xml
@@ -1,9 +1,10 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo>
     <record id="delete_subpart_calendar_event" model="base.automation">
-        <field name="name">Break Appointment</field> 
+        <field name="name">Break Appointment</field>
         <field name="model_id" ref="calendar.model_calendar_event"/>
         <field name="action_server_ids" eval="[(6, 0, [ref('break_subpart_calendar_event_server_action')])]"/>
+        <field name="trigger_field_ids" eval="[(6, 0, [])]"/>
         <field name="trigger">on_create_or_write</field>
         <field name="filter_domain">[
             ("x_break_start", "!=", False),

--- a/handyman/data/base_automation.xml
+++ b/handyman/data/base_automation.xml
@@ -7,6 +7,7 @@
         <field name="filter_pre_domain">[("move_id.x_task_id", "!=", False), ("id", "=", False)]</field>
         <field name="filter_domain">[("move_id.x_task_id.project_id.account_id", "!=", False)]</field>
         <field name="action_server_ids" eval="[(6, 0, [ref('action_add_default_analytic_account')])]"/>
+        <field name="trigger_field_ids" eval="[(6, 0, [])]"/>
     </record>
     <record id="base_automation_3" model="base.automation">
         <field name="name">Set section name in task name</field>

--- a/headhunter/data/base_automation.xml
+++ b/headhunter/data/base_automation.xml
@@ -12,6 +12,7 @@
         <field name="filter_domain">[("x_job_id", "!=", False)]</field>
         <field name="filter_pre_domain">[("x_job_id", "=", False)]</field>
         <field name="name">headhunter: Link to Job</field>
+        <field name="trigger_field_ids" eval="[(6, 0, [ref('x_job_id_field')])]"/>
     </record>
     <record id="base_automation_to_clear_availability_date" model="base.automation">
         <field name="name">Clear Availability Date</field>
@@ -19,6 +20,7 @@
         <field name="trigger">on_create_or_write</field>
         <field name="filter_domain">[("x_available", "=", False)]</field>
         <field name="filter_pre_domain">[("x_available", "!=", False)]</field>
+        <field name="trigger_field_ids" eval="[(6, 0, [ref('x_available_field')])]"/>
     </record>
     <!-- automation to copy date from hr.applicant model to x_cv_sent_application model only when mail is sent-->
     <record id="base_automation_to_send_mail" model="base.automation">
@@ -33,6 +35,7 @@
         <field name="trigger">on_create_or_write</field>
         <field name="filter_domain">[("opportunity_id", "!=", False)]</field>
         <field name="filter_pre_domain">[("opportunity_id", "=", False)]</field>
+        <field name="trigger_field_ids" eval="[(6, 0, [ref('sale_crm.field_sale_order__opportunity_id')])]"/>
     </record>
 
     <record id="automation_sync_x_available" model="base.automation">

--- a/real_estate/data/base_automation.xml
+++ b/real_estate/data/base_automation.xml
@@ -7,6 +7,7 @@
         <field name="trigger">on_create_or_write</field>
         <field name="filter_domain">[("x_technical_partner_id", "=", False), ("x_is_properties", "=", True)]</field>
         <field name="filter_pre_domain">[("x_technical_partner_id", "=", False)]</field>
+        <field name="trigger_field_ids" eval="[(6, 0, [ref('field_product_template_is_properties_category')])]"/>
     </record>
     <record id="prevent_publishing_draft_products" model="base.automation">
         <field name="name">Prevent Publishing Draft Products</field>

--- a/tests/test_generic/tests/test_xml.py
+++ b/tests/test_generic/tests/test_xml.py
@@ -190,6 +190,7 @@ class TestEnv(IndustryCase):
                 self._check_forcecreate_external_xmlid(tree, file_name, module)
                 self._check_update_status(tree, file_name)
                 self._check_knowledge_article_is_published(tree, file_name)
+                self._check_trigger_field_ids_is_set(tree, file_name)
                 self._check_knowledge_article_is_locked(tree, file_name)
                 checked_records_with_user = self._check_user_is_set(tree, checked_records_with_user)
                 self._check_duplicate_records(tree, file_name)
@@ -401,6 +402,18 @@ class TestEnv(IndustryCase):
             if is_published_fields:
                 _logger.warning(
                     f"Knowledge article in {file_name} should not have 'is_published' set to True."
+                )
+
+    def _check_trigger_field_ids_is_set(self, root, file_name):
+        for record in root.xpath("//record[@model='base.automation']"):
+            if (
+                record.xpath(".//field[@name='trigger' and (text()='on_create_or_write' or contains(@eval, 'on_create_or_write'))]")
+                and record.xpath(".//field[@name='filter_domain']")
+                and not record.xpath(".//field[@name='trigger_field_ids']")
+            ):
+                _logger.warning(
+                    "Automation %s is missing trigger_field_ids definition (otherwise fields from filter_domain are used).",
+                    record.get('id')
                 )
 
     def _check_knowledge_article_is_locked(self, root, file_name):


### PR DESCRIPTION
Before this commit, the filter_domain definition on a base.automation triggered on_create_or_write would use the fields from the filter_domain to define the trigger_field_ids (this behaviour changed since saas-19.3 at data module loading). While this can make sense for some automations, usually having the same field in filter_pre_domain and filter_domain, this is usually not what is expected, and trigger_field_ids should rather be empty (all fields) or defined more accurately.

This commit fixes this issue by imposing the definition of trigger_field_ids on all base.automation records with a filter_domain and triggered on_create_or_write, and adapt it case by case (False being the behaviour in previous versions).

task-6369105