### PR TITLE
[FIX] booking_engine: add eci/lco products to invoice:

### DIFF
--- a/booking_engine/__manifest__.py
+++ b/booking_engine/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Booking',
-    'version': '1.24',
+    'version': '1.25',
     'category': 'Hospitality',
     'author': 'Odoo S.A.',
     'depends': [

--- a/booking_engine/data/product_template.xml
+++ b/booking_engine/data/product_template.xml
@@ -19,7 +19,7 @@
         <field name="purchase_ok" eval="False"/>
         <field name="is_favorite" eval="True"/>
         <field name="service_type">manual</field>
-        <field name="invoice_policy">delivery</field>
+        <field name="invoice_policy">order</field>
         <field name="x_accommodation_product">early_checkin</field>
         <field name="list_price">15.0</field>
     </record>
@@ -30,7 +30,7 @@
         <field name="purchase_ok" eval="False"/>
         <field name="is_favorite" eval="True"/>
         <field name="service_type">manual</field>
-        <field name="invoice_policy">delivery</field>
+        <field name="invoice_policy">order</field>
         <field name="x_accommodation_product">late_checkout</field>
         <field name="list_price">15.0</field>
     </record>


### PR DESCRIPTION
Before this commmit, `product_product_early_checkin` and `product_product_late_checkout`s' `invoice_policy` was set to `delivery` resulted to them not being added to the invoices created from the sale orders because these products do not utilize a deliver method.

After this commit, the `invoice_policy` for these products have been set to `order` to allow them to be added to invoices directly based on the quantity on the sale order.

task-6396145