### PR TITLE
[FIX] headhunter: fix res_model domain for attachments

### DIFF
--- a/headhunter/data/ir_model_fields.xml
+++ b/headhunter/data/ir_model_fields.xml
@@ -210,7 +210,7 @@ for job in self:
         <field name="ttype">many2many</field>
         <field name="relation">ir.attachment</field>
         <field name="readonly" eval="True"/>
-        <field name="domain">[('res_model', '=', 'x_cv_sent_application')]</field>
+        <field name="domain">[('res_model', '=', 'hr.applicant')]</field>
     </record>
     <record id="x_cv_sent_ids_field" model="ir.model.fields">
         <field name="name">x_cv_sent_ids</field>


### PR DESCRIPTION
Introduced in https://github.com/odoo/industry/commit/9e2cabf067981db4d12b50cfb4e88df516d5e3ba