### PR TITLE
[FIX] *: prevent error when accessing the event page

### DIFF
--- a/gallery/__manifest__.py
+++ b/gallery/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Gallery',
-    'version': '1.2',
+    'version': '1.3',
     'category': 'Retail',
     'depends': [
         'base_industry_data',

--- a/gallery/demo/website_view.xml
+++ b/gallery/demo/website_view.xml
@@ -372,8 +372,8 @@
   <record id="ir_ui_view_4086" model="ir.ui.view">
     <field name="arch" type="xml">
       <data inherit_id="website_event.index_topbar">
-        <xpath expr="//section[hasclass('o_wevent_index_topbar_filters')]/h1[hasclass('me-auto')]" position="replace">
-          <h1 class="h4 my-0 me-auto pe-sm-4">Upcoming Events</h1>
+        <xpath expr="//section[hasclass('o_wevent_index_topbar_filters')]/div[hasclass('flex-grow-1')]/h1" position="replace">
+          <h1 class="mb-0 h4-fs pe-sm-4">Upcoming Events</h1>
         </xpath>
       </data>
     </field>

--- a/guided_tours/__manifest__.py
+++ b/guided_tours/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Guided Tours',
-    'version': '1.3',
+    'version': '1.4',
     'category': 'Hospitality',
     'author': 'Odoo S.A.',
     'depends': [

--- a/guided_tours/demo/website_view.xml
+++ b/guided_tours/demo/website_view.xml
@@ -214,8 +214,8 @@
   </record>
   <record id="ir_ui_view_3720" model="ir.ui.view">
     <field name="arch" type="xml">
-        <xpath expr="//section[hasclass('o_wevent_index_topbar_filters')]/h1[hasclass('me-auto')]" position="replace">
-          <h1 class="me-auto mb-0 h4">Guided Tours</h1>
+        <xpath expr="//section[hasclass('o_wevent_index_topbar_filters')]/div[hasclass('flex-grow-1')]/h1" position="replace">
+          <h1 class="mb-0 h4-fs">Guided Tours</h1>
         </xpath>
     </field>
     <field name="name">Topbar</field>

--- a/night_clubs/__manifest__.py
+++ b/night_clubs/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Night Clubs',
-    'version': '1.3',
+    'version': '1.4',
     'category': 'Hospitality',
     'author': 'Odoo S.A.',
     'depends': [

--- a/night_clubs/demo/website_view.xml
+++ b/night_clubs/demo/website_view.xml
@@ -338,8 +338,8 @@
     </record>
     <record id="ir_ui_view_3822" model="ir.ui.view">
         <field name="arch" type="xml">
-            <xpath expr="//section[hasclass('o_wevent_index_topbar_filters')]/h1[hasclass('me-auto')]" position="replace">
-                <h2 class="me-auto mb-0 h4">Parties</h2>
+            <xpath expr="//section[hasclass('o_wevent_index_topbar_filters')]/div[hasclass('flex-grow-1')]/h1" position="replace">
+                <h1 class="mb-0 h4-fs">Parties</h1>
             </xpath>
         </field>
         <field name="key">website_event.index_topbar</field>


### PR DESCRIPTION
*: gallery, guided_tours, night_clubs

Currently, an error occurs when a user accesses the event page on the website.

**Steps to Reproduce:**
 - Install the `gallery` with demo data.
 - Go to `Website` > `Events`.

`ValueError: Element '<xpath expr="//section[hasclass(&#39;o_wevent_index_topbar_filters&#39;)]/h1[hasclass(&#39;me-auto&#39;)]">' cannot be located in parent view`

After the [recent commit], which improved the font style changes for the `<h1>` element in 
the website editor, the `<h1>` element was modified. However, the code still references 
an XPath [1] that no longer exists in the main view. As a result, opening the event page 
raises an error. 
The same error also occurs in the guided_tours [2] and night_clubs [3] industries.

This commit ensures that the correct XPath is used in the gallery, guided_tours, and 
night_clubs event pages.

[recent commit]: https://github.com/odoo/odoo/commit/9d04d4d35ffdc4bbe4b6bb8c1c950697c71be95d

[1]- https://github.com/odoo/industry/blob/917876b4d62a7d0ff05706928b672171a4f0a1c9/gallery/demo/website_view.xml#L374-L378

[2]: https://github.com/odoo/industry/blob/917876b4d62a7d0ff05706928b672171a4f0a1c9/guided_tours/demo/website_view.xml#L217-L219

[3]: https://github.com/odoo/industry/blob/917876b4d62a7d0ff05706928b672171a4f0a1c9/night_clubs/demo/website_view.xml#L340-L343

sentry-7609379255