### PR TITLE
[FIX] industry_real_estate: prevent out of memory error on attachment related fields

### DIFF
--- a/industry_real_estate/data/ir_model_fields.xml
+++ b/industry_real_estate/data/ir_model_fields.xml
@@ -277,6 +277,7 @@ for property in self:
         <field name="name">x_property_attachment_image_ids</field>
         <field name="field_description">Property Images</field>
         <field name="model_id" ref="analytic.model_account_analytic_account"/>
+        <field name="domain">[('res_model', '=', 'account.analytic.account')]</field>
         <field name="relation">ir.attachment</field>
         <field name="relation_table">x_real_estate_property_attachment_image_rel</field>
         <field name="ttype">many2many</field>
@@ -286,6 +287,7 @@ for property in self:
         <field name="name">x_property_attachment_doc_ids</field>
         <field name="field_description">Property Documents</field>
         <field name="model_id" ref="analytic.model_account_analytic_account"/>
+        <field name="domain">[('res_model', '=', 'account.analytic.account')]</field>
         <field name="relation">ir.attachment</field>
         <field name="relation_table">x_real_estate_property_attachment_doc_rel</field>
         <field name="ttype">many2many</field>


### PR DESCRIPTION
Issue:
Since v19.0, an updated access check on ir.attachment records causes an out-of-memory error when loading models with related fields to attachments, specifically during the fields_get() call.
Standard Python-defined fields bypass this with `bypass_search_access=True` (in #217277).
Industry modules define fields in XML, where this can't be applied.

Fix:
Add a domain to the fields definition to restrict the query result.

opw-6348453