### PR TITLE
[FIX] booking_engine: add missing accommodation field in product view

### DIFF
--- a/booking_engine/data/ir_ui_view.xml
+++ b/booking_engine/data/ir_ui_view.xml
@@ -356,6 +356,19 @@
     <field name="type">form</field>
     <field name="active" eval="True"/>
   </record>
+  <record id="booking_engine_product_template_form_inherit" model="ir.ui.view">
+    <field name="arch" type="xml">
+      <xpath expr="//field[@name='show_qty_update_button']" position="before">
+        <field name="x_accommodation_product"/>
+      </xpath>
+    </field>
+    <field name="inherit_id" ref="product.product_template_only_form_view"/>
+    <field name="mode">extension</field>
+    <field name="model">product.template</field>
+    <field name="name">product.template.form.inherit.booking_engine</field>
+    <field name="type">form</field>
+    <field name="active" eval="True"/>
+  </record>
   <record id="booking_engine_planning_role_view_search" model="ir.ui.view">
     <field name="arch" type="xml">
         <xpath expr="//filter[@name='role_for_material']" position="replace"/>


### PR DESCRIPTION
The `x_accommodation_product` field was supposed to be added to product form view in odoo/industry#2205 but it was forgotten.

task-6150387