### PR TITLE
[FIX] headhunter: fix CV publicly available

### DIFF
--- a/headhunter/__manifest__.py
+++ b/headhunter/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Talent Acquisition',
-    'version': '1.6',
+    'version': '1.7',
     'category': 'Services',
     'depends': [
         'account',

--- a/headhunter/data/ir_actions_server.xml
+++ b/headhunter/data/ir_actions_server.xml
@@ -73,12 +73,12 @@ action['context'] =  {
         <field name="code"><![CDATA[
 if env.context.get('x_from_cv_send'):
     applicant = env['hr.applicant'].browse(record.res_id)
-    applicant.x_shared_cv_ids.write({'public': True})
     env['x_cv_sent_application'].create({
         'x_applicant_id': applicant.id,
         'x_cv_ids': [(6, 0, record.attachment_ids.ids)],
         'x_cv_sent_date': datetime.date.today(),
     })
+    record.attachment_ids.generate_access_token()
     applicant['x_is_cv_sent'] = True,
     applicant['x_published'] = True,
         ]]></field>

--- a/headhunter/data/portal_templates.xml
+++ b/headhunter/data/portal_templates.xml
@@ -55,7 +55,7 @@
                                 <t t-if="app.x_cv_ids">
                                     <t t-foreach="app.x_cv_ids" t-as="cv">
                                         <div>
-                                            <a t-att-href="'/web/content/%s?filename=%s&amp;download=false' % (cv.id, cv.name)" target="_blank">
+                                            <a t-att-href="f'/web/content/{cv.id}?access_token={cv.access_token}&amp;download=false'" target="_blank">
                                                 <i class="fa fa-file-pdf-o me-1"/>
                                                 <t t-out="cv.name or 'View CV'"/>
                                             </a>

--- a/headhunter/demo/website_ir_attachment.xml
+++ b/headhunter/demo/website_ir_attachment.xml
@@ -92,4 +92,8 @@
     <record id="hr_applicant_6" model="hr.applicant">
         <field name="x_shared_cv_ids" eval="[(6,0,[ref('ir_attachment_1237')])]"/>
     </record>
+
+    <function name="generate_access_token" model="ir.attachment">
+        <value eval="[ref('ir_attachment_1231'), ref('ir_attachment_1237')]"/>
+    </function>
 </odoo>

--- a/headhunter/demo/x_cv_sent_application.xml
+++ b/headhunter/demo/x_cv_sent_application.xml
@@ -3,9 +3,11 @@
     <record id="x_cv_sent_application_1" model="x_cv_sent_application">
         <field name="x_cv_sent_date" eval="(DateTime.today() - relativedelta(days=6)).strftime('%Y-%m-%d')"/>
         <field name="x_applicant_id" ref="hr_applicant_4"/>
+        <field name="x_cv_ids" eval="[(6, 0, [ref('ir_attachment_1231')])]"/>
     </record>
     <record id="x_cv_sent_application_3" model="x_cv_sent_application">
         <field name="x_cv_sent_date" eval="(DateTime.today() - relativedelta(days=6)).strftime('%Y-%m-%d')"/>
         <field name="x_applicant_id" ref="hr_applicant_6"/>
+        <field name="x_cv_ids" eval="[(6, 0, [ref('ir_attachment_1237')])]"/>
     </record>
 </odoo>


### PR DESCRIPTION
In the headhunter industry, to able the recruiters to see the CVs, we previously set the documents as public.

Security wise, this is not the best choice and so this commit changes that, by keeping the documents private and using a token in the cv portal page instead.

Task-6389177