### PR TITLE
[FIX] industry_real_estate: make property field required

### DIFF
--- a/industry_real_estate/__manifest__.py
+++ b/industry_real_estate/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Property Management',
-    'version': '1.4',
+    'version': '1.5',
     'category': 'Services',
     'depends': [
         'base_automation',

--- a/industry_real_estate/data/ir_ui_views.xml
+++ b/industry_real_estate/data/ir_ui_views.xml
@@ -170,7 +170,7 @@
                 <attribute name="string">Tenant</attribute>
             </field>
             <field name="partner_id" position="after">
-                <field name="x_account_analytic_account_id" readonly="state == 'sale'"/>
+                <field name="x_account_analytic_account_id" readonly="state == 'sale'" required="True"/>
                 <field name="x_guarant_partner_id"/>
             </field>
             <xpath expr="//div[@name='plan_block']/span" position="replace"/>


### PR DESCRIPTION
Before this commit, the **Property** field on rental contracts was optional, allowing contracts to be created without an associated property. This commit makes the field mandatory to ensure every rental contract is linked to a property.

Task-6394316