### PR TITLE
[FIX] guided_tours: prevent error when accessing the Book a Guide page

### DIFF
--- a/guided_tours/__manifest__.py
+++ b/guided_tours/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Guided Tours',
-    'version': '1.4',
+    'version': '1.5',
     'category': 'Hospitality',
     'author': 'Odoo S.A.',
     'depends': [

--- a/guided_tours/demo/website_view.xml
+++ b/guided_tours/demo/website_view.xml
@@ -226,8 +226,8 @@
   <record id="ir_ui_view_3844" model="ir.ui.view">
     <field name="arch" type="xml">
       <data name="Topbar" inherit_id="website_appointment.website_calendar_index_topbar">
-         <xpath expr="//section[hasclass('d-flex')]/h1[hasclass('me-auto')]" position="replace">
-            <h1 class="me-auto mb-0 h4">Choose your destination</h1>
+         <xpath expr="//section[hasclass('d-flex')]/div[hasclass('flex-grow-1')]/h1" position="replace">
+            <h1 class="h4 mb-0">Choose your destination</h1>
           </xpath>
       </data>
     </field>


### PR DESCRIPTION
Currently, an error occurs when a user accesses the Book a Guide page on the website.

**Steps to Reproduce:**

 - Install `guided_tours` with demo data.
 - Go to `Website` > `Book a Guide`.

`ValueError: Element '<xpath expr="//section[hasclass('d-flex')]/h1[hasclass('me-auto')]">'` 
`cannot be located in parent view (view: guided_tours.website_calendar_index_topbar)`

After the [recent commit] , the root `<h1>` was wrapped in a `<div>` so that Font Style changes apply 
correctly. However, the code still references an XPath [2] that no longer exists in the main view. As a 
result, opening the book a guide page raises an error.

This commit updates the XPath in the guided tours view to match the parent template structure.

[recent commit]: https://github.com/odoo/enterprise/commit/8477b72987a6ed49c0294e75196249af9442b3ab

[1]: https://github.com/odoo/enterprise/blob/56835e15df6b39200cd1da185e04dc09c2f24aef/website_appointment/views/appointment_templates_appointments.xml#L78-L80

[2]- https://github.com/odoo/industry/blob/37de4d74ab0ae4c5b9cf206ac5cf9c2738d8ce18/guided_tours/demo/website_view.xml#L229-L231


sentry-7609379255