### PR TITLE
[FIX] food_trucks: do not raise if pos.session does not exist

### DIFF
--- a/food_trucks/__manifest__.py
+++ b/food_trucks/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Food Trucks',
-    'version': '1.1',
+    'version': '1.2',
     'category': 'Hospitality',
     'author': 'Odoo S.A.',
     'depends': [

--- a/food_trucks/data/pos_config.xml
+++ b/food_trucks/data/pos_config.xml
@@ -5,7 +5,7 @@
   </function>
   <!-- temporarily close the session to remove the floor plans -->
   <function model="pos.session" name="write">
-      <value model="pos.session" eval="ref('pos_restaurant.pos_open_session_2')"/>
+      <value model="pos.session" eval="ref('pos_restaurant.pos_open_session_2', raise_if_not_found=False)"/>
       <value eval="{'state': 'closed'}"/>
   </function>
   <record id="pos_restaurant.pos_config_main_restaurant" model="pos.config" forcecreate="1">
@@ -13,7 +13,7 @@
     <field name="floor_ids" eval="False"/>
   </record>
   <function model="pos.session" name="write">
-      <value model="pos.session" eval="ref('pos_restaurant.pos_open_session_2')"/>
+      <value model="pos.session" eval="ref('pos_restaurant.pos_open_session_2', raise_if_not_found=False)"/>
       <value eval="{'state': 'opening_control'}"/>
   </function>
 </odoo>


### PR DESCRIPTION
Before this commit, the steps to close and re-open standard pos.session in order to edit the pos.config failed without demo data because the session does not exist.

This commit adds `raise_if_not_found=False` to the ref in order to skip the closing of the pos.session if this one does not exist.