### PR TITLE
[FIX] micro_brewery: Fix demo data for BoMs

### DIFF
--- a/micro_brewery/__manifest__.py
+++ b/micro_brewery/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Microbrewery',
-    'version': '2.5',
+    'version': '2.6',
     'category': 'Supply Chain',
     'depends': [
         'account',

--- a/micro_brewery/data/mrp_bom.xml
+++ b/micro_brewery/data/mrp_bom.xml
@@ -83,14 +83,4 @@
         <field name="type">normal</field>
         <field name="x_auto_production" eval="True"/>
     </record>
-    <record id="mrp_bom_17" model="mrp.bom">
-        <field name="product_tmpl_id" ref="product_template_13"/>
-        <field name="product_qty">24.0</field>
-        <field name="type">normal</field>
-    </record>
-    <record id="mrp_bom_18" model="mrp.bom">
-        <field name="product_tmpl_id" ref="product_template_14"/>
-        <field name="product_qty">24.0</field>
-        <field name="type">normal</field>
-    </record>
 </odoo>

--- a/micro_brewery/data/mrp_bom_line.xml
+++ b/micro_brewery/data/mrp_bom_line.xml
@@ -120,12 +120,4 @@
         <field name="product_id" ref="product_product_91"/>
         <field name="product_qty">1.0</field>
     </record>
-    <record id="mrp_bom_line_30" model="mrp.bom.line">
-        <field name="product_id" ref="product_product_16"/>
-        <field name="bom_id" ref="mrp_bom_17"/>
-    </record>
-    <record id="mrp_bom_line_31" model="mrp.bom.line">
-        <field name="product_id" ref="product_product_15"/>
-        <field name="bom_id" ref="mrp_bom_18"/>
-    </record>
 </odoo>


### PR DESCRIPTION
mrp_bom_17 and mrp_bom_18 are created for two products that are using
the auto-bom feature. This results in duplicate BoMs.

To fix, we can remove the BoM definition and let the BoMs be
created by the automation.

opw-6395817