### PR TITLE
[FIX] veterinary_clinic: fix consultation pet details flow

### DIFF
--- a/veterinary_clinic/__manifest__.py
+++ b/veterinary_clinic/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Veterinary Clinic',
-    'version': '1.3',
+    'version': '1.4',
     'category': 'Health and Fitness',
     'author': 'Odoo S.A.',
     'depends': [

--- a/veterinary_clinic/data/ir_model_fields.xml
+++ b/veterinary_clinic/data/ir_model_fields.xml
@@ -35,7 +35,7 @@
   <record id="x_pets_id_pet_line_field" model="ir.model.fields">
     <field name="ttype">many2one</field>
     <field name="copied" eval="True"/>
-    <field name="field_description">X Pets</field>
+    <field name="field_description">Pet</field>
     <field name="model_id" ref="x_pets_line_model_record"/>
     <field name="name">x_pets_id</field>
     <field name="relation">x_pets</field>

--- a/veterinary_clinic/data/ir_ui_view.xml
+++ b/veterinary_clinic/data/ir_ui_view.xml
@@ -155,10 +155,11 @@
       <list editable="bottom" default_order="x_name asc" open_form_view="true">
         <field name="x_sequence" widget="handle"/>
         <field name="x_name"/>
-        <field name="x_pet_name" optional="show"/>
-        <field name="x_species" optional="show"/>
-        <field name="x_breed" optional="show"/>
-        <field name="x_pet_owner" optional="show"/>
+        <field name="x_appointment_date"/>
+        <field name="x_pets_id"/>
+        <field name="x_species" optional="show" readonly="True" options="{'no_open': True}"/>
+        <field name="x_breed" optional="show" readonly="True" options="{'no_open': True}"/>
+        <field name="x_pet_owner" optional="show" readonly="True"/>
       </list>
     </field>
   </record>  
@@ -188,16 +189,17 @@
             </h1>
           </div>
   
-          <group name="group_left" string="Pet Details">
-            <field name="x_appointment_date"/>
-            <field name="x_pet_owner" required="True"/>
-            <field name="x_pet_name" widget="char" required="True"/>
-            <field name="x_microchip_number" required="True"/>
-            <field name="x_species" options="{'create_name_field': 'x_name'}"/>
-            <field name="x_breed" options="{'create_name_field': 'x_name'}"/>
-            <field name="x_aggression_level" widget="badge"/>
-            <field name="x_reproductive_status"/>
-            <field name="x_pet_date_of_birth"/>
+          <group name="pet_details" string="Pet Details">
+            <group name="group_left">
+                <field name="x_appointment_date"/>
+                <field name="x_pet_owner" readonly="True"/>
+                <field name="x_pets_id"/>
+            </group>
+            <group name="group_right">
+                <field name="x_aggression_level" widget="badge"/>
+                <field name="x_reproductive_status"/>
+                <field name="x_pet_date_of_birth"/>
+            </group>
           </group>
   
           <group name="group_right" string="General observations">


### PR DESCRIPTION
Step to reproduce:
- Go to Veterinary → Consultations.
- Create a new consultation.
- Fill in all the pet-related fields.
- Save the record.
- Reopen form view of the consultation.

Current behavior:
- Currently, pet-related information entered manually when creating a consultation. After saving and reopening the record, the entered pet details are no longer displayed.

Solution:
- Add the Pet (x_pet_ids) field to the consultation list view.
- When a pet is selected, automatically populate all related pet information from the selected pet.

Additional changes:
- Set the Species, Breed, and Pet Owner fields as read-only in the list view.
- Removed the Microchip Number, Species, and Breed fields from the form view.
- Adjusted the Pet Details layout to improve field alignment.

TaskId-6392018