### PR TITLE
[IMP] booking_engine: prevent bookings years in advance

### DIFF
--- a/booking_engine/data/product_pricelist_item.xml
+++ b/booking_engine/data/product_pricelist_item.xml
@@ -36,4 +36,15 @@
     <field name="percent_price">-50.0</field>
     <field name="x_name">Christmas</field>
   </record>
+  <record id="pricelist_item_block_future_booking" model="product.pricelist.item">
+    <field name="pricelist_id" ref="product_pricelist_1" />
+    <field name="applied_on">2_product_category</field>
+    <field name="display_applied_on">2_product_category</field>
+    <field name="categ_id" ref="product_category_6" />
+    <field name="compute_price">fixed</field>
+    <field name="fixed_price">0.0</field>
+    <field name="date_start" eval="datetime.now() + relativedelta(years=1)" />
+    <field name="date_end" eval="datetime.now() + relativedelta(years=30)" />
+    <field name="x_name">Booking Blocker</field>
+  </record>
 </odoo>

--- a/booking_engine/data/res_config_settings.xml
+++ b/booking_engine/data/res_config_settings.xml
@@ -16,6 +16,10 @@
             <value model="res.company" eval="{'account_price_include': 'tax_included'} if not obj().env.company._existing_accounting() else {}"/>
         </function>
         <function model="res.config.settings" name="execute" eval="[ref('res_config_settings_enable')]"/>
+        <function name="write" model="website">
+            <value eval="[ref('website.default_website')]"/>
+            <value eval="{'prevent_sale': True}"/>
+        </function>
     </data>
 
     <!-- House Keeping -->

--- a/campsite/data/knowledge_article.xml
+++ b/campsite/data/knowledge_article.xml
@@ -104,6 +104,25 @@
                     careful not to double book a resource with such change!</p>
             </div>
         </div>
+        <h4>Prevent bookings year in advance</h4>
+        <ul>
+            <li>Open the Default pricelist from the configuration menu.</li>
+            <li>See that it contains a rule booking blocker setting price to 0.</li>
+        </ul>
+        <div data-oe-role="status"
+            class="o_editor_banner user-select-none o-contenteditable-false lh-1 d-flex align-items-center alert alert-success pb-0 pt-3">
+            <i data-oe-aria-label="Banner Success" class="o_editor_banner_icon mb-3 fst-normal">✅</i>
+            <div class="o_editor_banner_content o-contenteditable-true w-100 px-3">
+                <p>A price at 0 combined with the setting "Hide Add To Cart" prevents bookings from your website!</p>
+            </div>
+        </div>
+        <div data-oe-role="status"
+            class="o_editor_banner user-select-none o-contenteditable-false lh-1 d-flex align-items-center alert alert-warning pb-0 pt-3">
+            <i data-oe-aria-label="Banner Warning" class="o_editor_banner_icon mb-3 fst-normal">⚠️</i>
+            <div class="o_editor_banner_content o-contenteditable-true w-100 px-3">
+                <p>Don't forget to replicate the Booking Blocker rule on all your pricelists and to specify the website this applies to.<br/>On a regular basis postpone this booking blocker start date season after season to unlock your calendar.</p>
+            </div>
+        </div>
         <h4>Enforcing weekly turnover</h4>
         <p>Optimizing weekly turnover to maximize occupancy during peak season, you can align your bookings to a weekly rental pattern (e.g., Saturday to Saturday). By restricting check-ins and check-outs to specific days, you synchronize your housekeeping and eliminate calendar gaps.</p>
         <ul>
@@ -185,7 +204,7 @@
                     fields at your convenience with studio. Just be careful, such customizations can
                     quickly become messy.</p>
             </div>
-        </div><h4 >Deliver extra services</h4><p>Now that they relax, you can offer extra services to make your guests fill even more
+        </div><h4 >Deliver extra services</h4><p>Now that they relax, you can offer extra services to make your guests feel even more
             comfortable!</p><ul>
             <li>At any time during their stay, open their rental order from the Campsite App.</li>
             <li>Add a line with Plancha or a Fan.</li>

--- a/guest_house/data/knowledge_article.xml
+++ b/guest_house/data/knowledge_article.xml
@@ -155,6 +155,25 @@
                     careful not to double book a resource with such change!</p>
             </div>
         </div>
+        <h4>Prevent bookings year in advance</h4>
+        <ul>
+            <li>Open the Default pricelist from the configuration menu.</li>
+            <li>See that it contains a rule booking blocker setting price to 0.</li>
+        </ul>
+        <div data-oe-role="status"
+            class="o_editor_banner user-select-none o-contenteditable-false lh-1 d-flex align-items-center alert alert-success pb-0 pt-3">
+            <i data-oe-aria-label="Banner Success" class="o_editor_banner_icon mb-3 fst-normal">✅</i>
+            <div class="o_editor_banner_content o-contenteditable-true w-100 px-3">
+                <p>A price at 0 combined with the setting "Hide Add To Cart" prevents bookings from your website!</p>
+            </div>
+        </div>
+        <div data-oe-role="status"
+            class="o_editor_banner user-select-none o-contenteditable-false lh-1 d-flex align-items-center alert alert-warning pb-0 pt-3">
+            <i data-oe-aria-label="Banner Warning" class="o_editor_banner_icon mb-3 fst-normal">⚠️</i>
+            <div class="o_editor_banner_content o-contenteditable-true w-100 px-3">
+                <p>Don't forget to replicate the Booking Blocker rule on all your pricelists and to specify the website this applies to.<br/>On a regular basis postpone this booking blocker start date season after season to unlock your calendar.</p>
+            </div>
+        </div>
         <h4>Blocking resources</h4>
         <p>You are repairing a room or simply welcoming family and don't want guests to book it?<br/>Alternatively, you are closing for a week during an inter season break?<br/>Let's have this reflected in your schedule!</p>
         <p><strong>Multiple resource blocking / period closure</strong></p>
@@ -250,7 +269,7 @@
             </div>
         </div>
         <h4>Deliver extra services</h4>
-        <p>Now that they relax, you can offer extra services to make your guests fill even more
+        <p>Now that they relax, you can offer extra services to make your guests feel even more
             comfortable!</p>
         <ul>
             <li>At any time during their stay, open their rental order from the Guest House App.</li>

--- a/holiday_house/data/knowledge_article.xml
+++ b/holiday_house/data/knowledge_article.xml
@@ -115,6 +115,25 @@ The Holiday House App relies on the Rental and Planning Apps binding, with a few
                 <p>Alternatively, switch to the list view, which is more suitable if the booking is not during the visualized date range and update the booking date range.</p>
             </div>
         </div>
+        <h4>Prevent bookings year in advance</h4>
+        <ul>
+            <li>Open the Default pricelist from the configuration menu.</li>
+            <li>See that it contains a rule booking blocker setting price to 0.</li>
+        </ul>
+        <div data-oe-role="status"
+            class="o_editor_banner user-select-none o-contenteditable-false lh-1 d-flex align-items-center alert alert-success pb-0 pt-3">
+            <i data-oe-aria-label="Banner Success" class="o_editor_banner_icon mb-3 fst-normal">✅</i>
+            <div class="o_editor_banner_content o-contenteditable-true w-100 px-3">
+                <p>A price at 0 combined with the setting "Hide Add To Cart" prevents bookings from your website!</p>
+            </div>
+        </div>
+        <div data-oe-role="status"
+            class="o_editor_banner user-select-none o-contenteditable-false lh-1 d-flex align-items-center alert alert-warning pb-0 pt-3">
+            <i data-oe-aria-label="Banner Warning" class="o_editor_banner_icon mb-3 fst-normal">⚠️</i>
+            <div class="o_editor_banner_content o-contenteditable-true w-100 px-3">
+                <p>Don't forget to replicate the Booking Blocker rule on all your pricelists and to specify the website this applies to.<br/>On a regular basis postpone this booking blocker start date season after season to unlock your calendar.</p>
+            </div>
+        </div>
         <h4>Enforcing weekly turnover</h4>
         <p>Optimizing weekly turnover to maximize occupancy during peak season, you can align your bookings to a weekly rental pattern (e.g., Saturday to Saturday). By restricting check-ins and check-outs to specific days, you synchronize your housekeeping and eliminate calendar gaps.</p>
         <ul>

--- a/hotel/data/knowledge_article.xml
+++ b/hotel/data/knowledge_article.xml
@@ -176,6 +176,25 @@
                     careful not to double book a resource with such change!</p>
             </div>
         </div>
+        <h4>Prevent bookings year in advance</h4>
+        <ul>
+            <li>Open the Default pricelist from the configuration menu.</li>
+            <li>See that it contains a rule booking blocker setting price to 0.</li>
+        </ul>
+        <div data-oe-role="status"
+            class="o_editor_banner user-select-none o-contenteditable-false lh-1 d-flex align-items-center alert alert-success pb-0 pt-3">
+            <i data-oe-aria-label="Banner Success" class="o_editor_banner_icon mb-3 fst-normal">✅</i>
+            <div class="o_editor_banner_content o-contenteditable-true w-100 px-3">
+                <p>A price at 0 combined with the setting "Hide Add To Cart" prevents bookings from your website!</p>
+            </div>
+        </div>
+        <div data-oe-role="status"
+            class="o_editor_banner user-select-none o-contenteditable-false lh-1 d-flex align-items-center alert alert-warning pb-0 pt-3">
+            <i data-oe-aria-label="Banner Warning" class="o_editor_banner_icon mb-3 fst-normal">⚠️</i>
+            <div class="o_editor_banner_content o-contenteditable-true w-100 px-3">
+                <p>Don't forget to replicate the Booking Blocker rule on all your pricelists and to specify the website this applies to.<br/>On a regular basis postpone this booking blocker start date season after season to unlock your calendar.</p>
+            </div>
+        </div>
         <h4>Blocking resources</h4>
         <p>You are repairing a room or simply welcoming family and don't want guests to book it?<br/>Alternatively, you are closing for a week during an inter season break?<br/>Let's have this reflected in your schedule!</p>
         <p><strong>Multiple resource blocking / period closure</strong></p>
@@ -269,7 +288,7 @@
             </div>
         </div>
         <h4>Deliver extra services</h4>
-        <p>Now that they relax, you can offer extra services to make your guests fill even more
+        <p>Now that they relax, you can offer extra services to make your guests feel even more
             comfortable!</p>
         <ul>
             <li>At any time during their stay, open their rental order from the Hotel App.</li>

--- a/hotel/demo/website/website.xml
+++ b/hotel/demo/website/website.xml
@@ -10,6 +10,7 @@
         <field name="show_line_subtotals_tax_selection">tax_included</field>
         <field name="logo" type="base64" file="hotel/static/src/img/content/website/logo.webp"/>
         <field name="favicon" type="base64" file="hotel/static/src/img/content/website/favicon.png"/>
+        <field name="prevent_sale" eval="True"/>
     </record>
 
     <function name="write" model="ir.model.data">
@@ -19,5 +20,9 @@
             ('model', '=', 'website'),
         ]"/>
         <value eval="{'res_id': ref('website_industry')}"/>
+    </function>
+    <function name="write" model="product.pricelist">
+        <value model="product.pricelist" search="[('id', '=', ref('booking_engine.product_pricelist_1'))]"/>
+        <value eval="{'website_id': ref('website_industry')}"/>
     </function>
 </odoo>


### PR DESCRIPTION
Rental businesses generally do not want to accept bookings several years
ahead as availability and pricing may change over time.

Add a default pricelist rule that sets the booking price to 0 beyond one
year in the future. Combined with the "Hide Add To Cart" website setting,
this prevents customers from booking dates outside the supported booking
window.

Update industry demo websites and knowledge articles to document and
support this configuration.

task-6246347