### PR TITLE
[FIX] veterinary_clinic: remove customization for sequence generation

### DIFF
--- a/veterinary_clinic/__manifest__.py
+++ b/veterinary_clinic/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Veterinary Clinic',
-    'version': '1.2',
+    'version': '1.3',
     'category': 'Health and Fitness',
     'author': 'Odoo S.A.',
     'depends': [

--- a/veterinary_clinic/data/base_automation.xml
+++ b/veterinary_clinic/data/base_automation.xml
@@ -3,7 +3,6 @@
   <record id="appointment_sequence_automation_rule" model="base.automation">
     <field name="name">Appointment Sequence</field>
     <field name="model_id" ref="x_pets_line_model_record"/>
-    <field name="trigger">on_create_or_write</field>
-    <field name="trigger_field_ids" eval="[(6, 0, [ref('created_by_field')])]"/>
+    <field name="trigger">on_create</field>
   </record>
 </odoo>

--- a/veterinary_clinic/data/ir_actions_server.xml
+++ b/veterinary_clinic/data/ir_actions_server.xml
@@ -29,11 +29,11 @@ action = {
   <record id="action_server_appointment_sequence" model="ir.actions.server" >
     <field name="name">Appointment Sequence server action</field>
     <field name="model_id" ref="x_pets_line_model_record"/>
-    <field name="state">code</field>
+    <field name="state">object_write</field>
+    <field name="update_path">x_name</field>
+    <field name="update_field_id" ref="x_name_pets_line_field"/>
+    <field name="evaluation_type">equation</field>
+    <field name="value"><![CDATA["APP/" + record.env['ir.sequence'].next_by_code('appointment.sequence')]]></field>
     <field name="base_automation_id" ref="appointment_sequence_automation_rule"/>
-    <field name="code"><![CDATA[
-for rec in records:
-    rec['x_name'] = "APP/" + rec.env['ir.sequence'].next_by_code('appointment.sequence')
-]]></field>
   </record>
 </odoo>

--- a/veterinary_clinic/data/ir_model_fields.xml
+++ b/veterinary_clinic/data/ir_model_fields.xml
@@ -766,13 +766,4 @@ for record in self: record['x_x_owner_x_pets_count'] = mapped_data.get(record.id
     <field name="selectable" eval="False"/>
     <field name="store" eval="False"/>
   </record>
-  <record id="created_by_field" model="ir.model.fields">
-    <field name="name">x_create_uid</field>
-    <field name="ttype">many2one</field>
-    <field name="copied" eval="True"/>
-    <field name="field_description">Created by </field>
-    <field name="model_id" ref="x_pets_line_model_record"/>
-    <field name="readonly" eval="True"/>
-    <field name="relation">res.users</field>
-  </record>
 </odoo>


### PR DESCRIPTION
Before this commit, the sequence was generated through a server action, which contributed to the LOC count.

With this commit, the sequence generation has been moved to a computation, preventing it from being counted as custom LOC.