### PR TITLE
[FIX] electronic_store: enable required configuration by default

### DIFF
--- a/electronic_store/__manifest__.py
+++ b/electronic_store/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Electronic Store',
-    'version': '1.2',
+    'version': '1.3',
     'category': 'Retail',
     'depends': [
         'crm',

--- a/electronic_store/data/res_config_settings.xml
+++ b/electronic_store/data/res_config_settings.xml
@@ -5,6 +5,7 @@
         <field name="group_lot_on_delivery_slip" eval="1"/>
         <field name="group_project_stages" eval="1"/>
         <field name="group_sale_order_template" eval="1"/>
+        <field name="group_stock_production_lot" eval="1"/>
     </record>
 
     <function name="execute" model="res.config.settings">


### PR DESCRIPTION
Issue
- A bug occurred because a required configuration was not enabled in the module.

Solution
- Enable the required Lots & Serial Numbers configuration so the related functionality works as expected.

TaskId-6383837