### PR TITLE
[FIX] booking_engine: Adapt to planning role field changes

### DIFF
--- a/booking_engine/__manifest__.py
+++ b/booking_engine/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Booking',
-    'version': '1.23',
+    'version': '1.24',
     'category': 'Hospitality',
     'author': 'Odoo S.A.',
     'depends': [

--- a/booking_engine/data/ir_actions_server.xml
+++ b/booking_engine/data/ir_actions_server.xml
@@ -28,7 +28,7 @@ elif record.x_total > 0:
         <field name="name">Allow only one resource per slot for rooms</field>
         <field name="code"><![CDATA[
 for slot in records:
-    if len(slot.resource_ids) > 1 and any(role.x_is_a_room_offer for role in slot.resource_ids.mapped('role_ids')):
+    if len(slot.resource_ids) > 1 and any(role.x_resource_category == 'stay_offer' for role in slot.resource_ids.mapped('role_ids')):
         raise UserError("Only one room can be assigned to a planning slot")
         ]]></field>
     </record>


### PR DESCRIPTION
The planning role model no longer provides the `x_is_a_room_offer` field, which has been replaced by the `x_resource_category` selection field.

Update the room offer logic accordingly to prevent tracebacks when blocking multiple resources and restore compatibility with the upstream changes.

Affected by: https://github.com/odoo/industry/pull/2061