### PR TITLE
[IMP] booking_engine: remove useless stock dependency

### DIFF
--- a/booking_engine/__manifest__.py
+++ b/booking_engine/__manifest__.py
@@ -14,7 +14,6 @@
         'web_studio',
         'website_appointment',
         'website_sale_renting_planning',
-        'website_sale_stock_renting',
     ],
     'data': [
         'data/product_pricelist.xml',


### PR DESCRIPTION
To prevent double booking from ecommerce, this module relied on stock warning saying that the product was not available. This warning recently moved from website_sale_stock_renting to website_sale_renting. This was the only reason stock was in the dependency, so it can be removed.