### PR TITLE
[FIX] *: Prevent traceback when changing carousel images

### DIFF
--- a/beauty_parlor/demo/website_view.xml
+++ b/beauty_parlor/demo/website_view.xml
@@ -368,9 +368,9 @@ Our goal is simple: make beauty care accessible, human, and enjoyable; whether i
                     <span class="visually-hidden">Next</span>
                   </button>
                   <div class="carousel-indicators s_carousel_indicators_dots o_not_editable">
-                    <button type="button" class="active" aria-label="Featured services carousel" data-bs-target="#myQuoteCarousel976508" data-bs-slide-to="0" aria-current="true"/>
-                    <button type="button" aria-label="Featured services carousel" data-bs-target="#myQuoteCarousel976508" data-bs-slide-to="1"/>
-                    <button type="button" aria-label="Featured services carousel" data-bs-target="#myQuoteCarousel976508" data-bs-slide-to="2"/>
+                    <button type="button" class="active" aria-label="Featured services carousel" data-bs-target="#myQuoteCarousel976508" data-bs-slide-to="0" aria-current="true" aria-selected="true"/>
+                    <button type="button" aria-label="Featured services carousel" data-bs-target="#myQuoteCarousel976508" data-bs-slide-to="1" aria-selected="false"/>
+                    <button type="button" aria-label="Featured services carousel" data-bs-target="#myQuoteCarousel976508" data-bs-slide-to="2" aria-selected="false"/>
                   </div>
                 </div>
               </section>

--- a/campsite/demo/website_view.xml
+++ b/campsite/demo/website_view.xml
@@ -175,9 +175,9 @@
                   <span class="visually-hidden">Next</span>
                 </button>
                 <div class="carousel-indicators s_carousel_indicators_dots o_not_editable">
-                  <button type="button" class="active" aria-label="Carousel Indicator" data-bs-target="#myQuoteCarousel877397" aria-current="true" data-bs-slide-to="0"/>
-                  <button type="button" aria-label="Carousel Indicator" data-bs-target="#myQuoteCarousel877397" data-bs-slide-to="1"/>
-                  <button type="button" aria-label="Carousel Indicator" data-bs-target="#myQuoteCarousel877397" data-bs-slide-to="2"/>
+                  <button type="button" class="active" aria-label="Carousel Indicator" data-bs-target="#myQuoteCarousel877397" aria-current="true" data-bs-slide-to="0" aria-selected="true"/>
+                  <button type="button" aria-label="Carousel Indicator" data-bs-target="#myQuoteCarousel877397" data-bs-slide-to="1" aria-selected="false"/>
+                  <button type="button" aria-label="Carousel Indicator" data-bs-target="#myQuoteCarousel877397" data-bs-slide-to="2" aria-selected="false"/>
                 </div>
               </div>
             </section>

--- a/driving_school/demo/website_view.xml
+++ b/driving_school/demo/website_view.xml
@@ -247,9 +247,9 @@
                   <span class="visually-hidden">Next</span>
                 </button>
                 <div class="carousel-indicators o_not_editable s_carousel_indicators_hidden">
-                  <button type="button" data-bs-slide-to="0" class="active" aria-label="Carousel indicator" data-bs-target="#myQuoteCarousel774738"/>
-                  <button type="button" data-bs-slide-to="1" aria-label="Carousel indicator" data-bs-target="#myQuoteCarousel774738"/>
-                  <button type="button" data-bs-slide-to="2" aria-label="Carousel indicator" data-bs-target="#myQuoteCarousel774738"/>
+                  <button type="button" data-bs-slide-to="0" class="active" aria-label="Carousel indicator" data-bs-target="#myQuoteCarousel774738" aria-selected="true"/>
+                  <button type="button" data-bs-slide-to="1" aria-label="Carousel indicator" data-bs-target="#myQuoteCarousel774738" aria-selected="false"/>
+                  <button type="button" data-bs-slide-to="2" aria-label="Carousel indicator" data-bs-target="#myQuoteCarousel774738" aria-selected="false"/>
                 </div>
               </div>
             </section>

--- a/dropshipping/demo/website_view.xml
+++ b/dropshipping/demo/website_view.xml
@@ -161,9 +161,9 @@ Durability meets design—our cases provide the ultimate protection without sacr
                   <span class="visually-hidden">Next</span>
                 </button>
                 <div class="carousel-indicators o_not_editable o_we_no_overlay">
-                  <button type="button" aria-label="Carousel indicator" data-bs-target="#myCarousel1742291533068" class="active" data-bs-slide-to="0" aria-current="true"/>
-                  <button type="button" aria-label="Carousel indicator" data-bs-target="#myCarousel1742291533068" data-bs-slide-to="1"/>
-                  <button type="button" aria-label="Carousel indicator" data-bs-target="#myCarousel1742291533068" data-bs-slide-to="2"/>
+                  <button type="button" aria-label="Carousel indicator" data-bs-target="#myCarousel1742291533068" class="active" data-bs-slide-to="0" aria-current="true" aria-selected="true"/>
+                  <button type="button" aria-label="Carousel indicator" data-bs-target="#myCarousel1742291533068" data-bs-slide-to="1" aria-selected="false"/>
+                  <button type="button" aria-label="Carousel indicator" data-bs-target="#myCarousel1742291533068" data-bs-slide-to="2" aria-selected="false"/>
                 </div>
               </div>
             </section>

--- a/elearning_platform/demo/website_view.xml
+++ b/elearning_platform/demo/website_view.xml
@@ -52,8 +52,8 @@
                   <span class="visually-hidden">Next</span>
                 </button>
                 <div class="carousel-indicators o_not_editable">
-                  <button type="button" aria-label="Carousel indicator" data-bs-target="#myCarousel1755590423281" class="active" data-bs-slide-to="0" aria-current="true"/>
-                  <button data-bs-target="#myCarousel1755590423281" aria-label="Carousel indicator" data-bs-slide-to="1"/>
+                  <button type="button" aria-label="Carousel indicator" data-bs-target="#myCarousel1755590423281" class="active" data-bs-slide-to="0" aria-current="true" aria-selected="true"/>
+                  <button data-bs-target="#myCarousel1755590423281" aria-label="Carousel indicator" data-bs-slide-to="1" aria-selected="false"/>
                 </div>
               </div>
             </section>

--- a/event_management/demo/website_view.xml
+++ b/event_management/demo/website_view.xml
@@ -200,9 +200,9 @@
                   <span class="visually-hidden">Next</span>
                 </button>
                 <div class="carousel-indicators s_carousel_indicators_dots">
-                  <button type="button" aria-label="Carousel indicator" data-bs-target="#myQuoteCarouselMinimal713229" class="active" data-bs-slide-to="0" aria-current="true"/>
-                  <button type="button" aria-label="Carousel indicator" data-bs-target="#myQuoteCarouselMinimal713229" data-bs-slide-to="1"/>
-                  <button type="button" aria-label="Carousel indicator" data-bs-target="#myQuoteCarouselMinimal713229" data-bs-slide-to="2"/>
+                  <button type="button" aria-label="Carousel indicator" data-bs-target="#myQuoteCarouselMinimal713229" class="active" data-bs-slide-to="0" aria-current="true" aria-selected="true"/>
+                  <button type="button" aria-label="Carousel indicator" data-bs-target="#myQuoteCarouselMinimal713229" data-bs-slide-to="1" aria-selected="false"/>
+                  <button type="button" aria-label="Carousel indicator" data-bs-target="#myQuoteCarouselMinimal713229" data-bs-slide-to="2" aria-selected="false"/>
                 </div>
               </div>
             </section>

--- a/holiday_house/demo/website_view.xml
+++ b/holiday_house/demo/website_view.xml
@@ -129,9 +129,9 @@
                   <span class="visually-hidden">Next</span>
                 </button>
                 <div class="carousel-indicators s_carousel_indicators_dots o_not_editable">
-                  <button type="button" class="active" aria-label="Image slider" data-bs-target="#myQuoteCarousel454527" aria-current="true" data-bs-slide-to="0"/>
-                  <button type="button" aria-label="Image slider" data-bs-target="#myQuoteCarousel454527" data-bs-slide-to="1"/>
-                  <button type="button" aria-label="Image slider" data-bs-target="#myQuoteCarousel454527" data-bs-slide-to="2"/>
+                  <button type="button" class="active" aria-label="Image slider" data-bs-target="#myQuoteCarousel454527" aria-current="true" data-bs-slide-to="0" aria-selected="true"/>
+                  <button type="button" aria-label="Image slider" data-bs-target="#myQuoteCarousel454527" data-bs-slide-to="1" aria-selected="false"/>
+                  <button type="button" aria-label="Image slider" data-bs-target="#myQuoteCarousel454527" data-bs-slide-to="2" aria-selected="false"/>
                 </div>
               </div>
             </section>

--- a/industry_lawyer/demo/website_view.xml
+++ b/industry_lawyer/demo/website_view.xml
@@ -466,9 +466,9 @@
                     <span class="visually-hidden">Next</span>
                   </button>
                   <div class="carousel-indicators s_carousel_indicators_dots o_not_editable o_we_no_overlay">
-                    <button type="button" aria-label="Carousel indicator" data-bs-target="#myQuoteCarousel775142" data-bs-slide-to="0" class="active" aria-current="true"/>
-                    <button type="button" aria-label="Carousel indicator" data-bs-target="#myQuoteCarousel775142" data-bs-slide-to="1"/>
-                    <button type="button" aria-label="Carousel indicator" data-bs-target="#myQuoteCarousel775142" data-bs-slide-to="2"/>
+                    <button type="button" aria-label="Carousel indicator" data-bs-target="#myQuoteCarousel775142" data-bs-slide-to="0" class="active" aria-current="true" aria-selected="true"/>
+                    <button type="button" aria-label="Carousel indicator" data-bs-target="#myQuoteCarousel775142" data-bs-slide-to="1" aria-selected="false"/>
+                    <button type="button" aria-label="Carousel indicator" data-bs-target="#myQuoteCarousel775142" data-bs-slide-to="2" aria-selected="false"/>
                   </div>
                 </div>
               </section>

--- a/marketing_agency/demo/website_view.xml
+++ b/marketing_agency/demo/website_view.xml
@@ -476,7 +476,7 @@
                     <span class="visually-hidden">Next</span>
                     </button>
                     <div class="carousel-indicators s_carousel_indicators_dots o_we_no_overlay d-none">
-                    <button type="button" aria-label="Carousel indicator" data-bs-target="#myCarousel1740499147719" class="active" data-bs-slide-to="0" aria-current="true"/>
+                    <button type="button" aria-label="Carousel indicator" data-bs-target="#myCarousel1740499147719" class="active" data-bs-slide-to="0" aria-current="true" aria-selected="true"/>
                     </div>
                 </div>
                 </section>

--- a/micro_brewery/demo/website_view.xml
+++ b/micro_brewery/demo/website_view.xml
@@ -220,9 +220,9 @@
                   <span class="visually-hidden">Next</span>
                 </button>
                 <div class="carousel-indicators s_carousel_indicators_dots o_not_editable o_we_no_overlay">
-                  <button type="button" aria-label="Carousel indicator" data-bs-target="#myQuoteCarousel486998" class="active" data-bs-slide-to="0" aria-current="true"/>
-                  <button type="button" aria-label="Carousel indicator" data-bs-target="#myQuoteCarousel486998" data-bs-slide-to="1"/>
-                  <button type="button" aria-label="Carousel indicator" data-bs-target="#myQuoteCarousel486998" data-bs-slide-to="2"/>
+                  <button type="button" aria-label="Carousel indicator" data-bs-target="#myQuoteCarousel486998" class="active" data-bs-slide-to="0" aria-current="true" aria-selected="true"/>
+                  <button type="button" aria-label="Carousel indicator" data-bs-target="#myQuoteCarousel486998" data-bs-slide-to="1" aria-selected="false"/>
+                  <button type="button" aria-label="Carousel indicator" data-bs-target="#myQuoteCarousel486998" data-bs-slide-to="2" aria-selected="false"/>
                 </div>
               </div>
             </section>

--- a/night_clubs/demo/website_view.xml
+++ b/night_clubs/demo/website_view.xml
@@ -321,9 +321,9 @@
                                     <span class="visually-hidden">Next</span>
                                 </button>
                                 <div class="carousel-indicators o_not_editable">
-                                    <button type="button" class="active" aria-label="Carousel indicator" data-bs-target="#myQuoteCarousel970616" data-bs-slide-to="0" aria-current="true" />
-                                    <button type="button" aria-label="Carousel indicator" data-bs-target="#myQuoteCarousel970616" data-bs-slide-to="1" />
-                                    <button type="button" aria-label="Carousel indicator" data-bs-target="#myQuoteCarousel970616" data-bs-slide-to="2" />
+                                    <button type="button" class="active" aria-label="Carousel indicator" data-bs-target="#myQuoteCarousel970616" data-bs-slide-to="0" aria-current="true" aria-selected="true"/>
+                                    <button type="button" aria-label="Carousel indicator" data-bs-target="#myQuoteCarousel970616" data-bs-slide-to="1" aria-selected="false"/>
+                                    <button type="button" aria-label="Carousel indicator" data-bs-target="#myQuoteCarousel970616" data-bs-slide-to="2" aria-selected="false"/>
                                 </div>
                             </div>
                         </section>


### PR DESCRIPTION
Changing a carousel image triggered a traceback because the expected `aria-selected` accessibility attribute was missing.

Add the `aria-selected` attribute to preserve the expected DOM structure and prevent the traceback when updating carousel images.

Affected By: https://github.com/odoo/odoo/pull/250170

Task: 6420113