### PR TITLE
[FIX] electronic_store: fix warranty field alignment

### DIFF
--- a/electronic_store/__manifest__.py
+++ b/electronic_store/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Electronic Store',
-    'version': '1.3',
+    'version': '1.4',
     'category': 'Retail',
     'depends': [
         'crm',

--- a/electronic_store/data/ir_ui_view.xml
+++ b/electronic_store/data/ir_ui_view.xml
@@ -12,9 +12,12 @@
             <xpath expr="//field[@name='default_code']" position="attributes">
                 <attribute name="string">Model Number</attribute>
             </xpath>
-            <field name="tracking" position="after">
-                <field name="x_warranty_months" invisible="tracking != 'serial'"/>
-            </field>
+            <xpath expr="//field[@name='tracking']/parent::div" position="after">
+                <label for="x_warranty_months" string="Warranty (Months)" invisible="tracking != 'serial'"/>
+                <div class="o_row w-100" invisible="tracking != 'serial'">
+                    <field name="x_warranty_months"/>
+                </div>
+            </xpath>
         </field>
     </record>
     <record id="x_project_task_worksheet_template_1_ir_ui_view_1" model="ir.ui.view">


### PR DESCRIPTION
Before this commit, the warranty field was displayed after the stat button, making it unclear where the value should be updated.

This commit moves the warranty field below the Track Inventory field, ensuring proper alignment and improving the user experience.

Task-6387471