### PR TITLE
[FIX] art_craft: add missing dependency

### DIFF
--- a/art_craft/__manifest__.py
+++ b/art_craft/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Arts & Crafts Store',
-    'version': '1.3',
+    'version': '1.4',
     'category': 'Retail',
     'depends': [
         'appointment',
@@ -11,6 +11,7 @@
         'purchase',
         'sale_service',
         'website_crm',
+        'website_event',
         'website_sale_loyalty',
     ],
     'data': [


### PR DESCRIPTION
In the forwardport commit below, there was a dependency that was removed in a merge conflict. This commit adds back website_event to the dependencies and a minor bump of version.

https://github.com/odoo/industry/commit/9d1620ad30b0b7ef368ba002a18f45c10cd342d8