### PR TITLE
[IMP] construction: enable services and materials re-invoicing

### DIFF
--- a/construction/__manifest__.py
+++ b/construction/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Construction Builder',
-    'version': '1.6',
+    'version': '1.7',
     'category': 'Construction',
     'depends': [
         'base_industry_data',

--- a/construction/data/knowledge_article.xml
+++ b/construction/data/knowledge_article.xml
@@ -851,6 +851,35 @@
             </div>
         </div>
 
+        <h5>On the fly services and materials invoicing</h5>
+        <p>
+            Rather than focusing on meticulous tracking, you might capture on the fly the time spent and materials used onsite on a regular basis or because you just bought last minute supplies on the way. In such cases, you can use the Services &amp; Materials re-invoicing.
+        </p>
+        <p>
+            <strong>How to use it:</strong>
+        </p>
+        <ul>
+            <li>Define your product re-invoicing costs at sales price.</li>
+            <li>Open the Sales App and navigate to the To Invoice / Services &amp; Materials menu.</li>
+            <li>Hit the new button to add a line, select the order and fill in the information given your needs to invoice.</li>
+        </ul>
+        <div data-oe-role="status"
+            class="o_editor_banner user-select-none o-contenteditable-false lh-1 d-flex align-items-center alert alert-success pb-0 pt-3"
+            contenteditable="false" role="status">
+                <i data-oe-aria-label="Banner Success" class="o_editor_banner_icon mb-3 fst-normal"
+                aria-label="Banner Success">✅</i>
+                <div class="o_editor_banner_content o-contenteditable-true w-100 px-3"
+                contenteditable="true">
+                <div class="o-paragraph">
+                    With every new line:
+                    <ul>
+                        <li>Orders with the selected products already quoted will see the delivery quantity increased.</li>
+                        <li>While orders where listed products were not present shall see a new line for this product even if not ordered.</li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+
         <h5>Time sheet based invoicing</h5>
         <p>
             Some of your work is to invoice given the amount of time spent. <br/>

--- a/construction/data/product_product.xml
+++ b/construction/data/product_product.xml
@@ -10,6 +10,7 @@
         <field name="standard_price">73.0</field>
         <field name="weight">1389.0</field>
         <field name="categ_id" ref="product_category_45"/>
+        <field name="reinvoice_policy">sales_price</field>
     </record>
     <record id="product_product_6" model="product.product">
         <field name="name">Masonry mortar 25kg</field>
@@ -21,6 +22,7 @@
         <field name="standard_price">472.0</field>
         <field name="weight">1224.0</field>
         <field name="categ_id" ref="product_category_45"/>
+        <field name="reinvoice_policy">sales_price</field>
     </record>
     <record id="product_product_7" model="product.product">
         <field name="name">Travelling costs</field>
@@ -28,6 +30,7 @@
         <field name="uom_id" ref="uom.product_uom_km"/>
         <field name="standard_price">0.8</field>
         <field name="categ_id" ref="product_category_18"/>
+        <field name="reinvoice_policy">sales_price</field>
     </record>
     <record id="sale_timesheet.time_product" model="product.product" forcecreate="True">
         <field name="name">Service on Timesheets</field>

--- a/construction/data/product_template.xml
+++ b/construction/data/product_template.xml
@@ -9,6 +9,7 @@
         <field name="purchase_method">receive</field>
         <field name="service_type">manual</field>
         <field name="invoice_policy">order</field>
+        <field name="reinvoice_policy">sales_price</field>
     </record>
     <record id="product_template_14" model="product.template" context="{'create_product_product': False}">
         <field name="name">Adapted WC</field>
@@ -18,6 +19,7 @@
         <field name="purchase_method">receive</field>
         <field name="service_type">manual</field>
         <field name="invoice_policy">order</field>
+        <field name="reinvoice_policy">sales_price</field>
     </record>
     <record id="product_template_34" model="product.template" context="{'create_product_product': False}">
         <field name="name">Bathrooms</field>
@@ -27,6 +29,7 @@
         <field name="purchase_method">receive</field>
         <field name="service_type">manual</field>
         <field name="invoice_policy">order</field>
+        <field name="reinvoice_policy">sales_price</field>
     </record>
     <record id="product_template_16" model="product.template" context="{'create_product_product': False}">
         <field name="name">Cooking line</field>
@@ -36,6 +39,7 @@
         <field name="purchase_method">receive</field>
         <field name="service_type">manual</field>
         <field name="invoice_policy">order</field>
+        <field name="reinvoice_policy">sales_price</field>
     </record>
     <record id="product_template_19" model="product.template" context="{'create_product_product': False}">
         <field name="name">Dishwasher station</field>
@@ -45,6 +49,7 @@
         <field name="purchase_method">receive</field>
         <field name="service_type">manual</field>
         <field name="invoice_policy">order</field>
+        <field name="reinvoice_policy">sales_price</field>
     </record>
     <record id="product_template_32" model="product.template" context="{'create_product_product': False}">
         <field name="name">Emergency lights</field>
@@ -54,6 +59,7 @@
         <field name="purchase_method">receive</field>
         <field name="service_type">manual</field>
         <field name="invoice_policy">order</field>
+        <field name="reinvoice_policy">sales_price</field>
     </record>
     <record id="product_template_11" model="product.template" context="{'create_product_product': False}">
         <field name="name">Exterior lighting</field>
@@ -63,6 +69,7 @@
         <field name="purchase_method">receive</field>
         <field name="service_type">manual</field>
         <field name="invoice_policy">order</field>
+        <field name="reinvoice_policy">sales_price</field>
     </record>
     <record id="product_template_28" model="product.template" context="{'create_product_product': False}">
         <field name="name">Extraction hood</field>
@@ -72,6 +79,7 @@
         <field name="purchase_method">receive</field>
         <field name="service_type">manual</field>
         <field name="invoice_policy">order</field>
+        <field name="reinvoice_policy">sales_price</field>
     </record>
     <record id="product_template_20" model="product.template" context="{'create_product_product': False}">
         <field name="name">Extraction system</field>
@@ -81,6 +89,7 @@
         <field name="purchase_method">receive</field>
         <field name="service_type">manual</field>
         <field name="invoice_policy">order</field>
+        <field name="reinvoice_policy">sales_price</field>
     </record>
     <record id="product_template_55" model="product.template" context="{'create_product_product': False}">
         <field name="name">Fire-rated partitions</field>
@@ -90,6 +99,7 @@
         <field name="purchase_method">receive</field>
         <field name="service_type">manual</field>
         <field name="invoice_policy">order</field>
+        <field name="reinvoice_policy">sales_price</field>
     </record>
     <record id="product_template_10" model="product.template" context="{'create_product_product': False}">
         <field name="name">Garden cleanup</field>
@@ -99,6 +109,7 @@
         <field name="purchase_method">receive</field>
         <field name="service_type">manual</field>
         <field name="invoice_policy">order</field>
+        <field name="reinvoice_policy">sales_price</field>
     </record>
     <record id="product_template_9" model="product.template" context="{'create_product_product': False}">
         <field name="name">Gravel parking</field>
@@ -108,6 +119,7 @@
         <field name="purchase_method">receive</field>
         <field name="service_type">manual</field>
         <field name="invoice_policy">order</field>
+        <field name="reinvoice_policy">sales_price</field>
     </record>
     <record id="product_template_35" model="product.template" context="{'create_product_product': False}">
         <field name="name">Guest WCs</field>
@@ -117,6 +129,7 @@
         <field name="purchase_method">receive</field>
         <field name="service_type">manual</field>
         <field name="invoice_policy">order</field>
+        <field name="reinvoice_policy">sales_price</field>
     </record>
     <record id="product_template_25" model="product.template" context="{'create_product_product': False}">
         <field name="name">Heat pump</field>
@@ -126,6 +139,7 @@
         <field name="purchase_method">receive</field>
         <field name="service_type">manual</field>
         <field name="invoice_policy">order</field>
+        <field name="reinvoice_policy">sales_price</field>
     </record>
     <record id="product_template_37" model="product.template" context="{'create_product_product': False}">
         <field name="name">Hot water system</field>
@@ -135,6 +149,7 @@
         <field name="purchase_method">receive</field>
         <field name="service_type">manual</field>
         <field name="invoice_policy">order</field>
+        <field name="reinvoice_policy">sales_price</field>
     </record>
     <record id="product_template_33" model="product.template" context="{'create_product_product': False}">
         <field name="name">Installation Labour</field>
@@ -146,6 +161,7 @@
         <field name="purchase_method">purchase</field>
         <field name="service_type">timesheet</field>
         <field name="invoice_policy">order</field>
+        <field name="reinvoice_policy">sales_price</field>
     </record>
     <record id="product_template_36" model="product.template" context="{'create_product_product': False}">
         <field name="name">Kitchen plumbing</field>
@@ -155,6 +171,7 @@
         <field name="purchase_method">receive</field>
         <field name="service_type">manual</field>
         <field name="invoice_policy">order</field>
+        <field name="reinvoice_policy">sales_price</field>
     </record>
     <record id="product_template_46" model="product.template" context="{'create_product_product': False}">
         <field name="name">Labour &amp; site management</field>
@@ -166,6 +183,7 @@
         <field name="purchase_method">purchase</field>
         <field name="service_type">timesheet</field>
         <field name="invoice_policy">order</field>
+        <field name="reinvoice_policy">sales_price</field>
     </record>
     <record id="product_template_41" model="product.template" context="{'create_product_product': False}">
         <field name="name">Labour &amp; supervision</field>
@@ -177,6 +195,7 @@
         <field name="purchase_method">purchase</field>
         <field name="service_type">timesheet</field>
         <field name="invoice_policy">order</field>
+        <field name="reinvoice_policy">sales_price</field>
     </record>
     <record id="product_template_56" model="product.template" context="{'create_product_product': False}">
         <field name="name">General Labour</field>
@@ -188,6 +207,7 @@
         <field name="purchase_method">purchase</field>
         <field name="service_type">timesheet</field>
         <field name="invoice_policy">delivery</field>
+        <field name="reinvoice_policy">sales_price</field>
     </record>
     <record id="product_template_30" model="product.template" context="{'create_product_product': False}">
         <field name="name">Lighting</field>
@@ -197,6 +217,7 @@
         <field name="purchase_method">receive</field>
         <field name="service_type">manual</field>
         <field name="invoice_policy">order</field>
+        <field name="reinvoice_policy">sales_price</field>
     </record>
     <record id="product_template_43" model="product.template" context="{'create_product_product': False}">
         <field name="name">New openings</field>
@@ -206,6 +227,7 @@
         <field name="purchase_method">receive</field>
         <field name="service_type">manual</field>
         <field name="invoice_policy">order</field>
+        <field name="reinvoice_policy">sales_price</field>
     </record>
     <record id="product_template_29" model="product.template" context="{'create_product_product': False}">
         <field name="name">New panel</field>
@@ -215,6 +237,7 @@
         <field name="purchase_method">receive</field>
         <field name="service_type">manual</field>
         <field name="invoice_policy">order</field>
+        <field name="reinvoice_policy">sales_price</field>
     </record>
     <record id="product_template_23" model="product.template" context="{'create_product_product': False}">
         <field name="name">Painting</field>
@@ -225,6 +248,7 @@
         <field name="purchase_method">receive</field>
         <field name="service_type">manual</field>
         <field name="invoice_policy">order</field>
+        <field name="reinvoice_policy">sales_price</field>
     </record>
     <record id="product_template_22" model="product.template" context="{'create_product_product': False}">
         <field name="name">Parquet</field>
@@ -235,6 +259,7 @@
         <field name="purchase_method">receive</field>
         <field name="service_type">manual</field>
         <field name="invoice_policy">order</field>
+        <field name="reinvoice_policy">sales_price</field>
     </record>
     <record id="product_template_53" model="product.template" context="{'create_product_product': False}">
         <field name="name">Plasterboard walls</field>
@@ -245,6 +270,7 @@
         <field name="purchase_method">receive</field>
         <field name="service_type">manual</field>
         <field name="invoice_policy">order</field>
+        <field name="reinvoice_policy">sales_price</field>
     </record>
     <record id="product_template_57" model="product.template" context="{'create_product_product': False}">
         <field name="name">Project Management</field>
@@ -257,6 +283,7 @@
         <field name="service_type">timesheet</field>
         <field name="invoice_policy">order</field>
         <field name="project_template_id" ref="project_project_3"/>
+        <field name="reinvoice_policy">sales_price</field>
     </record>
     <record id="product_template_58" model="product.template" context="{'create_product_product': False}">
         <field name="name">Purchase Management</field>
@@ -268,6 +295,7 @@
         <field name="purchase_method">purchase</field>
         <field name="service_type">timesheet</field>
         <field name="invoice_policy">order</field>
+        <field name="reinvoice_policy">sales_price</field>
     </record>
     <record id="product_template_15" model="product.template" context="{'create_product_product': False}">
         <field name="name">Ramp</field>
@@ -277,6 +305,7 @@
         <field name="purchase_method">receive</field>
         <field name="service_type">manual</field>
         <field name="invoice_policy">order</field>
+        <field name="reinvoice_policy">sales_price</field>
     </record>
     <record id="product_template_17" model="product.template" context="{'create_product_product': False}">
         <field name="name">Refrigeration</field>
@@ -286,6 +315,7 @@
         <field name="purchase_method">receive</field>
         <field name="service_type">manual</field>
         <field name="invoice_policy">order</field>
+        <field name="reinvoice_policy">sales_price</field>
     </record>
     <record id="product_template_42" model="product.template" context="{'create_product_product': False}">
         <field name="name">Reinforcement beams</field>
@@ -295,6 +325,7 @@
         <field name="purchase_method">receive</field>
         <field name="service_type">manual</field>
         <field name="invoice_policy">order</field>
+        <field name="reinvoice_policy">sales_price</field>
     </record>
     <record id="product_template_49" model="product.template" context="{'create_product_product': False}">
         <field name="name">Roof insulation</field>
@@ -305,6 +336,7 @@
         <field name="purchase_method">receive</field>
         <field name="service_type">manual</field>
         <field name="invoice_policy">order</field>
+        <field name="reinvoice_policy">sales_price</field>
     </record>
     <record id="product_template_48" model="product.template" context="{'create_product_product': False}">
         <field name="name">Roof structure repair</field>
@@ -314,6 +346,7 @@
         <field name="purchase_method">receive</field>
         <field name="service_type">manual</field>
         <field name="invoice_policy">order</field>
+        <field name="reinvoice_policy">sales_price</field>
     </record>
     <record id="product_template_26" model="product.template" context="{'create_product_product': False}">
         <field name="name">Room radiators</field>
@@ -323,6 +356,7 @@
         <field name="purchase_method">receive</field>
         <field name="service_type">manual</field>
         <field name="invoice_policy">order</field>
+        <field name="reinvoice_policy">sales_price</field>
     </record>
     <record id="product_template_45" model="product.template" context="{'create_product_product': False}">
         <field name="name">Screed</field>
@@ -333,6 +367,7 @@
         <field name="purchase_method">receive</field>
         <field name="service_type">manual</field>
         <field name="invoice_policy">order</field>
+        <field name="reinvoice_policy">sales_price</field>
     </record>
     <record id="product_template_40" model="product.template" context="{'create_product_product': False}">
         <field name="name">Site protection</field>
@@ -342,6 +377,7 @@
         <field name="purchase_method">receive</field>
         <field name="service_type">manual</field>
         <field name="invoice_policy">order</field>
+        <field name="reinvoice_policy">sales_price</field>
     </record>
     <record id="product_template_24" model="product.template" context="{'create_product_product': False}">
         <field name="name">Skirting &amp; details</field>
@@ -351,6 +387,7 @@
         <field name="purchase_method">receive</field>
         <field name="service_type">manual</field>
         <field name="invoice_policy">order</field>
+        <field name="reinvoice_policy">sales_price</field>
     </record>
     <record id="product_template_51" model="product.template" context="{'create_product_product': False}">
         <field name="name">Sliding doors</field>
@@ -360,6 +397,7 @@
         <field name="purchase_method">receive</field>
         <field name="service_type">manual</field>
         <field name="invoice_policy">order</field>
+        <field name="reinvoice_policy">sales_price</field>
     </record>
     <record id="product_template_31" model="product.template" context="{'create_product_product': False}">
         <field name="name">Sockets &amp; cabling</field>
@@ -369,6 +407,7 @@
         <field name="purchase_method">receive</field>
         <field name="service_type">manual</field>
         <field name="invoice_policy">order</field>
+        <field name="reinvoice_policy">sales_price</field>
     </record>
     <record id="product_template_18" model="product.template" context="{'create_product_product': False}">
         <field name="name">Stainless prep</field>
@@ -378,6 +417,7 @@
         <field name="purchase_method">receive</field>
         <field name="service_type">manual</field>
         <field name="invoice_policy">order</field>
+        <field name="reinvoice_policy">sales_price</field>
     </record>
     <record id="product_template_44" model="product.template" context="{'create_product_product': False}">
         <field name="name">Stone repair</field>
@@ -388,6 +428,7 @@
         <field name="purchase_method">receive</field>
         <field name="service_type">manual</field>
         <field name="invoice_policy">order</field>
+        <field name="reinvoice_policy">sales_price</field>
     </record>
     <record id="product_template_47" model="product.template" context="{'create_product_product': False}">
         <field name="name">Tile supply &amp; install</field>
@@ -398,6 +439,7 @@
         <field name="purchase_method">receive</field>
         <field name="service_type">manual</field>
         <field name="invoice_policy">order</field>
+        <field name="reinvoice_policy">sales_price</field>
     </record>
     <record id="product_template_21" model="product.template" context="{'create_product_product': False}">
         <field name="name">Tiling</field>
@@ -408,6 +450,7 @@
         <field name="purchase_method">receive</field>
         <field name="service_type">manual</field>
         <field name="invoice_policy">order</field>
+        <field name="reinvoice_policy">sales_price</field>
     </record>
     <record id="product_template_27" model="product.template" context="{'create_product_product': False}">
         <field name="name">VMC</field>
@@ -417,6 +460,7 @@
         <field name="purchase_method">receive</field>
         <field name="service_type">manual</field>
         <field name="invoice_policy">order</field>
+        <field name="reinvoice_policy">sales_price</field>
     </record>
     <record id="product_template_38" model="product.template" context="{'create_product_product': False}">
         <field name="name">Wall &amp; floor removal</field>
@@ -427,6 +471,7 @@
         <field name="purchase_method">receive</field>
         <field name="service_type">manual</field>
         <field name="invoice_policy">order</field>
+        <field name="reinvoice_policy">sales_price</field>
     </record>
     <record id="product_template_39" model="product.template" context="{'create_product_product': False}">
         <field name="name">Waste disposal</field>
@@ -436,6 +481,7 @@
         <field name="purchase_method">receive</field>
         <field name="service_type">manual</field>
         <field name="invoice_policy">order</field>
+        <field name="reinvoice_policy">sales_price</field>
     </record>
     <record id="product_template_50" model="product.template" context="{'create_product_product': False}">
         <field name="name">Windows</field>
@@ -445,6 +491,7 @@
         <field name="purchase_method">receive</field>
         <field name="service_type">manual</field>
         <field name="invoice_policy">order</field>
+        <field name="reinvoice_policy">sales_price</field>
     </record>
     <record id="product_template_8" model="product.template" context="{'create_product_product': False}">
         <field name="name">Wooden terrace</field>
@@ -455,6 +502,7 @@
         <field name="purchase_method">receive</field>
         <field name="service_type">manual</field>
         <field name="invoice_policy">order</field>
+        <field name="reinvoice_policy">sales_price</field>
     </record>
     <record id="product_template_79" model="product.template" context="{'create_product_product': False}">
         <field name="name">Excavator</field>
@@ -465,6 +513,7 @@
         <field name="purchase_method">receive</field>
         <field name="service_type">manual</field>
         <field name="invoice_policy">order</field>
+        <field name="reinvoice_policy">sales_price</field>
     </record>
     <record id="product_template_80" model="product.template" context="{'create_product_product': False, 'update_product_template_attribute_values': False}">
         <field name="name">Estimated Labour</field>
@@ -476,5 +525,6 @@
         <field name="service_type">timesheet</field>
         <field name="invoice_policy">order</field>
         <field name="service_policy">ordered_prepaid</field>
+        <field name="reinvoice_policy">sales_price</field>
     </record>
 </odoo>

--- a/construction/data/res_config_settings.xml
+++ b/construction/data/res_config_settings.xml
@@ -13,6 +13,7 @@
         <field name="documents_hr_settings" eval="1"/>
         <field name="group_analytic_accounting" eval="1"/>
         <field name="group_uom" eval="1"/>
+        <field name="group_services_and_material" eval="1"/>
     </record>
 
     <function name="execute" model="res.config.settings">


### PR DESCRIPTION
- Activate the Services & Materials setting by default in the industry configuration.
- Configure relevant service and material products with reinvoice_policy='sales_price'.
- Update the knowledge article with instructions explaining services and materials invoicing workflow and its behavior when adding invoice lines.

Task: 6410707