### PR TITLE
[FIX] construction_developer: align unit price and margin formulas

### DIFF
--- a/construction_developer/__manifest__.py
+++ b/construction_developer/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Construction Developer',
-    'version': '1.16',
+    'version': '1.17',
     'category': 'Construction',
     'depends': [
         'base_industry_data',

--- a/construction_developer/data/ir_actions_server.xml
+++ b/construction_developer/data/ir_actions_server.xml
@@ -169,7 +169,7 @@ for product in records:
         <field name="state">code</field>
         <field name="code"><![CDATA[
 for wi in records:
-    wi['x_unit_margin'] = (wi.x_unit_price - wi.x_unit_cost) / wi.x_unit_cost if wi.x_unit_cost > 0 else False
+    wi['x_unit_margin'] = (wi.x_unit_price - wi.x_unit_cost) / wi.x_unit_price if wi.x_unit_price > 0 else False
 ]]></field>
     </record>
     <record id="server_action_update_price_if_margin_fixed" model="ir.actions.server">
@@ -178,7 +178,7 @@ for wi in records:
         <field name="state">code</field>
         <field name="code"><![CDATA[
 for wi in records:
-    wi['x_unit_price'] = wi.x_unit_cost * (1 + wi.x_unit_margin)
+    wi['x_unit_price'] = wi.x_unit_cost / (1 - wi.x_unit_margin)
 ]]></field>
     </record>
     <record id="server_action_recompute_price_with_components_prices" model="ir.actions.server">

--- a/construction_developer/data/ir_model_fields.xml
+++ b/construction_developer/data/ir_model_fields.xml
@@ -384,7 +384,7 @@ for record in self:
         <field name="compute"><![CDATA[
 for record in self:
     if not record.x_is_margin_fixed:
-        record['x_unit_margin'] = (record.x_unit_price - record.x_unit_cost) / record.x_unit_cost if record.x_unit_cost > 0 else False
+        record['x_unit_margin'] = (record.x_unit_price - record.x_unit_cost) / record.x_unit_price if record.x_unit_price > 0 else False
 ]]></field>
         <field name="ttype">float</field>
         <field name="depends">x_unit_price,x_unit_cost</field>

--- a/tests/test_construction_developer/tests/test_action_server.py
+++ b/tests/test_construction_developer/tests/test_action_server.py
@@ -68,21 +68,21 @@ class ActionServerTestCase(TransactionCase):
         self.assertEqual(test_template_work_item_lines[1].x_unit_price, 40.0, "Assignation error: The second work item line should have a price of 40.0")
         self.assertEqual(self.test_template_work_item.x_unit_cost, 50.0, "The cost of work item is not computed correctly: it should be the sum of the product of components costs by quantity")
         self.assertEqual(self.test_template_work_item.x_unit_price, 100.0, "The price of work item is not computed correctly: it should be the sum of the product of components prices by quantity")
-        self.assertEqual(self.test_template_work_item.x_unit_margin, 1.0, "The margin of work item is not computed correctly: it should be equal to 1.0 at this point")
+        self.assertEqual(self.test_template_work_item.x_unit_margin, 0.5, "The margin of work item is not computed correctly: it should be equal to 0.5 at this point")
         test_template_work_item_lines[0].x_unit_cost = 20
         self.assertEqual(self.test_template_work_item.x_unit_cost, 100.0, "The cost of work item is not recomputed correctly when the cost of a component changes")
         self.assertEqual(self.test_template_work_item.x_unit_price, 100.0, "The price of work item changes when the cost of a component changes but it should not happen")
         self.assertEqual(self.test_template_work_item.x_unit_margin, 0.0, "The margin of work item is not correct after the cost of a component changes: it should be recomputed to represent the new value")
-        test_template_work_item_lines[1].x_unit_price = 240
+        test_template_work_item_lines[1].x_unit_price = 340
         self.assertEqual(self.test_template_work_item.x_unit_cost, 100.0, "The cost of work item changes after the price of a component changes while it should not happen")
-        self.assertEqual(self.test_template_work_item.x_unit_price, 300.0, "The price of work item is not recomputed correctly when the price of a component changes")
-        self.assertEqual(self.test_template_work_item.x_unit_margin, 2.0, "The margin of work item is not correct after the price of a component changes: it should be recomputed to represent the new value")
+        self.assertEqual(self.test_template_work_item.x_unit_price, 400.0, "The price of work item is not recomputed correctly when the price of a component changes")
+        self.assertEqual(self.test_template_work_item.x_unit_margin, 0.75, "The margin of work item is not correct after the price of a component changes: it should be recomputed to represent the new value")
         self.test_template_work_item.x_is_margin_fixed = True
-        self.test_template_work_item.x_unit_price = 200
-        self.assertEqual(self.test_template_work_item.x_unit_margin, 1.0, "When margin is fixed, the margin should be recomputed if we change manually the price of work item")
+        self.test_template_work_item.x_unit_price = 500
+        self.assertEqual(self.test_template_work_item.x_unit_margin, 0.8, "When margin is fixed, the margin should be recomputed if we change manually the price of work item")
         self.test_template_work_item.x_unit_margin = 0.5
-        self.assertEqual(self.test_template_work_item.x_unit_price, 150.0, "When margin is fixed, the price should be recomputed if we change manually the margin of work item")
+        self.assertEqual(self.test_template_work_item.x_unit_price, 200.0, "When margin is fixed, the price should be recomputed if we change manually the margin of work item")
         test_template_work_item_lines[1].x_unit_cost = 10
         self.assertEqual(self.test_template_work_item.x_unit_margin, 0.5, "When margin is fixed, the margin of work item should stay the same when the cost of a component changes")
         self.assertEqual(self.test_template_work_item.x_unit_cost, 90.0, "When margin is fixed, the cost of work item should be recomputed when the cost of a component changes")
-        self.assertEqual(self.test_template_work_item.x_unit_price, 135.0, "When margin is fixed, the price of work item should be recomputed when the cost of a component changes")
+        self.assertEqual(self.test_template_work_item.x_unit_price, 180.0, "When margin is fixed, the price of work item should be recomputed when the cost of a component changes")


### PR DESCRIPTION
- Redefine unit margin as a percentage of the selling price
- Update the inverse unit price calculation to keep both formulas mathematically consistent
- Update affected tests to validate the new behavior

Task: 6273532