### PR TITLE
[FIX] members_club: use dynamic blog URL reference

### DIFF
--- a/members_club/__manifest__.py
+++ b/members_club/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Members Club',
-    'version': '1.1',
+    'version': '1.2',
     'category': 'Hospitality',
     'author': 'Odoo S.A.',
     'depends': [

--- a/members_club/demo/website_menu.xml
+++ b/members_club/demo/website_menu.xml
@@ -24,7 +24,7 @@
   </record>
   <record id="website_menu_13" model="website.menu">
     <field name="name">News</field>
-    <field name="url">/blog/news-2</field>
+    <field name="url" model="blog.blog" eval="'blog/%s' % obj().env.ref('members_club.blog_blog_1').id"/>
     <field name="website_id" ref="website.default_website"/>
     <field name="parent_id" ref="website_menu_4"/>
   </record>


### PR DESCRIPTION
Replace the hardcoded blog URL with the blog's `id` to ensure the redirect remains valid if the URL changes.

Task: 6372202