### PR TITLE
[FIX] headhunter: assign string context during uninstall

### DIFF
--- a/headhunter/__manifest__.py
+++ b/headhunter/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Talent Acquisition',
-    'version': '1.7',
+    'version': '1.8',
     'category': 'Services',
     'depends': [
         'account',

--- a/headhunter/data/uninstall_hook.xml
+++ b/headhunter/data/uninstall_hook.xml
@@ -12,7 +12,7 @@
         <record id="uninstall_hook_action_server" model="ir.actions.server">
         <field name="code"><![CDATA[
 if hr_recruitment_action_hr_job_applications := env.ref('hr_recruitment.action_hr_job_applications', raise_if_not_found=False):
-    hr_recruitment_action_hr_job_applications['context'] = {'search_default_job_id': [active_id], 'search_default_applicants': 1, 'default_job_id': active_id, 'dialog_size':'medium', 'allow_search_matching_applicants': 1}
+    hr_recruitment_action_hr_job_applications['context'] = "{'search_default_job_id': [active_id], 'search_default_applicants': 1, 'default_job_id': active_id, 'dialog_size':'medium', 'allow_search_matching_applicants': 1}"
 
 if hr_recruitment_crm_case_categ0_act_job := env.ref('hr_recruitment.crm_case_categ0_act_job', raise_if_not_found=False):
     hr_recruitment_crm_case_categ0_act_job['context'] = {'search_default_applicants': 1}


### PR DESCRIPTION
Currently, an error occurs when user uninstalls `headhunter` industry.

Steps to replicate:
- Install `Headhunter`, Uninstall `Headhunter`.

Error:
```
NameError: name 'active_id' is not defined

ValueError: NameError('name 'active_id' is not defined') while evaluating
'if hr_recruitment_action_hr_job_applications := env.ref('hr_recruitment.action_hr_job_applications', raise_if_not_found=False):
    hr_recruitment_action_hr_job_applications['context'] = {'search_default_job_id': [active_id], 'search_default_applicants': 1, 'default_job_id': active_id, 'dialog_size':'medium', 'allow_search_matching_applicants': 1}

if hr_recruitment_crm_case_categ0_act_job := env.ref('hr_recruitment.crm_case_categ0_act_job', raise_if_not_found=False):
    hr_recruitment_crm_case_categ0_act_job['context'] = {'search_default_applicants': 1}'

```

Cause:
- The uninstall hook restores the `action_hr_job_application` window action's context. The context contain `active_id`, which is meant to be stored as a Python expression and evaluated only when the action is executed.

- The hook was instead assigning a Python dictionary, causing `active_id` to be evaluated immediately while the server action was running during module uninstallation. Since `active_id` is not available in that evaluation context, the uninstall failed with a `NameError`.

Solution:
- Restored the window action context as the string instead of a dictionary, so `active_id` is evaluated only when the action is executed rather than during module uninstallation.

sentry-7644005053