### PR TITLE
[IMP] hotel+: add default Booking Engine dashboard

### DIFF
--- a/booking_engine/__manifest__.py
+++ b/booking_engine/__manifest__.py
@@ -29,6 +29,7 @@
         'data/planning_slot_template.xml',
         'data/product_template.xml',
         'data/ir_actions_server.xml',
+        'data/ir_actions_client.xml',
         'data/base_automation.xml',
         'data/resource_calendar_data.xml',
         'data/ir_cron.xml',
@@ -53,7 +54,12 @@
         'demo/payment_provider_demo.xml',
     ],
     'assets': {
+        'spreadsheet.o_spreadsheet': [
+            'booking_engine/static/src/js/dashboard.js',
+            'booking_engine/static/src/xml/dashboard.xml',
+        ],
         'web.assets_backend': [
+            'booking_engine/static/src/js/dashboard_action_loader.js',
             'booking_engine/static/src/scss/gantt.scss',
         ],
         'web.assets_backend_lazy': [
@@ -67,6 +73,7 @@
         'data/website_view.xml',
         'static/src/scss/gantt.scss',
         'static/src/xml/gantt_pill_flags.xml',
+        'static/src/xml/dashboard.xml',
     ],
     'images': ['images/main.png'],
 }

--- a/booking_engine/data/ir_actions_client.xml
+++ b/booking_engine/data/ir_actions_client.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo noupdate="1">
+    <record id="ir_actions_dashboard_action" model="ir.actions.client">
+        <field name="name">Dashboards</field>
+        <field name="path">accommodation</field>
+        <field name="tag">booking_engine.dashboard_action</field>
+    </record>
+</odoo>

--- a/booking_engine/data/ir_actions_server.xml
+++ b/booking_engine/data/ir_actions_server.xml
@@ -133,7 +133,7 @@ if (project := env['project.project'].search([('x_is_house_keeping_project', '='
     last_midnight = datetime.datetime.today().replace(hour=0, minute=0, second=0, microsecond=0)
     eci_product = env['product.product'].search([('x_accommodation_product', '=', 'early_checkin')], limit=1)
     lco_product = env['product.product'].search([('x_accommodation_product', '=', 'late_checkout')], limit=1)
-    for slot in env['planning.slot'].search([('start_datetime', '<', last_midnight), ('end_datetime', '>=', last_midnight), ('resource_ids.x_category', '=', 'stay_offer')]):
+    for slot in env['planning.slot'].search([('start_datetime', '<', last_midnight), ('end_datetime', '>=', last_midnight), ('resource_ids.x_category', '=', 'stay_offer'), ('sale_line_id', '!=',False)]):
         end_today = slot.end_datetime < last_midnight + datetime.timedelta(hours=24)
         cleaning_points = slot.sale_line_id.product_id.x_checkout_cleaning if end_today else slot.sale_line_id.product_id.x_stayover_cleaning
         if not cleaning_points: continue
@@ -143,7 +143,7 @@ if (project := env['project.project'].search([('x_is_house_keeping_project', '='
             'project_id': project.id,
             'partner_id': slot.sale_line_id.order_id.partner_id.id,
             'description': "Automatically generated house keeping task.",
-            'date_deadline': (last_midnight + datetime.timedelta(hours=24)),
+            'date_deadline': (last_midnight + datetime.timedelta(hours=slot.sale_line_id.product_id.pickup_time)),
             'x_resource_id': slot.resource_ids[:1].id,
             'x_cleaning': 'checkout' if end_today else 'stayover',
             'x_cleaning_points': cleaning_points,

--- a/booking_engine/data/ir_ui_menu.xml
+++ b/booking_engine/data/ir_ui_menu.xml
@@ -1,6 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo auto_sequence="1">
   <menuitem id="booking_engine_menu_root" name="Booking" sequence="1">
+    <menuitem id="booking_engine_dashboard_menu" name="Dashboard" action="ir_actions_dashboard_action"/>
     <menuitem id="booking_engine_schedule_menu" name="Schedule" action="booking_engine_rooms_schedule_action"/>
     <menuitem id="booking_engine_orders_menu" name="Orders" action="booking_engine_rooms_order_action"/>
     <menuitem id="menu_house_keeping" name="House Keeping" groups="group_house_keeping">

--- a/booking_engine/data/spreadsheet_dashboard.xml
+++ b/booking_engine/data/spreadsheet_dashboard.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
     <record id="spreadsheet_dashboard_group_accomodation" model="spreadsheet.dashboard.group">
-        <field name="name">Accomodation</field>
+        <field name="name">Accommodation</field>
         <field name="sequence">0</field>
     </record>
     <record id="spreadsheet_dashboard_1" model="spreadsheet.dashboard">
@@ -10,4 +10,23 @@
         <field name="dashboard_group_id" ref="spreadsheet_dashboard_group_accomodation"/>
         <field name="group_ids" eval="[(6, 0, [ref('base.group_system')])]"/>
     </record>
+    <record id="spreadsheet_dashboard_2" model="spreadsheet.dashboard">
+        <field name="spreadsheet_binary_data" type="bytes" file="booking_engine/static/src/binary/spreadsheet_dashboard/Day-to-day-Operations.osheet.json"/>
+        <field name="name">Day-to-Day Operations</field>
+        <field name="dashboard_group_id" ref="spreadsheet_dashboard_group_accomodation"/>
+        <field name="group_ids" eval="[(6, 0, [ref('base.group_user')])]"/>
+    </record>
+
+    <function model="spreadsheet.dashboard" name="write">
+        <value model="spreadsheet.dashboard" eval="obj().env.ref('booking_engine.spreadsheet_dashboard_2').id"/>
+        <value model="spreadsheet.dashboard" eval="{
+            'spreadsheet_data': (
+                obj().env.ref('booking_engine.spreadsheet_dashboard_2').spreadsheet_data
+            ).replace(
+                '*project_id*', str(obj().env.ref('booking_engine.project_project_1').id)
+            ).replace(
+                '*ready_project_stage*', str(obj().env.ref('booking_engine.project_task_type_18').id)
+            )
+        }"/>
+    </function>
 </odoo>

--- a/booking_engine/static/src/binary/spreadsheet_dashboard/Day-to-day-Operations.osheet.json
+++ b/booking_engine/static/src/binary/spreadsheet_dashboard/Day-to-day-Operations.osheet.json
@@ -1,0 +1,684 @@
+{
+  "version": "19.3.10",
+  "sheets": [
+    {
+      "id": "sheet1",
+      "name": "Dashboard",
+      "colNumber": 14,
+      "rowNumber": 39,
+      "rows": {},
+      "cols": {
+        "0": {
+          "size": 29
+        },
+        "1": {
+          "size": 29
+        },
+        "2": {
+          "size": 170
+        },
+        "3": {
+          "size": 197
+        },
+        "4": {
+          "size": 20
+        },
+        "5": {
+          "size": 29
+        },
+        "6": {
+          "size": 170
+        },
+        "7": {
+          "size": 197
+        },
+        "8": {
+          "size": 20
+        },
+        "9": {
+          "size": 99
+        },
+        "10": {
+          "size": 99
+        },
+        "11": {
+          "size": 99
+        },
+        "12": {
+          "size": 99
+        },
+        "13": {
+          "size": 29
+        }
+      },
+      "merges": [],
+      "cells": {
+        "B2": "[Check In](odoo://view/{\"viewType\":\"graph\",\"action\":{\"domain\":[[\"state\",\"not in\",[\"draft\",\"cancel\",\"sent\"]]],\"context\":{\"group_by\":[\"date:month\"],\"graph_measure\":\"price_subtotal\",\"graph_mode\":\"line\",\"graph_groupbys\":[\"date:month\"]},\"modelName\":\"sale.report\",\"views\":[[false,\"graph\"],[false,\"pivot\"],[false,\"search\"]]},\"threshold\":0,\"name\":\"Sales Analysis\"})",
+        "B5": "[Orders](odoo://view/{\"viewType\":\"kanban\",\"action\":{\"xmlId\":\"booking_engine.booking_engine_rooms_order_action\",\"domain\":[\"&\",[\"x_order_involves_room\",\"=\",true],\"&\",[\"is_rental_order\",\"=\",true],\"&\",\"&\",[\"next_action_date\",\">=\",\"today\"],[\"next_action_date\",\"<\",\"today +1d\"],[\"rental_status\",\"=\",\"pickup\"]],\"context\":{\"group_by\":[]},\"modelName\":\"sale.order\",\"views\":[[false,\"kanban\"],[false,\"list\"],[false,\"form\"],[false,\"search\"]]},\"threshold\":0,\"name\":\"Orders\"})",
+        "C3": "=\"[Pending (\"&SUMIF(Computations!$A$3:$A$4,\"Reserved\",Computations!$B$3:$B$4)&\"/\"&SUM(Computations!$B$3:$B$4)&\")](odoo://view/\"&\"{\"&CHAR(34)&\"viewType\"&CHAR(34)&\": \"&CHAR(34)&\"kanban\"&CHAR(34)&\", \"&CHAR(34)&\"action\"&CHAR(34)&\": {\"&CHAR(34)&\"xmlId\"&CHAR(34)&\": \"&CHAR(34)&\"booking_engine.booking_engine_rooms_order_action\"&CHAR(34)&\", \"&CHAR(34)&\"domain\"&CHAR(34)&\": [\"&CHAR(34)&\"&\"&CHAR(34)&\", [\"&CHAR(34)&\"x_order_involves_room\"&CHAR(34)&\", \"&CHAR(34)&\"=\"&CHAR(34)&\", true], \"&CHAR(34)&\"&\"&CHAR(34)&\", [\"&CHAR(34)&\"is_rental_order\"&CHAR(34)&\", \"&CHAR(34)&\"=\"&CHAR(34)&\", true], \"&CHAR(34)&\"&\"&CHAR(34)&\", \"&CHAR(34)&\"&\"&CHAR(34)&\", [\"&CHAR(34)&\"next_action_date\"&CHAR(34)&\", \"&CHAR(34)&\">=\"&CHAR(34)&\", \"&CHAR(34)&\"today\"&CHAR(34)&\"], [\"&CHAR(34)&\"next_action_date\"&CHAR(34)&\", \"&CHAR(34)&\"<\"&CHAR(34)&\", \"&CHAR(34)&\"today +1d\"&CHAR(34)&\"], [\"&CHAR(34)&\"rental_status\"&CHAR(34)&\", \"&CHAR(34)&\"=\"&CHAR(34)&\", \"&CHAR(34)&\"pickup\"&CHAR(34)&\"]], \"&CHAR(34)&\"context\"&CHAR(34)&\": {\"&CHAR(34)&\"group_by\"&CHAR(34)&\": []}, \"&CHAR(34)&\"modelName\"&CHAR(34)&\": \"&CHAR(34)&\"sale.order\"&CHAR(34)&\", \"&CHAR(34)&\"views\"&CHAR(34)&\": [[false, \"&CHAR(34)&\"kanban\"&CHAR(34)&\"], [false, \"&CHAR(34)&\"list\"&CHAR(34)&\"], [false, \"&CHAR(34)&\"form\"&CHAR(34)&\"], [false, \"&CHAR(34)&\"search\"&CHAR(34)&\"]]}, \"&CHAR(34)&\"threshold\"&CHAR(34)&\": 0, \"&CHAR(34)&\"name\"&CHAR(34)&\": \"&CHAR(34)&\"Orders\"&CHAR(34)&\"}\"&\")\"",
+        "C19": "Pending Early Check In",
+        "C20": "=ODOO.LIST(1,80)",
+        "D3": "=\"[Done (\"&SUMIF(Computations!$A$3:$A$4,\"Pickedup\",Computations!$B$3:$B$4)&\"/\"&SUM(Computations!$B$3:$B$4)&\")](odoo://view/\"&\"{\"&CHAR(34)&\"viewType\"&CHAR(34)&\": \"&CHAR(34)&\"kanban\"&CHAR(34)&\", \"&CHAR(34)&\"action\"&CHAR(34)&\": {\"&CHAR(34)&\"xmlId\"&CHAR(34)&\": \"&CHAR(34)&\"booking_engine.booking_engine_rooms_order_action\"&CHAR(34)&\", \"&CHAR(34)&\"domain\"&CHAR(34)&\": [\"&CHAR(34)&\"&\"&CHAR(34)&\", [\"&CHAR(34)&\"x_order_involves_room\"&CHAR(34)&\", \"&CHAR(34)&\"=\"&CHAR(34)&\", true], \"&CHAR(34)&\"&\"&CHAR(34)&\", [\"&CHAR(34)&\"is_rental_order\"&CHAR(34)&\", \"&CHAR(34)&\"=\"&CHAR(34)&\", true], \"&CHAR(34)&\"&\"&CHAR(34)&\", \"&CHAR(34)&\"&\"&CHAR(34)&\", [\"&CHAR(34)&\"next_action_date\"&CHAR(34)&\", \"&CHAR(34)&\">=\"&CHAR(34)&\", \"&CHAR(34)&\"today\"&CHAR(34)&\"], [\"&CHAR(34)&\"next_action_date\"&CHAR(34)&\", \"&CHAR(34)&\"<\"&CHAR(34)&\", \"&CHAR(34)&\"today +1d\"&CHAR(34)&\"], [\"&CHAR(34)&\"rental_status\"&CHAR(34)&\", \"&CHAR(34)&\"=\"&CHAR(34)&\", \"&CHAR(34)&\"return\"&CHAR(34)&\"]], \"&CHAR(34)&\"context\"&CHAR(34)&\": {\"&CHAR(34)&\"group_by\"&CHAR(34)&\": []}, \"&CHAR(34)&\"modelName\"&CHAR(34)&\": \"&CHAR(34)&\"sale.order\"&CHAR(34)&\", \"&CHAR(34)&\"views\"&CHAR(34)&\": [[false, \"&CHAR(34)&\"kanban\"&CHAR(34)&\"], [false, \"&CHAR(34)&\"list\"&CHAR(34)&\"], [false, \"&CHAR(34)&\"form\"&CHAR(34)&\"], [false, \"&CHAR(34)&\"search\"&CHAR(34)&\"]]}, \"&CHAR(34)&\"threshold\"&CHAR(34)&\": 0, \"&CHAR(34)&\"name\"&CHAR(34)&\": \"&CHAR(34)&\"Orders\"&CHAR(34)&\"}\"&\")\"",
+        "F2": "[Check Out](odoo://view/{\"viewType\":\"graph\",\"action\":{\"domain\":[[\"state\",\"not in\",[\"draft\",\"cancel\",\"sent\"]]],\"context\":{\"group_by\":[\"date:month\"],\"graph_measure\":\"price_subtotal\",\"graph_mode\":\"line\",\"graph_groupbys\":[\"date:month\"]},\"modelName\":\"sale.report\",\"views\":[[false,\"graph\"],[false,\"pivot\"],[false,\"search\"]]},\"threshold\":0,\"name\":\"Sales Analysis\"})",
+        "G3": "=\"[Pending (\"&SUMIF(Computations!$A$8:$A$9,\"Pickedup\",Computations!$B$8:$B$9)&\"/\"&SUM(Computations!$B$8:$B$9)&\")](odoo://view/\"&\"{\"&CHAR(34)&\"viewType\"&CHAR(34)&\": \"&CHAR(34)&\"kanban\"&CHAR(34)&\", \"&CHAR(34)&\"action\"&CHAR(34)&\": {\"&CHAR(34)&\"xmlId\"&CHAR(34)&\": \"&CHAR(34)&\"booking_engine.booking_engine_rooms_order_action\"&CHAR(34)&\", \"&CHAR(34)&\"domain\"&CHAR(34)&\": [\"&CHAR(34)&\"&\"&CHAR(34)&\", [\"&CHAR(34)&\"x_order_involves_room\"&CHAR(34)&\", \"&CHAR(34)&\"=\"&CHAR(34)&\", true], \"&CHAR(34)&\"&\"&CHAR(34)&\", [\"&CHAR(34)&\"is_rental_order\"&CHAR(34)&\", \"&CHAR(34)&\"=\"&CHAR(34)&\", true], \"&CHAR(34)&\"&\"&CHAR(34)&\", \"&CHAR(34)&\"&\"&CHAR(34)&\", [\"&CHAR(34)&\"rental_return_date\"&CHAR(34)&\", \"&CHAR(34)&\">=\"&CHAR(34)&\", \"&CHAR(34)&\"today\"&CHAR(34)&\"], [\"&CHAR(34)&\"rental_return_date\"&CHAR(34)&\", \"&CHAR(34)&\"<\"&CHAR(34)&\", \"&CHAR(34)&\"today +1d\"&CHAR(34)&\"], [\"&CHAR(34)&\"rental_status\"&CHAR(34)&\", \"&CHAR(34)&\"=\"&CHAR(34)&\", \"&CHAR(34)&\"return\"&CHAR(34)&\"]], \"&CHAR(34)&\"context\"&CHAR(34)&\": {\"&CHAR(34)&\"group_by\"&CHAR(34)&\": []}, \"&CHAR(34)&\"modelName\"&CHAR(34)&\": \"&CHAR(34)&\"sale.order\"&CHAR(34)&\", \"&CHAR(34)&\"views\"&CHAR(34)&\": [[false, \"&CHAR(34)&\"kanban\"&CHAR(34)&\"], [false, \"&CHAR(34)&\"list\"&CHAR(34)&\"], [false, \"&CHAR(34)&\"form\"&CHAR(34)&\"], [false, \"&CHAR(34)&\"search\"&CHAR(34)&\"]]}, \"&CHAR(34)&\"threshold\"&CHAR(34)&\": 0, \"&CHAR(34)&\"name\"&CHAR(34)&\": \"&CHAR(34)&\"Orders\"&CHAR(34)&\"}\"&\")\"",
+        "G19": "Pending Late Check Out",
+        "G20": "=ODOO.LIST(2,80)",
+        "H3": "=\"[Done (\"&SUMIF(Computations!$A$8:$A$9,\"Returned\",Computations!$B$8:$B$9)&\"/\"&SUM(Computations!$B$8:$B$9)&\")](odoo://view/\"&\"{\"&CHAR(34)&\"viewType\"&CHAR(34)&\": \"&CHAR(34)&\"kanban\"&CHAR(34)&\", \"&CHAR(34)&\"action\"&CHAR(34)&\": {\"&CHAR(34)&\"xmlId\"&CHAR(34)&\": \"&CHAR(34)&\"booking_engine.booking_engine_rooms_order_action\"&CHAR(34)&\", \"&CHAR(34)&\"domain\"&CHAR(34)&\": [\"&CHAR(34)&\"&\"&CHAR(34)&\", [\"&CHAR(34)&\"x_order_involves_room\"&CHAR(34)&\", \"&CHAR(34)&\"=\"&CHAR(34)&\", true], \"&CHAR(34)&\"&\"&CHAR(34)&\", [\"&CHAR(34)&\"is_rental_order\"&CHAR(34)&\", \"&CHAR(34)&\"=\"&CHAR(34)&\", true], \"&CHAR(34)&\"&\"&CHAR(34)&\", \"&CHAR(34)&\"&\"&CHAR(34)&\", [\"&CHAR(34)&\"next_action_date\"&CHAR(34)&\", \"&CHAR(34)&\">=\"&CHAR(34)&\", \"&CHAR(34)&\"today\"&CHAR(34)&\"], [\"&CHAR(34)&\"next_action_date\"&CHAR(34)&\", \"&CHAR(34)&\"<\"&CHAR(34)&\", \"&CHAR(34)&\"today +1d\"&CHAR(34)&\"], [\"&CHAR(34)&\"rental_status\"&CHAR(34)&\", \"&CHAR(34)&\"=\"&CHAR(34)&\", \"&CHAR(34)&\"returned\"&CHAR(34)&\"]], \"&CHAR(34)&\"context\"&CHAR(34)&\": {\"&CHAR(34)&\"group_by\"&CHAR(34)&\": []}, \"&CHAR(34)&\"modelName\"&CHAR(34)&\": \"&CHAR(34)&\"sale.order\"&CHAR(34)&\", \"&CHAR(34)&\"views\"&CHAR(34)&\": [[false, \"&CHAR(34)&\"kanban\"&CHAR(34)&\"], [false, \"&CHAR(34)&\"list\"&CHAR(34)&\"], [false, \"&CHAR(34)&\"form\"&CHAR(34)&\"], [false, \"&CHAR(34)&\"search\"&CHAR(34)&\"]]}, \"&CHAR(34)&\"threshold\"&CHAR(34)&\": 0, \"&CHAR(34)&\"name\"&CHAR(34)&\": \"&CHAR(34)&\"Orders\"&CHAR(34)&\"}\"&\")\"",
+        "J2": "[House Keeping](odoo://view/{\"viewType\":\"graph\",\"action\":{\"domain\":[[\"state\",\"not in\",[\"draft\",\"cancel\",\"sent\"]]],\"context\":{\"group_by\":[\"date:month\"],\"graph_measure\":\"price_subtotal\",\"graph_mode\":\"line\",\"graph_groupbys\":[\"date:month\"]},\"modelName\":\"sale.report\",\"views\":[[false,\"graph\"],[false,\"pivot\"],[false,\"search\"]]},\"threshold\":0,\"name\":\"Sales Analysis\"})",
+        "K3": "=\"Pending (\"&Computations!$B$12&\"/\"&sum(Computations!$B$12:$B$13)&\")\"",
+        "L3": {
+          "S": [
+            "Done (",
+            "=",
+            "="
+          ],
+          "R": "+R1|="
+        }
+      },
+      "styles": {
+        "A2:N2": 1,
+        "A18:N18": 1,
+        "A19:D19": 2,
+        "F19:H19": 2,
+        "N19": 2,
+        "C3": 3,
+        "G3": 3,
+        "K3": 3,
+        "D3": 4,
+        "H3": 4,
+        "L3": 4,
+        "E20": 5,
+        "I20:M20": 5
+      },
+      "formats": {
+        "A21:B22": 1,
+        "F21:F22": 1,
+        "N21:N22": 1
+      },
+      "borders": {
+        "B2:D2": 1,
+        "F2:H2": 1,
+        "J2:M2": 1
+      },
+      "conditionalFormats": [],
+      "dataValidationRules": [],
+      "figures": [
+        {
+          "id": "e0939785-05d9",
+          "col": 1,
+          "row": 2,
+          "offset": {
+            "x": 0,
+            "y": 22
+          },
+          "width": 397,
+          "height": 335,
+          "tag": "chart",
+          "data": {
+            "dataSource": {
+              "labelRange": "Computations!A3:A4",
+              "type": "range",
+              "dataSets": [
+                {
+                  "dataSetId": "70832acb-537c",
+                  "dataRange": "Computations!B3:B4"
+                }
+              ],
+              "dataSetsHaveTitle": false
+            },
+            "dataSetStyles": {},
+            "legendPosition": "top",
+            "title": {},
+            "type": "pie",
+            "aggregated": false,
+            "isDoughnut": false,
+            "humanize": true,
+            "showValues": false,
+            "slicesColors": [
+              "#F1C232",
+              "#6AA84F"
+            ],
+            "annotationText": "",
+            "chartId": "116fc185-a127"
+          }
+        },
+        {
+          "id": "cb2c8c61-f5d1",
+          "col": 5,
+          "row": 2,
+          "offset": {
+            "x": 0,
+            "y": 22
+          },
+          "width": 396,
+          "height": 335,
+          "tag": "chart",
+          "data": {
+            "dataSource": {
+              "labelRange": "Computations!A8:A9",
+              "type": "range",
+              "dataSets": [
+                {
+                  "dataSetId": "a3a84f66-3d75",
+                  "dataRange": "Computations!B8:B9"
+                }
+              ],
+              "dataSetsHaveTitle": false
+            },
+            "dataSetStyles": {},
+            "legendPosition": "top",
+            "title": {},
+            "type": "pie",
+            "aggregated": false,
+            "isDoughnut": false,
+            "humanize": true,
+            "showValues": false,
+            "slicesColors": [
+              "#F1C232",
+              "#6AA84F"
+            ],
+            "annotationText": "",
+            "chartId": "beeca729-c25b"
+          }
+        },
+        {
+          "id": "5f799a15-9409",
+          "col": 8,
+          "row": 2,
+          "offset": {
+            "x": 19,
+            "y": 22
+          },
+          "width": 397,
+          "height": 335,
+          "tag": "chart",
+          "data": {
+            "dataSource": {
+              "labelRange": "Computations!C12:C13",
+              "type": "range",
+              "dataSets": [
+                {
+                  "dataSetId": "16290dad-b7bc",
+                  "dataRange": "Computations!B12:B13"
+                }
+              ],
+              "dataSetsHaveTitle": false
+            },
+            "dataSetStyles": {},
+            "legendPosition": "top",
+            "title": {},
+            "type": "pie",
+            "aggregated": false,
+            "isDoughnut": false,
+            "humanize": true,
+            "showValues": false,
+            "slicesColors": [
+              "#F1C232",
+              "#6FA8DC",
+              "#93C47D"
+            ],
+            "annotationText": "",
+            "chartId": "222e338b-b0ce"
+          }
+        }
+      ],
+      "tables": [
+        {
+          "range": "C20",
+          "type": "dynamic",
+          "config": {
+            "hasFilters": false,
+            "totalRow": false,
+            "firstColumn": false,
+            "lastColumn": false,
+            "numberOfHeaders": 1,
+            "bandedRows": true,
+            "bandedColumns": false,
+            "styleId": "None",
+            "automaticAutofill": false
+          }
+        },
+        {
+          "range": "G20",
+          "type": "dynamic",
+          "config": {
+            "hasFilters": false,
+            "totalRow": false,
+            "firstColumn": false,
+            "lastColumn": false,
+            "numberOfHeaders": 1,
+            "bandedRows": true,
+            "bandedColumns": false,
+            "styleId": "None",
+            "automaticAutofill": false
+          }
+        }
+      ],
+      "areGridLinesVisible": true,
+      "isVisible": true,
+      "headerGroups": {
+        "ROW": [],
+        "COL": []
+      },
+      "defaultStyle": {
+        "colDefault": {},
+        "rowDefault": {
+          "2": 7,
+          "18": 8,
+          "19": 9
+        },
+        "sheetDefault": 6
+      },
+      "comments": {}
+    },
+    {
+      "id": "4586cb21-c4e1",
+      "name": "Computations",
+      "colNumber": 26,
+      "rowNumber": 101,
+      "rows": {},
+      "cols": {
+        "0": {
+          "size": 76
+        },
+        "1": {
+          "size": 75
+        }
+      },
+      "merges": [],
+      "cells": {
+        "A1": "Pickups",
+        "A2": "=PIVOT(4)",
+        "A6": "Check outs",
+        "A7": "=PIVOT(5)",
+        "A11": "House keeping",
+        "A12": "=PIVOT(7)",
+        "A13": {
+          "N": "+-1"
+        },
+        "C12": "Pending",
+        "C13": "Done"
+      },
+      "styles": {
+        "A1": 1,
+        "A6": 1,
+        "A11": 1
+      },
+      "formats": {},
+      "borders": {
+        "A1": 1,
+        "A6": 1,
+        "A11": 1
+      },
+      "conditionalFormats": [],
+      "dataValidationRules": [],
+      "figures": [],
+      "tables": [],
+      "areGridLinesVisible": true,
+      "isVisible": true,
+      "isLocked": false,
+      "headerGroups": {
+        "ROW": [],
+        "COL": []
+      },
+      "comments": {}
+    }
+  ],
+  "styles": {
+    "1": {
+      "textColor": "#01666b",
+      "bold": true,
+      "fontSize": 16
+    },
+    "2": {
+      "textColor": "#01666b"
+    },
+    "3": {
+      "align": "right"
+    },
+    "4": {
+      "align": "left"
+    },
+    "5": {
+      "bold": false
+    },
+    "6": {},
+    "7": {
+      "align": "center",
+      "bold": true
+    },
+    "8": {
+      "fontSize": 11
+    },
+    "9": {
+      "bold": true
+    }
+  },
+  "formats": {
+    "1": "@"
+  },
+  "borders": {
+    "1": {
+      "bottom": {
+        "style": "thin",
+        "color": "#CCCCCC"
+      }
+    }
+  },
+  "revisionId": "1fc73ad5-d814-4832-8e3a-1e99d95ce0ac",
+  "uniqueFigureIds": true,
+  "settings": {
+    "locale": {
+      "name": "English (US)",
+      "code": "en_US",
+      "thousandsSeparator": ",",
+      "decimalSeparator": ".",
+      "dateFormat": "mm/dd/yyyy",
+      "timeFormat": "hh:mm:ss a",
+      "formulaArgSeparator": ",",
+      "weekStart": 7
+    }
+  },
+  "pivots": {
+    "d84b8bd8-4570": {
+      "type": "ODOO",
+      "name": "Sales Order",
+      "model": "sale.order",
+      "rows": [
+        {
+          "fieldName": "rental_status",
+          "order": "asc"
+        }
+      ],
+      "columns": [],
+      "measures": [
+        {
+          "id": "amount_total:count",
+          "fieldName": "amount_total",
+          "aggregator": "count"
+        }
+      ],
+      "style": {
+        "tableStyleId": "PivotTableStyleMedium12",
+        "displayTotals": false,
+        "displayColumnHeaders": true,
+        "displayMeasuresRow": false
+      },
+      "filters": [],
+      "domain": [
+        "&",
+        "&",
+        [
+          "rental_start_date",
+          ">=",
+          "today"
+        ],
+        [
+          "rental_start_date",
+          "<",
+          "today +1d"
+        ],
+        [
+          "rental_status",
+          "in",
+          [
+            "pickup",
+            "return"
+          ]
+        ]
+      ],
+      "formulaId": "4",
+      "fieldMatching": {}
+    },
+    "c6d83582-738d": {
+      "type": "ODOO",
+      "name": "Sales Order",
+      "model": "sale.order",
+      "rows": [
+        {
+          "fieldName": "rental_status",
+          "order": "asc"
+        }
+      ],
+      "columns": [],
+      "measures": [
+        {
+          "id": "amount_total:count",
+          "fieldName": "amount_total",
+          "aggregator": "count"
+        }
+      ],
+      "style": {
+        "tableStyleId": "PivotTableStyleMedium12",
+        "displayMeasuresRow": false,
+        "displayColumnHeaders": true,
+        "displayTotals": false
+      },
+      "filters": [],
+      "domain": [
+        "&",
+        "&",
+        [
+          "rental_return_date",
+          ">=",
+          "today"
+        ],
+        [
+          "rental_return_date",
+          "<",
+          "today +1d"
+        ],
+        [
+          "rental_status",
+          "in",
+          [
+            "return",
+            "returned"
+          ]
+        ]
+      ],
+      "formulaId": "5",
+      "fieldMatching": {}
+    },
+    "966fca9c-b60f": {
+      "type": "ODOO",
+      "name": "Task",
+      "model": "project.task",
+      "rows": [],
+      "columns": [],
+      "measures": [
+        {
+          "id": "__count:count",
+          "fieldName": "__count",
+          "aggregator": "count"
+        }
+      ],
+      "style": {
+        "tableStyleId": "PivotTableStyleMedium12",
+        "displayTotals": false,
+        "displayMeasuresRow": false,
+        "displayColumnHeaders": false
+      },
+      "domain": [
+        "&",
+        "&",
+        "&",
+        [
+          "project_id.id",
+          "=",
+          "*project_id*"
+        ],
+        [
+          "date_deadline",
+          ">=",
+          "today"
+        ],
+        [
+          "date_deadline",
+          "<",
+          "today +1d"
+        ],
+        [
+          "stage_id.id",
+          "=",
+          "*ready_project_stage*"
+        ]
+      ],
+      "filters": [],
+      "formulaId": "6",
+      "fieldMatching": {}
+    },
+    "c0e62ec3-d35b": {
+      "type": "ODOO",
+      "name": "Task",
+      "model": "project.task",
+      "rows": [],
+      "columns": [],
+      "measures": [
+        {
+          "id": "__count:count",
+          "fieldName": "__count",
+          "aggregator": "count"
+        }
+      ],
+      "style": {
+        "tableStyleId": "PivotTableStyleMedium12",
+        "displayMeasuresRow": false,
+        "displayColumnHeaders": false,
+        "displayTotals": false
+      },
+      "domain": [
+        "&",
+        "&",
+        "&",
+        [
+          "project_id.id",
+          "=",
+          "*project_id*"
+        ],
+        [
+          "date_deadline",
+          ">=",
+          "today"
+        ],
+        [
+          "date_deadline",
+          "<",
+          "today +1d"
+        ],
+        [
+          "stage_id.id",
+          "!=",
+          "*ready_project_stage*"
+        ]
+      ],
+      "filters": [],
+      "formulaId": "7",
+      "fieldMatching": {}
+    }
+  },
+  "pivotNextId": 9,
+  "customTableStyles": {},
+  "namedRanges": {},
+  "globalFilters": [],
+  "lists": {
+    "1": {
+      "model": "sale.order",
+      "name": "Sales Order",
+      "columns": [
+        {
+          "name": "name",
+          "string": "Number",
+          "hidden": false
+        },
+        {
+          "name": "partner_id",
+          "string": "Customer",
+          "hidden": false
+        }
+      ],
+      "domain": [
+        "&",
+        "&",
+        "&",
+        [
+          "rental_start_date",
+          ">=",
+          "today"
+        ],
+        [
+          "rental_start_date",
+          "<",
+          "today +1d"
+        ],
+        [
+          "rental_status",
+          "=",
+          "pickup"
+        ],
+        [
+          "order_line.product_template_id.x_accommodation_product",
+          "=",
+          "early_checkin"
+        ]
+      ],
+      "context": {},
+      "orderBy": [
+        {
+          "name": "rental_start_date",
+          "asc": false
+        }
+      ],
+      "fieldMatching": {}
+    },
+    "2": {
+      "model": "sale.order",
+      "name": "Sales Order",
+      "columns": [
+        {
+          "name": "name",
+          "string": "Number"
+        },
+        {
+          "name": "partner_id",
+          "string": "Customer"
+        }
+      ],
+      "domain": [
+        "&",
+        "&",
+        "&",
+        [
+          "rental_return_date",
+          ">=",
+          "today"
+        ],
+        [
+          "rental_return_date",
+          "<",
+          "today +1d"
+        ],
+        [
+          "rental_status",
+          "=",
+          "return"
+        ],
+        [
+          "order_line.product_template_id.x_accommodation_product",
+          "=",
+          "late_checkout"
+        ]
+      ],
+      "context": {},
+      "orderBy": [],
+      "fieldMatching": {}
+    }
+  },
+  "listNextId": 3,
+  "odooLinkReferences": {
+    "222e338b-b0ce": {
+      "type": "odooMenu",
+      "odooMenuId": "booking_engine.menu_tasks_house_keeping"
+    }
+  }
+}

--- a/booking_engine/static/src/js/dashboard.js
+++ b/booking_engine/static/src/js/dashboard.js
@@ -1,0 +1,34 @@
+import { onWillStart } from "@odoo/owl";
+import { registry } from "@web/core/registry";
+import { SpreadsheetDashboardAction } from '@spreadsheet_dashboard/bundle/dashboard_action/dashboard_action';
+
+class BookingEngineDashboardAction extends SpreadsheetDashboardAction {
+    static template = "booking_engine.DashboardAction";
+
+    setup() {
+        super.setup();
+        this.accommodationIds = ["spreadsheet_dashboard_2"]
+        this.accommodationDashboardResIds = [];
+
+        onWillStart(async () => {
+            this.accommodationDashboardResIds = await Promise.all(
+                this.accommodationIds.map(async (xmlId) => {
+                    const [, resId] = await this.orm.call("ir.model.data", "check_object_reference", ["booking_engine", xmlId]);
+                    return resId;
+                })
+            );
+        });
+    }
+
+    getDashboardGroups() {
+        const groups = this.loader.getDashboardGroups();
+        groups.forEach(group => {
+            group.dashboards = group.dashboards.filter(
+                dashboard => this.accommodationDashboardResIds.includes(dashboard.data.id)
+            );
+        });
+        return groups;
+    }
+}
+
+registry.category("actions").add("booking_engine.dashboard_action", BookingEngineDashboardAction, { force: true });

--- a/booking_engine/static/src/js/dashboard_action_loader.js
+++ b/booking_engine/static/src/js/dashboard_action_loader.js
@@ -1,0 +1,3 @@
+import { addSpreadsheetActionLazyLoader } from "@spreadsheet/assets_backend/spreadsheet_action_loader";
+
+addSpreadsheetActionLazyLoader("booking_engine.dashboard_action");

--- a/booking_engine/static/src/xml/dashboard.xml
+++ b/booking_engine/static/src/xml/dashboard.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates>
+    <t t-name="booking_engine.DashboardAction.Expanded" t-inherit="spreadsheet_dashboard.DashboardAction.Expanded">
+        <xpath expr="//header[hasclass('o_search_panel_section_header')]" position="replace"/>
+    </t>
+    <div t-name="booking_engine.DashboardAction" t-inherit="spreadsheet_dashboard.DashboardAction">
+        <xpath expr="//ControlPanel" position="replace">
+            <ControlPanel display="this.controlPanelDisplay"/>
+        </xpath>
+        <xpath expr="//t[@t-call='spreadsheet_dashboard.DashboardAction.Expanded']" position="replace">
+            <t t-if="this.state.sidebarExpanded" t-call="booking_engine.DashboardAction.Expanded"/>
+        </xpath>
+    </div>
+</templates>

--- a/campsite/__manifest__.py
+++ b/campsite/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Campsite',
-    'version': '1.8',
+    'version': '1.9',
     'category': 'Hospitality',
     'author': 'Odoo S.A.',
     'depends': [
@@ -27,6 +27,7 @@
         'data/views.xml',
         'data/res_config_settings.xml',
         'data/spreadsheet_dashboard.xml',
+        'data/ir_actions_client.xml',
     ],
     'demo': [
         'demo/res_company.xml',

--- a/campsite/data/ir_actions_client.xml
+++ b/campsite/data/ir_actions_client.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo noupdate="1">
+    <record id="booking_engine.ir_actions_dashboard_action" model="ir.actions.client" forcecreate="0">
+        <field name="path">campsite</field>
+    </record>
+</odoo>

--- a/guest_house/__manifest__.py
+++ b/guest_house/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Guest House',
-    'version': '1.7',
+    'version': '1.8',
     'category': 'Hospitality',
     'author': 'Odoo S.A.',
     'depends': [
@@ -21,6 +21,7 @@
         'data/website_view.xml',
         'data/res_config_settings.xml',
         'data/spreadsheet_dashboard.xml',
+        'data/ir_actions_client.xml',
     ],
     'demo': [
         'demo/res_company.xml',

--- a/guest_house/data/ir_actions_client.xml
+++ b/guest_house/data/ir_actions_client.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo noupdate="1">
+    <record id="booking_engine.ir_actions_dashboard_action" model="ir.actions.client" forcecreate="0">
+        <field name="path">guest-house</field>
+    </record>
+</odoo>

--- a/holiday_house/__manifest__.py
+++ b/holiday_house/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Holiday House',
-    'version': '1.6',
+    'version': '1.7',
     'category': 'Hospitality',
     'author': 'Odoo S.A.',
     'depends': [
@@ -22,6 +22,7 @@
         'data/web_views.xml',
         'data/res_config_settings.xml',
         'data/spreadsheet_dashboard.xml',
+        'data/ir_actions_client.xml',
     ],
     'demo': [
         'demo/res_company.xml',

--- a/holiday_house/data/ir_actions_client.xml
+++ b/holiday_house/data/ir_actions_client.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo noupdate="1">
+    <record id="booking_engine.ir_actions_dashboard_action" model="ir.actions.client" forcecreate="0">
+        <field name="path">holiday-house</field>
+    </record>
+</odoo>

--- a/hotel/__manifest__.py
+++ b/hotel/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Hotel',
-    'version': '1.9',
+    'version': '1.10',
     'category': 'Hospitality',
     'author': 'Odoo S.A.',
     'depends': [
@@ -25,6 +25,7 @@
         'data/views.xml',
         'data/res_config_settings.xml',
         'data/spreadsheet_dashboard.xml',
+        'data/ir_actions_client.xml',
     ],
     'demo': [
         'demo/res_company.xml',

--- a/hotel/data/ir_actions_client.xml
+++ b/hotel/data/ir_actions_client.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo noupdate="1">
+    <record id="booking_engine.ir_actions_dashboard_action" model="ir.actions.client" forcecreate="0">
+        <field name="path">hotel</field>
+    </record>
+</odoo>

--- a/tests/test_booking_engine/tests/test_action_server.py
+++ b/tests/test_booking_engine/tests/test_action_server.py
@@ -201,8 +201,8 @@ class BookingEngineAutomationsTestCase(TransactionCase):
         self.assertEqual(task.x_cleaning, 'checkout',
             "Checkout tasks should be marked as checkout cleaning",
         )
-        self.assertEqual(task.date_deadline, last_midnight + timedelta(hours=24),
-            "Checkout task deadline should be end of the day",
+        self.assertEqual(task.date_deadline, last_midnight + timedelta(hours=sale_line.product_id.pickup_time),
+            "Checkout task deadline should match the product pickup time",
         )
 
     def test_automation_on_task_stage_clean(self):


### PR DESCRIPTION
Implement a day-to-day dashboard for accommodation industries and expose it as the default landing page of the Booking Engine app.

[IMP] booking_engine: Refine housekeeping task deadlines
- Only create housekeeping tasks for planning slots linked to a sale order line.
- Set the task deadline to the associated stay offer check-in time instead of a
fixed value, improving task visibility on the dashboard.

Task: 6205260