### PR TITLE
[FIX] booking_engine, hotel: restore functional housekeeping demo data

### DIFF
--- a/booking_engine/__manifest__.py
+++ b/booking_engine/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Booking',
-    'version': '1.24',
+    'version': '1.26',
     'category': 'Hospitality',
     'author': 'Odoo S.A.',
     'depends': [

--- a/booking_engine/data/ir_actions_act_window.xml
+++ b/booking_engine/data/ir_actions_act_window.xml
@@ -88,4 +88,12 @@
         <field name="view_mode">list,form</field>
         <field name="context" eval="{'default_calendar_id': ref('calendar_1', raise_if_not_found=False)}"/>
     </record>
+    <data noupdate="1">
+        <record id="planning.planning_action_my_calendar_view_gantt" model="ir.actions.act_window.view" forcecreate="0">
+            <field name="sequence" eval="1"/>
+        </record>
+        <record id="planning.planning_action_my_calendar_view_calendar" model="ir.actions.act_window.view" forcecreate="0">
+            <field name="sequence" eval="10"/>
+        </record>
+    </data>
 </odoo>

--- a/booking_engine/data/ir_model_fields.xml
+++ b/booking_engine/data/ir_model_fields.xml
@@ -616,10 +616,11 @@ for record in self:
         <field name="model_id" ref="resource.model_resource_resource" />
         <field name="store">False</field>
         <field name="compute"><![CDATA[
+for record in self:
+  record['x_time_allocated_today'] = 0
 today = datetime.datetime.today()
 resource_slots = self.env['planning.slot']._read_group([('resource_ids', 'in', self.ids), ('resource_ids.x_category', '=', 'house_keeping'), ('end_datetime', '>=', today)], ['resource_ids'], ['id:recordset'])
-for slots, resource in resource_slots:
-  resource['x_time_allocated_today'] = 0
+for resource, slots in resource_slots:
   for slot in slots:
     if slot.start_datetime.date() <= today.date():
       resource['x_time_allocated_today'] += max((min(slot.end_datetime, today.replace(hour=23, minute=59, second=59)) - max(today, slot.start_datetime)).total_seconds(), 0)

--- a/booking_engine/data/ir_ui_view.xml
+++ b/booking_engine/data/ir_ui_view.xml
@@ -142,6 +142,11 @@
         <xpath expr="//filter[@name='group_by_role']" position="after">
           <filter string="Customer" name="Customer" context="{'group_by':'partner_id'}"/>
         </xpath>
+        <xpath expr="//filter[@name='conflict_shifts']" position="before">
+          <filter string="Today's Check In" name="filter_checkin_today" domain="[('sale_order_id.rental_status', '=', 'pickup'), ('sale_order_id.rental_start_date', '&gt;=', 'today'), ('sale_order_id.rental_start_date', '&lt;', 'today +1d')]"/>
+          <filter string="Today's Check Out" name="filter_checkout_today" domain="[('sale_order_id.rental_status', '=', 'return'), ('sale_order_id.rental_return_date', '&gt;=', 'today'), ('sale_order_id.rental_return_date', '&lt;', 'today +1d')]"/>
+          <separator/>
+        </xpath>
     </field>
     <field name="inherit_id" ref="planning.planning_view_search"/>
     <field name="mode">primary</field>
@@ -194,10 +199,11 @@
     <field name="type">kanban</field>
     <field name="active" eval="True"/>
   </record>
-  <record id="sale_planning.planning_role_view_tree_inherit_sale_planning" model="ir.ui.view" forcecreate="1">
-    <field name="name">planning.role.list.inherit.sale.planning</field>
+  <record id="booking_engine_planning_role_view_tree" model="ir.ui.view">
+    <field name="name">planning.role.list.inherit.booking_engine</field>
     <field name="model">planning.role</field>
     <field name="inherit_id" ref="planning.planning_role_view_tree"/>
+    <field name="mode">primary</field>
     <field name="arch" type="xml">
         <xpath expr="//field[@name='resource_ids']" position="after">
             <field name="product_ids" widget="many2many_tags" placeholder="e.g. Cleaning Services" context="{'default_type': 'service', 'default_planning_enabled': True, 'default_planning_role_id': id}"/>
@@ -228,7 +234,7 @@
         </xpath>
     </field>
     <field name="inherit_id" ref="planning.planning_role_view_form"/>
-    <field name="mode">extension</field>
+    <field name="mode">primary</field>
     <field name="model">planning.role</field>
     <field name="name">planning.role.form.inherit.booking_engine</field>
     <field name="priority">160</field>
@@ -581,7 +587,8 @@
     <field name="search_view_id" ref="booking_engine_planning_role_view_search"/>
     <field name="view_ids" eval="[
       (5, 0, 0),
-      (0, 0, {'view_mode': 'list', 'view_id': ref('planning.planning_role_view_tree')}),
+      (0, 0, {'view_mode': 'list', 'view_id': ref('booking_engine_planning_role_view_tree')}),
+      (0, 0, {'view_mode': 'form', 'view_id': ref('planning_form_view')}),
     ]"/>
   </record>
   <record id="booking_engine_rooms_resources_action" model="ir.actions.act_window">
@@ -1054,23 +1061,10 @@
           </xpath>
       </field>
   </record>
-  <record id="planning_search_view_inherit_booking_engine" model="ir.ui.view">
-    <field name="name">planning.slot.search.inherit.booking_engine</field>
-    <field name="model">planning.slot</field>
-    <field name="inherit_id" ref="planning.planning_view_search_base"/>
-    <field name="mode">extension</field>
-    <field name="active" eval="True"/>
-    <field name="arch" type="xml">
-        <xpath expr="//filter[@name='conflict_shifts']" position="before">
-          <filter string="Today's Check In" name="filter_checkin_today" domain="[('sale_order_id.rental_status', '=', 'pickup'), ('sale_order_id.rental_start_date', '&gt;=', 'today'), ('sale_order_id.rental_start_date', '&lt;', 'today +1d')]"/>
-          <filter string="Today's Check Out" name="filter_checkout_today" domain="[('sale_order_id.rental_status', '=', 'return'), ('sale_order_id.rental_return_date', '&gt;=', 'today'), ('sale_order_id.rental_return_date', '&lt;', 'today +1d')]"/>
-          <separator/>
-        </xpath>
-    </field>
-  </record>
+
   <record id="view_inherit_planning_role_kanban" model="ir.ui.view">
     <field name="inherit_id" ref="planning.planning_role_view_kanban"/>
-    <field name="mode">extension</field>
+    <field name="mode">primary</field>
     <field name="model">planning.role</field>
     <field name="type">kanban</field>
     <field name="active" eval="True"/>

--- a/booking_engine/demo/hr_employee.xml
+++ b/booking_engine/demo/hr_employee.xml
@@ -6,7 +6,9 @@
         <field name="address_id" ref="base.main_partner"/>
         <field name="job_title">Room Cleaner</field>
         <field name="planning_role_ids" eval="[(6, 0, [ref('house_keeping_planning_role')])]"/>
-        <field name="resource_calendar_id" ref="resource.resource_calendar_std"/>
+        <field name="resource_calendar_id" eval="False"/>
+        <field name="hours_per_week">40.0</field>
+        <field name="hours_per_day">0.0</field>
     </record>
     <record id="hr_employee_3" model="hr.employee">
         <field name="name">Jan Itor</field>
@@ -14,7 +16,9 @@
         <field name="address_id" ref="base.main_partner"/>
         <field name="job_title">Room Cleaner</field>
         <field name="planning_role_ids" eval="[(6, 0, [ref('house_keeping_planning_role')])]"/>
-        <field name="resource_calendar_id" ref="resource.resource_calendar_std"/>
+        <field name="resource_calendar_id" eval="False"/>
+        <field name="hours_per_week">40.0</field>
+        <field name="hours_per_day">0.0</field>
     </record>
     <record id="hr_employee_4" model="hr.employee">
         <field name="name">Polly Shine</field>
@@ -22,6 +26,8 @@
         <field name="address_id" ref="base.main_partner"/>
         <field name="job_title">Room Cleaner</field>
         <field name="planning_role_ids" eval="[(6, 0, [ref('house_keeping_planning_role')])]"/>
-        <field name="resource_calendar_id" ref="resource.resource_calendar_std"/>
+        <field name="resource_calendar_id" eval="False"/>
+        <field name="hours_per_week">40.0</field>
+        <field name="hours_per_day">0.0</field>
     </record>
 </odoo>

--- a/campsite/__manifest__.py
+++ b/campsite/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Campsite',
-    'version': '1.8',
+    'version': '1.9',
     'category': 'Hospitality',
     'author': 'Odoo S.A.',
     'depends': [

--- a/campsite/demo/planning_slot_post.xml
+++ b/campsite/demo/planning_slot_post.xml
@@ -1,4 +1,250 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo>
+    <data noupdate="1">
+        <record id="planning_slot_26" model="planning.slot">
+            <field name="start_datetime" eval="DateTime.now().replace(hour=7, minute=0, second=0, microsecond=0) + relativedelta(days=11)"/>
+            <field name="end_datetime" eval="DateTime.now().replace(hour=11, minute=0, second=0, microsecond=0) + relativedelta(days=11)"/>
+            <field name="template_id" ref="booking_engine.planning_slot_template_1"/>
+            <field name="role_id" ref="booking_engine.house_keeping_planning_role"/>
+            <field name="x_nights">1</field>
+        </record>
+        <record id="planning_slot_25" model="planning.slot">
+            <field name="start_datetime" eval="DateTime.now().replace(hour=7, minute=0, second=0, microsecond=0) + relativedelta(days=11)"/>
+            <field name="end_datetime" eval="DateTime.now().replace(hour=9, minute=0, second=0, microsecond=0) + relativedelta(days=11)"/>
+            <field name="template_id" ref="booking_engine.planning_slot_template_2"/>
+            <field name="role_id" ref="booking_engine.house_keeping_planning_role"/>
+            <field name="x_nights">1</field>
+        </record>
+        <record id="planning_slot_24" model="planning.slot">
+            <field name="start_datetime" eval="DateTime.now().replace(hour=7, minute=0, second=0, microsecond=0) + relativedelta(days=11)"/>
+            <field name="end_datetime" eval="DateTime.now().replace(hour=11, minute=0, second=0, microsecond=0) + relativedelta(days=11)"/>
+            <field name="template_id" ref="booking_engine.planning_slot_template_1"/>
+            <field name="role_id" ref="booking_engine.house_keeping_planning_role"/>
+            <field name="x_nights">1</field>
+        </record>
+        <record id="planning_slot_29" model="planning.slot">
+            <field name="start_datetime" eval="DateTime.now().replace(hour=7, minute=0, second=0, microsecond=0) + relativedelta(days=10)"/>
+            <field name="end_datetime" eval="DateTime.now().replace(hour=11, minute=0, second=0, microsecond=0) + relativedelta(days=10)"/>
+            <field name="template_id" ref="booking_engine.planning_slot_template_1"/>
+            <field name="role_id" ref="booking_engine.house_keeping_planning_role"/>
+            <field name="x_nights">1</field>
+        </record>
+        <record id="planning_slot_28" model="planning.slot">
+            <field name="start_datetime" eval="DateTime.now().replace(hour=7, minute=0, second=0, microsecond=0) + relativedelta(days=10)"/>
+            <field name="end_datetime" eval="DateTime.now().replace(hour=9, minute=0, second=0, microsecond=0) + relativedelta(days=10)"/>
+            <field name="template_id" ref="booking_engine.planning_slot_template_2"/>
+            <field name="role_id" ref="booking_engine.house_keeping_planning_role"/>
+            <field name="x_nights">1</field>
+        </record>
+        <record id="planning_slot_27" model="planning.slot">
+            <field name="start_datetime" eval="DateTime.now().replace(hour=7, minute=0, second=0, microsecond=0) + relativedelta(days=10)"/>
+            <field name="end_datetime" eval="DateTime.now().replace(hour=9, minute=0, second=0, microsecond=0) + relativedelta(days=10)"/>
+            <field name="template_id" ref="booking_engine.planning_slot_template_2"/>
+            <field name="role_id" ref="booking_engine.house_keeping_planning_role"/>
+            <field name="x_nights">1</field>
+        </record>
+        <record id="planning_slot_31" model="planning.slot">
+            <field name="start_datetime" eval="DateTime.now().replace(hour=7, minute=0, second=0, microsecond=0) + relativedelta(days=9)"/>
+            <field name="end_datetime" eval="DateTime.now().replace(hour=11, minute=0, second=0, microsecond=0) + relativedelta(days=9)"/>
+            <field name="template_id" ref="booking_engine.planning_slot_template_1"/>
+            <field name="role_id" ref="booking_engine.house_keeping_planning_role"/>
+            <field name="x_nights">1</field>
+        </record>
+        <record id="planning_slot_30" model="planning.slot">
+            <field name="start_datetime" eval="DateTime.now().replace(hour=7, minute=0, second=0, microsecond=0) + relativedelta(days=9)"/>
+            <field name="end_datetime" eval="DateTime.now().replace(hour=9, minute=0, second=0, microsecond=0) + relativedelta(days=9)"/>
+            <field name="template_id" ref="booking_engine.planning_slot_template_2"/>
+            <field name="role_id" ref="booking_engine.house_keeping_planning_role"/>
+            <field name="x_nights">1</field>
+        </record>
+        <record id="planning_slot_33" model="planning.slot">
+            <field name="start_datetime" eval="DateTime.now().replace(hour=7, minute=0, second=0, microsecond=0) + relativedelta(days=8)"/>
+            <field name="end_datetime" eval="DateTime.now().replace(hour=11, minute=0, second=0, microsecond=0) + relativedelta(days=8)"/>
+            <field name="template_id" ref="booking_engine.planning_slot_template_1"/>
+            <field name="role_id" ref="booking_engine.house_keeping_planning_role"/>
+            <field name="x_nights">1</field>
+        </record>
+        <record id="planning_slot_32" model="planning.slot">
+            <field name="start_datetime" eval="DateTime.now().replace(hour=7, minute=0, second=0, microsecond=0) + relativedelta(days=8)"/>
+            <field name="end_datetime" eval="DateTime.now().replace(hour=9, minute=0, second=0, microsecond=0) + relativedelta(days=8)"/>
+            <field name="template_id" ref="booking_engine.planning_slot_template_2"/>
+            <field name="role_id" ref="booking_engine.house_keeping_planning_role"/>
+            <field name="x_nights">1</field>
+        </record>
+        <record id="planning_slot_35" model="planning.slot">
+            <field name="start_datetime" eval="DateTime.now().replace(hour=7, minute=0, second=0, microsecond=0) + relativedelta(days=7)"/>
+            <field name="end_datetime" eval="DateTime.now().replace(hour=11, minute=0, second=0, microsecond=0) + relativedelta(days=7)"/>
+            <field name="template_id" ref="booking_engine.planning_slot_template_1"/>
+            <field name="role_id" ref="booking_engine.house_keeping_planning_role"/>
+            <field name="x_nights">1</field>
+        </record>
+        <record id="planning_slot_34" model="planning.slot">
+            <field name="start_datetime" eval="DateTime.now().replace(hour=7, minute=0, second=0, microsecond=0) + relativedelta(days=7)"/>
+            <field name="end_datetime" eval="DateTime.now().replace(hour=9, minute=0, second=0, microsecond=0) + relativedelta(days=7)"/>
+            <field name="template_id" ref="booking_engine.planning_slot_template_2"/>
+            <field name="role_id" ref="booking_engine.house_keeping_planning_role"/>
+            <field name="x_nights">1</field>
+        </record>
+        <record id="planning_slot_38" model="planning.slot">
+            <field name="start_datetime" eval="DateTime.now().replace(hour=7, minute=0, second=0, microsecond=0) + relativedelta(days=6)"/>
+            <field name="end_datetime" eval="DateTime.now().replace(hour=11, minute=0, second=0, microsecond=0) + relativedelta(days=6)"/>
+            <field name="template_id" ref="booking_engine.planning_slot_template_1"/>
+            <field name="role_id" ref="booking_engine.house_keeping_planning_role"/>
+            <field name="x_nights">1</field>
+        </record>
+        <record id="planning_slot_37" model="planning.slot">
+            <field name="start_datetime" eval="DateTime.now().replace(hour=7, minute=0, second=0, microsecond=0) + relativedelta(days=6)"/>
+            <field name="end_datetime" eval="DateTime.now().replace(hour=9, minute=0, second=0, microsecond=0) + relativedelta(days=6)"/>
+            <field name="template_id" ref="booking_engine.planning_slot_template_2"/>
+            <field name="role_id" ref="booking_engine.house_keeping_planning_role"/>
+            <field name="x_nights">1</field>
+        </record>
+        <record id="planning_slot_36" model="planning.slot">
+            <field name="start_datetime" eval="DateTime.now().replace(hour=7, minute=0, second=0, microsecond=0) + relativedelta(days=6)"/>
+            <field name="end_datetime" eval="DateTime.now().replace(hour=9, minute=0, second=0, microsecond=0) + relativedelta(days=6)"/>
+            <field name="template_id" ref="booking_engine.planning_slot_template_2"/>
+            <field name="role_id" ref="booking_engine.house_keeping_planning_role"/>
+            <field name="x_nights">1</field>
+        </record>
+        <record id="planning_slot_40" model="planning.slot">
+            <field name="start_datetime" eval="DateTime.now().replace(hour=7, minute=0, second=0, microsecond=0) + relativedelta(days=5)"/>
+            <field name="end_datetime" eval="DateTime.now().replace(hour=11, minute=0, second=0, microsecond=0) + relativedelta(days=5)"/>
+            <field name="template_id" ref="booking_engine.planning_slot_template_1"/>
+            <field name="role_id" ref="booking_engine.house_keeping_planning_role"/>
+            <field name="x_nights">1</field>
+        </record>
+        <record id="planning_slot_39" model="planning.slot">
+            <field name="start_datetime" eval="DateTime.now().replace(hour=7, minute=0, second=0, microsecond=0) + relativedelta(days=5)"/>
+            <field name="end_datetime" eval="DateTime.now().replace(hour=9, minute=0, second=0, microsecond=0) + relativedelta(days=5)"/>
+            <field name="template_id" ref="booking_engine.planning_slot_template_2"/>
+            <field name="role_id" ref="booking_engine.house_keeping_planning_role"/>
+            <field name="x_nights">1</field>
+        </record>
+        <record id="planning_slot_23" model="planning.slot">
+            <field name="start_datetime" eval="DateTime.now().replace(hour=7, minute=0, second=0, microsecond=0) + relativedelta(days=4)"/>
+            <field name="end_datetime" eval="DateTime.now().replace(hour=11, minute=0, second=0, microsecond=0) + relativedelta(days=4)"/>
+            <field name="template_id" ref="booking_engine.planning_slot_template_1"/>
+            <field name="role_id" ref="booking_engine.house_keeping_planning_role"/>
+            <field name="x_nights">1</field>
+        </record>
+        <record id="planning_slot_20" model="planning.slot">
+            <field name="start_datetime" eval="DateTime.now().replace(hour=7, minute=0, second=0, microsecond=0) + relativedelta(days=4)"/>
+            <field name="end_datetime" eval="DateTime.now().replace(hour=9, minute=0, second=0, microsecond=0) + relativedelta(days=4)"/>
+            <field name="template_id" ref="booking_engine.planning_slot_template_2"/>
+            <field name="role_id" ref="booking_engine.house_keeping_planning_role"/>
+            <field name="x_nights">1</field>
+        </record>
+        <record id="planning_slot_16" model="planning.slot">
+            <field name="start_datetime" eval="DateTime.now().replace(hour=7, minute=0, second=0, microsecond=0) + relativedelta(days=4)"/>
+            <field name="end_datetime" eval="DateTime.now().replace(hour=11, minute=0, second=0, microsecond=0) + relativedelta(days=4)"/>
+            <field name="template_id" ref="booking_engine.planning_slot_template_1"/>
+            <field name="role_id" ref="booking_engine.house_keeping_planning_role"/>
+            <field name="x_nights">1</field>
+        </record>
+        <record id="planning_slot_22" model="planning.slot">
+            <field name="start_datetime" eval="DateTime.now().replace(hour=7, minute=0, second=0, microsecond=0) + relativedelta(days=3)"/>
+            <field name="end_datetime" eval="DateTime.now().replace(hour=9, minute=0, second=0, microsecond=0) + relativedelta(days=3)"/>
+            <field name="template_id" ref="booking_engine.planning_slot_template_2"/>
+            <field name="role_id" ref="booking_engine.house_keeping_planning_role"/>
+            <field name="x_nights">1</field>
+        </record>
+        <record id="planning_slot_19" model="planning.slot">
+            <field name="start_datetime" eval="DateTime.now().replace(hour=7, minute=0, second=0, microsecond=0) + relativedelta(days=3)"/>
+            <field name="end_datetime" eval="DateTime.now().replace(hour=9, minute=0, second=0, microsecond=0) + relativedelta(days=3)"/>
+            <field name="template_id" ref="booking_engine.planning_slot_template_2"/>
+            <field name="role_id" ref="booking_engine.house_keeping_planning_role"/>
+            <field name="x_nights">1</field>
+        </record>
+        <record id="planning_slot_15" model="planning.slot">
+            <field name="start_datetime" eval="DateTime.now().replace(hour=7, minute=0, second=0, microsecond=0) + relativedelta(days=3)"/>
+            <field name="end_datetime" eval="DateTime.now().replace(hour=11, minute=0, second=0, microsecond=0) + relativedelta(days=3)"/>
+            <field name="template_id" ref="booking_engine.planning_slot_template_1"/>
+            <field name="role_id" ref="booking_engine.house_keeping_planning_role"/>
+            <field name="x_nights">1</field>
+        </record>
+        <record id="planning_slot_18" model="planning.slot">
+            <field name="start_datetime" eval="DateTime.now().replace(hour=7, minute=0, second=0, microsecond=0) + relativedelta(days=2)"/>
+            <field name="end_datetime" eval="DateTime.now().replace(hour=9, minute=0, second=0, microsecond=0) + relativedelta(days=2)"/>
+            <field name="template_id" ref="booking_engine.planning_slot_template_2"/>
+            <field name="role_id" ref="booking_engine.house_keeping_planning_role"/>
+            <field name="x_nights">1</field>
+        </record>
+        <record id="planning_slot_14" model="planning.slot">
+            <field name="start_datetime" eval="DateTime.now().replace(hour=7, minute=0, second=0, microsecond=0) + relativedelta(days=2)"/>
+            <field name="end_datetime" eval="DateTime.now().replace(hour=11, minute=0, second=0, microsecond=0) + relativedelta(days=2)"/>
+            <field name="template_id" ref="booking_engine.planning_slot_template_1"/>
+            <field name="role_id" ref="booking_engine.house_keeping_planning_role"/>
+            <field name="x_nights">1</field>
+        </record>
+        <record id="planning_slot_17" model="planning.slot">
+            <field name="start_datetime" eval="DateTime.now().replace(hour=7, minute=0, second=0, microsecond=0) + relativedelta(days=1)"/>
+            <field name="end_datetime" eval="DateTime.now().replace(hour=9, minute=0, second=0, microsecond=0) + relativedelta(days=1)"/>
+            <field name="template_id" ref="booking_engine.planning_slot_template_2"/>
+            <field name="role_id" ref="booking_engine.house_keeping_planning_role"/>
+            <field name="x_nights">1</field>
+        </record>
+        <record id="planning_slot_13" model="planning.slot">
+            <field name="start_datetime" eval="DateTime.now().replace(hour=7, minute=0, second=0, microsecond=0) + relativedelta(days=1)"/>
+            <field name="end_datetime" eval="DateTime.now().replace(hour=11, minute=0, second=0, microsecond=0) + relativedelta(days=1)"/>
+            <field name="template_id" ref="booking_engine.planning_slot_template_1"/>
+            <field name="role_id" ref="booking_engine.house_keeping_planning_role"/>
+            <field name="x_nights">1</field>
+        </record>
+        <record id="planning_slot_10" model="planning.slot">
+            <field name="start_datetime" eval="DateTime.now().replace(hour=7, minute=0, second=0, microsecond=0)"/>
+            <field name="end_datetime" eval="DateTime.now().replace(hour=9, minute=0, second=0, microsecond=0)"/>
+            <field name="template_id" ref="booking_engine.planning_slot_template_2"/>
+            <field name="role_id" ref="booking_engine.house_keeping_planning_role"/>
+            <field name="x_nights">1</field>
+        </record>
+        <record id="planning_slot_9" model="planning.slot">
+            <field name="start_datetime" eval="DateTime.now().replace(hour=7, minute=0, second=0, microsecond=0)"/>
+            <field name="end_datetime" eval="DateTime.now().replace(hour=11, minute=0, second=0, microsecond=0)"/>
+            <field name="template_id" ref="booking_engine.planning_slot_template_1"/>
+            <field name="role_id" ref="booking_engine.house_keeping_planning_role"/>
+            <field name="x_nights">1</field>
+        </record>
+        <record id="planning_slot_21" model="planning.slot">
+            <field name="start_datetime" eval="DateTime.now().replace(hour=7, minute=0, second=0, microsecond=0) - relativedelta(days=1)"/>
+            <field name="end_datetime" eval="DateTime.now().replace(hour=9, minute=0, second=0, microsecond=0) - relativedelta(days=1)"/>
+            <field name="template_id" ref="booking_engine.planning_slot_template_2"/>
+            <field name="role_id" ref="booking_engine.house_keeping_planning_role"/>
+            <field name="x_nights">1</field>
+        </record>
+        <record id="planning_slot_7" model="planning.slot">
+            <field name="start_datetime" eval="DateTime.now().replace(hour=7, minute=0, second=0, microsecond=0) - relativedelta(days=1)"/>
+            <field name="end_datetime" eval="DateTime.now().replace(hour=11, minute=0, second=0, microsecond=0) - relativedelta(days=1)"/>
+            <field name="template_id" ref="booking_engine.planning_slot_template_1"/>
+            <field name="role_id" ref="booking_engine.house_keeping_planning_role"/>
+            <field name="x_nights">1</field>
+        </record>
+        <record id="planning_slot_12" model="planning.slot">
+            <field name="start_datetime" eval="DateTime.now().replace(hour=7, minute=0, second=0, microsecond=0) - relativedelta(days=2)"/>
+            <field name="end_datetime" eval="DateTime.now().replace(hour=9, minute=0, second=0, microsecond=0) - relativedelta(days=2)"/>
+            <field name="template_id" ref="booking_engine.planning_slot_template_2"/>
+            <field name="role_id" ref="booking_engine.house_keeping_planning_role"/>
+            <field name="x_nights">1</field>
+        </record>
+        <record id="planning_slot_11" model="planning.slot">
+            <field name="start_datetime" eval="DateTime.now().replace(hour=7, minute=0, second=0, microsecond=0) - relativedelta(days=2)"/>
+            <field name="end_datetime" eval="DateTime.now().replace(hour=11, minute=0, second=0, microsecond=0) - relativedelta(days=2)"/>
+            <field name="template_id" ref="booking_engine.planning_slot_template_1"/>
+            <field name="role_id" ref="booking_engine.house_keeping_planning_role"/>
+            <field name="x_nights">1</field>
+        </record>
+
+        <function name="auto_plan_ids" model="planning.slot" context="{'planning_slot_id': ref('planning_slot_7')}">
+          <value eval="[]"/>
+        </function>
+
+        <function name="action_send" model="planning.send">
+            <value model="planning.send" eval="[obj().env['planning.send'].create({
+                'employee_ids': [(6, 0, [ref('booking_engine.hr_employee_2'), ref('booking_engine.hr_employee_3'), ref('booking_engine.hr_employee_4')])],
+                'start_datetime': DateTime.now().replace(hour=0, minute=0, second=0, microsecond=0) - relativedelta(days=3),
+                'end_datetime': DateTime.now().replace(hour=23, minute=59, second=59, microsecond=999999) + relativedelta(days=4),
+            }).id]"/>
+        </function>
+    </data>
+
     <function name="run" model="ir.actions.server" eval="[ref('booking_engine.server_action_update_rooms')]"/>
 </odoo>

--- a/hotel/__manifest__.py
+++ b/hotel/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Hotel',
-    'version': '1.9',
+    'version': '1.10',
     'category': 'Hospitality',
     'author': 'Odoo S.A.',
     'depends': [
@@ -37,7 +37,6 @@
         'demo/sale_order_line.xml',
         'demo/sale_order_post.xml',
         'demo/planning_slot_post.xml',
-
         'demo/website/website.xml',
         'demo/website/server_actions.xml',
         'demo/website/assets.xml',

--- a/hotel/demo/planning_slot_post.xml
+++ b/hotel/demo/planning_slot_post.xml
@@ -2,239 +2,232 @@
 <odoo>
     <data noupdate="1">
         <record id="planning_slot_26" model="planning.slot">
-            <field name="start_datetime" eval="DateTime.now().replace(hour=7) + relativedelta(days=11)"/>
-            <field name="end_datetime" eval="DateTime.now().replace(hour=11) + relativedelta(days=11)"/>
+            <field name="start_datetime" eval="DateTime.now().replace(hour=7, minute=0, second=0, microsecond=0) + relativedelta(days=11)"/>
+            <field name="end_datetime" eval="DateTime.now().replace(hour=11, minute=0, second=0, microsecond=0) + relativedelta(days=11)"/>
             <field name="template_id" ref="booking_engine.planning_slot_template_1"/>
             <field name="role_id" ref="booking_engine.house_keeping_planning_role"/>
             <field name="x_nights">1</field>
         </record>
         <record id="planning_slot_25" model="planning.slot">
-            <field name="start_datetime" eval="DateTime.now().replace(hour=7) + relativedelta(days=11)"/>
-            <field name="end_datetime" eval="DateTime.now().replace(hour=9) + relativedelta(days=11)"/>
+            <field name="start_datetime" eval="DateTime.now().replace(hour=7, minute=0, second=0, microsecond=0) + relativedelta(days=11)"/>
+            <field name="end_datetime" eval="DateTime.now().replace(hour=9, minute=0, second=0, microsecond=0) + relativedelta(days=11)"/>
             <field name="template_id" ref="booking_engine.planning_slot_template_2"/>
             <field name="role_id" ref="booking_engine.house_keeping_planning_role"/>
             <field name="x_nights">1</field>
         </record>
         <record id="planning_slot_24" model="planning.slot">
-            <field name="start_datetime" eval="DateTime.now().replace(hour=7) + relativedelta(days=11)"/>
-            <field name="end_datetime" eval="DateTime.now().replace(hour=11) + relativedelta(days=11)"/>
+            <field name="start_datetime" eval="DateTime.now().replace(hour=7, minute=0, second=0, microsecond=0) + relativedelta(days=11)"/>
+            <field name="end_datetime" eval="DateTime.now().replace(hour=11, minute=0, second=0, microsecond=0) + relativedelta(days=11)"/>
             <field name="template_id" ref="booking_engine.planning_slot_template_1"/>
             <field name="role_id" ref="booking_engine.house_keeping_planning_role"/>
             <field name="x_nights">1</field>
         </record>
         <record id="planning_slot_29" model="planning.slot">
-            <field name="start_datetime" eval="DateTime.now().replace(hour=7) + relativedelta(days=10)"/>
-            <field name="end_datetime" eval="DateTime.now().replace(hour=11) + relativedelta(days=10)"/>
+            <field name="start_datetime" eval="DateTime.now().replace(hour=7, minute=0, second=0, microsecond=0) + relativedelta(days=10)"/>
+            <field name="end_datetime" eval="DateTime.now().replace(hour=11, minute=0, second=0, microsecond=0) + relativedelta(days=10)"/>
             <field name="template_id" ref="booking_engine.planning_slot_template_1"/>
             <field name="role_id" ref="booking_engine.house_keeping_planning_role"/>
             <field name="x_nights">1</field>
         </record>
         <record id="planning_slot_28" model="planning.slot">
-            <field name="start_datetime" eval="DateTime.now().replace(hour=7) + relativedelta(days=10)"/>
-            <field name="end_datetime" eval="DateTime.now().replace(hour=9) + relativedelta(days=10)"/>
+            <field name="start_datetime" eval="DateTime.now().replace(hour=7, minute=0, second=0, microsecond=0) + relativedelta(days=10)"/>
+            <field name="end_datetime" eval="DateTime.now().replace(hour=9, minute=0, second=0, microsecond=0) + relativedelta(days=10)"/>
             <field name="template_id" ref="booking_engine.planning_slot_template_2"/>
             <field name="role_id" ref="booking_engine.house_keeping_planning_role"/>
             <field name="x_nights">1</field>
         </record>
         <record id="planning_slot_27" model="planning.slot">
-            <field name="start_datetime" eval="DateTime.now().replace(hour=7) + relativedelta(days=10)"/>
-            <field name="end_datetime" eval="DateTime.now().replace(hour=9) + relativedelta(days=10)"/>
+            <field name="start_datetime" eval="DateTime.now().replace(hour=7, minute=0, second=0, microsecond=0) + relativedelta(days=10)"/>
+            <field name="end_datetime" eval="DateTime.now().replace(hour=9, minute=0, second=0, microsecond=0) + relativedelta(days=10)"/>
             <field name="template_id" ref="booking_engine.planning_slot_template_2"/>
             <field name="role_id" ref="booking_engine.house_keeping_planning_role"/>
             <field name="x_nights">1</field>
         </record>
         <record id="planning_slot_31" model="planning.slot">
-            <field name="start_datetime" eval="DateTime.now().replace(hour=7) + relativedelta(days=9)"/>
-            <field name="end_datetime" eval="DateTime.now().replace(hour=11) + relativedelta(days=9)"/>
+            <field name="start_datetime" eval="DateTime.now().replace(hour=7, minute=0, second=0, microsecond=0) + relativedelta(days=9)"/>
+            <field name="end_datetime" eval="DateTime.now().replace(hour=11, minute=0, second=0, microsecond=0) + relativedelta(days=9)"/>
             <field name="template_id" ref="booking_engine.planning_slot_template_1"/>
             <field name="role_id" ref="booking_engine.house_keeping_planning_role"/>
             <field name="x_nights">1</field>
         </record>
         <record id="planning_slot_30" model="planning.slot">
-            <field name="start_datetime" eval="DateTime.now().replace(hour=7) + relativedelta(days=9)"/>
-            <field name="end_datetime" eval="DateTime.now().replace(hour=9) + relativedelta(days=9)"/>
+            <field name="start_datetime" eval="DateTime.now().replace(hour=7, minute=0, second=0, microsecond=0) + relativedelta(days=9)"/>
+            <field name="end_datetime" eval="DateTime.now().replace(hour=9, minute=0, second=0, microsecond=0) + relativedelta(days=9)"/>
             <field name="template_id" ref="booking_engine.planning_slot_template_2"/>
             <field name="role_id" ref="booking_engine.house_keeping_planning_role"/>
             <field name="x_nights">1</field>
         </record>
         <record id="planning_slot_33" model="planning.slot">
-            <field name="start_datetime" eval="DateTime.now().replace(hour=7) + relativedelta(days=8)"/>
-            <field name="end_datetime" eval="DateTime.now().replace(hour=11) + relativedelta(days=8)"/>
+            <field name="start_datetime" eval="DateTime.now().replace(hour=7, minute=0, second=0, microsecond=0) + relativedelta(days=8)"/>
+            <field name="end_datetime" eval="DateTime.now().replace(hour=11, minute=0, second=0, microsecond=0) + relativedelta(days=8)"/>
             <field name="template_id" ref="booking_engine.planning_slot_template_1"/>
             <field name="role_id" ref="booking_engine.house_keeping_planning_role"/>
             <field name="x_nights">1</field>
         </record>
         <record id="planning_slot_32" model="planning.slot">
-            <field name="start_datetime" eval="DateTime.now().replace(hour=7) + relativedelta(days=8)"/>
-            <field name="end_datetime" eval="DateTime.now().replace(hour=9) + relativedelta(days=8)"/>
+            <field name="start_datetime" eval="DateTime.now().replace(hour=7, minute=0, second=0, microsecond=0) + relativedelta(days=8)"/>
+            <field name="end_datetime" eval="DateTime.now().replace(hour=9, minute=0, second=0, microsecond=0) + relativedelta(days=8)"/>
             <field name="template_id" ref="booking_engine.planning_slot_template_2"/>
             <field name="role_id" ref="booking_engine.house_keeping_planning_role"/>
             <field name="x_nights">1</field>
         </record>
         <record id="planning_slot_35" model="planning.slot">
-            <field name="start_datetime" eval="DateTime.now().replace(hour=7) + relativedelta(days=7)"/>
-            <field name="end_datetime" eval="DateTime.now().replace(hour=11) + relativedelta(days=7)"/>
+            <field name="start_datetime" eval="DateTime.now().replace(hour=7, minute=0, second=0, microsecond=0) + relativedelta(days=7)"/>
+            <field name="end_datetime" eval="DateTime.now().replace(hour=11, minute=0, second=0, microsecond=0) + relativedelta(days=7)"/>
             <field name="template_id" ref="booking_engine.planning_slot_template_1"/>
             <field name="role_id" ref="booking_engine.house_keeping_planning_role"/>
             <field name="x_nights">1</field>
         </record>
         <record id="planning_slot_34" model="planning.slot">
-            <field name="start_datetime" eval="DateTime.now().replace(hour=7) + relativedelta(days=7)"/>
-            <field name="end_datetime" eval="DateTime.now().replace(hour=9) + relativedelta(days=7)"/>
+            <field name="start_datetime" eval="DateTime.now().replace(hour=7, minute=0, second=0, microsecond=0) + relativedelta(days=7)"/>
+            <field name="end_datetime" eval="DateTime.now().replace(hour=9, minute=0, second=0, microsecond=0) + relativedelta(days=7)"/>
             <field name="template_id" ref="booking_engine.planning_slot_template_2"/>
             <field name="role_id" ref="booking_engine.house_keeping_planning_role"/>
             <field name="x_nights">1</field>
         </record>
         <record id="planning_slot_38" model="planning.slot">
-            <field name="start_datetime" eval="DateTime.now().replace(hour=7) + relativedelta(days=6)"/>
-            <field name="end_datetime" eval="DateTime.now().replace(hour=11) + relativedelta(days=6)"/>
+            <field name="start_datetime" eval="DateTime.now().replace(hour=7, minute=0, second=0, microsecond=0) + relativedelta(days=6)"/>
+            <field name="end_datetime" eval="DateTime.now().replace(hour=11, minute=0, second=0, microsecond=0) + relativedelta(days=6)"/>
             <field name="template_id" ref="booking_engine.planning_slot_template_1"/>
             <field name="role_id" ref="booking_engine.house_keeping_planning_role"/>
             <field name="x_nights">1</field>
         </record>
         <record id="planning_slot_37" model="planning.slot">
-            <field name="start_datetime" eval="DateTime.now().replace(hour=7) + relativedelta(days=6)"/>
-            <field name="end_datetime" eval="DateTime.now().replace(hour=9) + relativedelta(days=6)"/>
+            <field name="start_datetime" eval="DateTime.now().replace(hour=7, minute=0, second=0, microsecond=0) + relativedelta(days=6)"/>
+            <field name="end_datetime" eval="DateTime.now().replace(hour=9, minute=0, second=0, microsecond=0) + relativedelta(days=6)"/>
             <field name="template_id" ref="booking_engine.planning_slot_template_2"/>
             <field name="role_id" ref="booking_engine.house_keeping_planning_role"/>
             <field name="x_nights">1</field>
         </record>
         <record id="planning_slot_36" model="planning.slot">
-            <field name="start_datetime" eval="DateTime.now().replace(hour=7) + relativedelta(days=6)"/>
-            <field name="end_datetime" eval="DateTime.now().replace(hour=9) + relativedelta(days=6)"/>
+            <field name="start_datetime" eval="DateTime.now().replace(hour=7, minute=0, second=0, microsecond=0) + relativedelta(days=6)"/>
+            <field name="end_datetime" eval="DateTime.now().replace(hour=9, minute=0, second=0, microsecond=0) + relativedelta(days=6)"/>
             <field name="template_id" ref="booking_engine.planning_slot_template_2"/>
             <field name="role_id" ref="booking_engine.house_keeping_planning_role"/>
             <field name="x_nights">1</field>
         </record>
         <record id="planning_slot_40" model="planning.slot">
-            <field name="start_datetime" eval="DateTime.now().replace(hour=7) + relativedelta(days=5)"/>
-            <field name="end_datetime" eval="DateTime.now().replace(hour=11) + relativedelta(days=5)"/>
+            <field name="start_datetime" eval="DateTime.now().replace(hour=7, minute=0, second=0, microsecond=0) + relativedelta(days=5)"/>
+            <field name="end_datetime" eval="DateTime.now().replace(hour=11, minute=0, second=0, microsecond=0) + relativedelta(days=5)"/>
             <field name="template_id" ref="booking_engine.planning_slot_template_1"/>
             <field name="role_id" ref="booking_engine.house_keeping_planning_role"/>
             <field name="x_nights">1</field>
         </record>
         <record id="planning_slot_39" model="planning.slot">
-            <field name="start_datetime" eval="DateTime.now().replace(hour=7) + relativedelta(days=5)"/>
-            <field name="end_datetime" eval="DateTime.now().replace(hour=9) + relativedelta(days=5)"/>
+            <field name="start_datetime" eval="DateTime.now().replace(hour=7, minute=0, second=0, microsecond=0) + relativedelta(days=5)"/>
+            <field name="end_datetime" eval="DateTime.now().replace(hour=9, minute=0, second=0, microsecond=0) + relativedelta(days=5)"/>
             <field name="template_id" ref="booking_engine.planning_slot_template_2"/>
             <field name="role_id" ref="booking_engine.house_keeping_planning_role"/>
             <field name="x_nights">1</field>
         </record>
         <record id="planning_slot_23" model="planning.slot">
-            <field name="start_datetime" eval="DateTime.now().replace(hour=7) + relativedelta(days=4)"/>
-            <field name="end_datetime" eval="DateTime.now().replace(hour=11) + relativedelta(days=4)"/>
+            <field name="start_datetime" eval="DateTime.now().replace(hour=7, minute=0, second=0, microsecond=0) + relativedelta(days=4)"/>
+            <field name="end_datetime" eval="DateTime.now().replace(hour=11, minute=0, second=0, microsecond=0) + relativedelta(days=4)"/>
             <field name="template_id" ref="booking_engine.planning_slot_template_1"/>
             <field name="role_id" ref="booking_engine.house_keeping_planning_role"/>
             <field name="x_nights">1</field>
         </record>
         <record id="planning_slot_20" model="planning.slot">
-            <field name="start_datetime" eval="DateTime.now().replace(hour=7) + relativedelta(days=4)"/>
-            <field name="end_datetime" eval="DateTime.now().replace(hour=9) + relativedelta(days=4)"/>
+            <field name="start_datetime" eval="DateTime.now().replace(hour=7, minute=0, second=0, microsecond=0) + relativedelta(days=4)"/>
+            <field name="end_datetime" eval="DateTime.now().replace(hour=9, minute=0, second=0, microsecond=0) + relativedelta(days=4)"/>
             <field name="template_id" ref="booking_engine.planning_slot_template_2"/>
             <field name="role_id" ref="booking_engine.house_keeping_planning_role"/>
             <field name="x_nights">1</field>
         </record>
         <record id="planning_slot_16" model="planning.slot">
-            <field name="start_datetime" eval="DateTime.now().replace(hour=7) + relativedelta(days=4)"/>
-            <field name="end_datetime" eval="DateTime.now().replace(hour=11) + relativedelta(days=4)"/>
+            <field name="start_datetime" eval="DateTime.now().replace(hour=7, minute=0, second=0, microsecond=0) + relativedelta(days=4)"/>
+            <field name="end_datetime" eval="DateTime.now().replace(hour=11, minute=0, second=0, microsecond=0) + relativedelta(days=4)"/>
             <field name="template_id" ref="booking_engine.planning_slot_template_1"/>
             <field name="role_id" ref="booking_engine.house_keeping_planning_role"/>
             <field name="x_nights">1</field>
         </record>
         <record id="planning_slot_22" model="planning.slot">
-            <field name="start_datetime" eval="DateTime.now().replace(hour=7) + relativedelta(days=3)"/>
-            <field name="end_datetime" eval="DateTime.now().replace(hour=9) + relativedelta(days=3)"/>
+            <field name="start_datetime" eval="DateTime.now().replace(hour=7, minute=0, second=0, microsecond=0) + relativedelta(days=3)"/>
+            <field name="end_datetime" eval="DateTime.now().replace(hour=9, minute=0, second=0, microsecond=0) + relativedelta(days=3)"/>
             <field name="template_id" ref="booking_engine.planning_slot_template_2"/>
             <field name="role_id" ref="booking_engine.house_keeping_planning_role"/>
             <field name="x_nights">1</field>
         </record>
         <record id="planning_slot_19" model="planning.slot">
-            <field name="start_datetime" eval="DateTime.now().replace(hour=7) + relativedelta(days=3)"/>
-            <field name="end_datetime" eval="DateTime.now().replace(hour=9) + relativedelta(days=3)"/>
+            <field name="start_datetime" eval="DateTime.now().replace(hour=7, minute=0, second=0, microsecond=0) + relativedelta(days=3)"/>
+            <field name="end_datetime" eval="DateTime.now().replace(hour=9, minute=0, second=0, microsecond=0) + relativedelta(days=3)"/>
             <field name="template_id" ref="booking_engine.planning_slot_template_2"/>
             <field name="role_id" ref="booking_engine.house_keeping_planning_role"/>
             <field name="x_nights">1</field>
         </record>
         <record id="planning_slot_15" model="planning.slot">
-            <field name="start_datetime" eval="DateTime.now().replace(hour=7) + relativedelta(days=3)"/>
-            <field name="end_datetime" eval="DateTime.now().replace(hour=11) + relativedelta(days=3)"/>
+            <field name="start_datetime" eval="DateTime.now().replace(hour=7, minute=0, second=0, microsecond=0) + relativedelta(days=3)"/>
+            <field name="end_datetime" eval="DateTime.now().replace(hour=11, minute=0, second=0, microsecond=0) + relativedelta(days=3)"/>
             <field name="template_id" ref="booking_engine.planning_slot_template_1"/>
             <field name="role_id" ref="booking_engine.house_keeping_planning_role"/>
             <field name="x_nights">1</field>
         </record>
         <record id="planning_slot_18" model="planning.slot">
-            <field name="start_datetime" eval="DateTime.now().replace(hour=7) + relativedelta(days=2)"/>
-            <field name="end_datetime" eval="DateTime.now().replace(hour=9) + relativedelta(days=2)"/>
+            <field name="start_datetime" eval="DateTime.now().replace(hour=7, minute=0, second=0, microsecond=0) + relativedelta(days=2)"/>
+            <field name="end_datetime" eval="DateTime.now().replace(hour=9, minute=0, second=0, microsecond=0) + relativedelta(days=2)"/>
             <field name="template_id" ref="booking_engine.planning_slot_template_2"/>
             <field name="role_id" ref="booking_engine.house_keeping_planning_role"/>
             <field name="x_nights">1</field>
         </record>
         <record id="planning_slot_14" model="planning.slot">
-            <field name="start_datetime" eval="DateTime.now().replace(hour=7) + relativedelta(days=2)"/>
-            <field name="end_datetime" eval="DateTime.now().replace(hour=11) + relativedelta(days=2)"/>
+            <field name="start_datetime" eval="DateTime.now().replace(hour=7, minute=0, second=0, microsecond=0) + relativedelta(days=2)"/>
+            <field name="end_datetime" eval="DateTime.now().replace(hour=11, minute=0, second=0, microsecond=0) + relativedelta(days=2)"/>
             <field name="template_id" ref="booking_engine.planning_slot_template_1"/>
             <field name="role_id" ref="booking_engine.house_keeping_planning_role"/>
             <field name="x_nights">1</field>
         </record>
         <record id="planning_slot_17" model="planning.slot">
-            <field name="start_datetime" eval="DateTime.now().replace(hour=7) + relativedelta(days=1)"/>
-            <field name="end_datetime" eval="DateTime.now().replace(hour=9) + relativedelta(days=1)"/>
+            <field name="start_datetime" eval="DateTime.now().replace(hour=7, minute=0, second=0, microsecond=0) + relativedelta(days=1)"/>
+            <field name="end_datetime" eval="DateTime.now().replace(hour=9, minute=0, second=0, microsecond=0) + relativedelta(days=1)"/>
             <field name="template_id" ref="booking_engine.planning_slot_template_2"/>
             <field name="role_id" ref="booking_engine.house_keeping_planning_role"/>
             <field name="x_nights">1</field>
         </record>
         <record id="planning_slot_13" model="planning.slot">
-            <field name="start_datetime" eval="DateTime.now().replace(hour=7) + relativedelta(days=1)"/>
-            <field name="end_datetime" eval="DateTime.now().replace(hour=11) + relativedelta(days=1)"/>
+            <field name="start_datetime" eval="DateTime.now().replace(hour=7, minute=0, second=0, microsecond=0) + relativedelta(days=1)"/>
+            <field name="end_datetime" eval="DateTime.now().replace(hour=11, minute=0, second=0, microsecond=0) + relativedelta(days=1)"/>
             <field name="template_id" ref="booking_engine.planning_slot_template_1"/>
             <field name="role_id" ref="booking_engine.house_keeping_planning_role"/>
             <field name="x_nights">1</field>
         </record>
         <record id="planning_slot_10" model="planning.slot">
-            <field name="start_datetime" eval="DateTime.now().replace(hour=7)"/>
-            <field name="end_datetime" eval="DateTime.now().replace(hour=9)"/>
+            <field name="start_datetime" eval="DateTime.now().replace(hour=7, minute=0, second=0, microsecond=0)"/>
+            <field name="end_datetime" eval="DateTime.now().replace(hour=9, minute=0, second=0, microsecond=0)"/>
             <field name="template_id" ref="booking_engine.planning_slot_template_2"/>
             <field name="role_id" ref="booking_engine.house_keeping_planning_role"/>
             <field name="x_nights">1</field>
         </record>
         <record id="planning_slot_9" model="planning.slot">
-            <field name="start_datetime" eval="DateTime.now().replace(hour=7)"/>
-            <field name="end_datetime" eval="DateTime.now().replace(hour=11)"/>
+            <field name="start_datetime" eval="DateTime.now().replace(hour=7, minute=0, second=0, microsecond=0)"/>
+            <field name="end_datetime" eval="DateTime.now().replace(hour=11, minute=0, second=0, microsecond=0)"/>
             <field name="template_id" ref="booking_engine.planning_slot_template_1"/>
             <field name="role_id" ref="booking_engine.house_keeping_planning_role"/>
             <field name="x_nights">1</field>
         </record>
         <record id="planning_slot_21" model="planning.slot">
-            <field name="start_datetime" eval="DateTime.now().replace(hour=7) - relativedelta(days=1)"/>
-            <field name="end_datetime" eval="DateTime.now().replace(hour=9) - relativedelta(days=1)"/>
-            <field name="template_id" ref="booking_engine.planning_slot_template_2"/>
-            <field name="role_id" ref="booking_engine.house_keeping_planning_role"/>
-            <field name="x_nights">1</field>
-        </record>
-        <record id="planning_slot2" model="planning.slot">
-            <field name="start_datetime" eval="DateTime.now().replace(hour=7) - relativedelta(days=1)"/>
-            <field name="end_datetime" eval="DateTime.now().replace(hour=9) - relativedelta(days=1)"/>
+            <field name="start_datetime" eval="DateTime.now().replace(hour=7, minute=0, second=0, microsecond=0) - relativedelta(days=1)"/>
+            <field name="end_datetime" eval="DateTime.now().replace(hour=9, minute=0, second=0, microsecond=0) - relativedelta(days=1)"/>
             <field name="template_id" ref="booking_engine.planning_slot_template_2"/>
             <field name="role_id" ref="booking_engine.house_keeping_planning_role"/>
             <field name="x_nights">1</field>
         </record>
         <record id="planning_slot_7" model="planning.slot">
-            <field name="start_datetime" eval="DateTime.now().replace(hour=7) - relativedelta(days=1)"/>
-            <field name="end_datetime" eval="DateTime.now().replace(hour=11) - relativedelta(days=1)"/>
+            <field name="start_datetime" eval="DateTime.now().replace(hour=7, minute=0, second=0, microsecond=0) - relativedelta(days=1)"/>
+            <field name="end_datetime" eval="DateTime.now().replace(hour=11, minute=0, second=0, microsecond=0) - relativedelta(days=1)"/>
             <field name="template_id" ref="booking_engine.planning_slot_template_1"/>
             <field name="role_id" ref="booking_engine.house_keeping_planning_role"/>
             <field name="x_nights">1</field>
         </record>
         <record id="planning_slot_12" model="planning.slot">
-            <field name="start_datetime" eval="DateTime.now().replace(hour=7) - relativedelta(days=2)"/>
-            <field name="end_datetime" eval="DateTime.now().replace(hour=9) - relativedelta(days=2)"/>
+            <field name="start_datetime" eval="DateTime.now().replace(hour=7, minute=0, second=0, microsecond=0) - relativedelta(days=2)"/>
+            <field name="end_datetime" eval="DateTime.now().replace(hour=9, minute=0, second=0, microsecond=0) - relativedelta(days=2)"/>
             <field name="template_id" ref="booking_engine.planning_slot_template_2"/>
             <field name="role_id" ref="booking_engine.house_keeping_planning_role"/>
             <field name="x_nights">1</field>
         </record>
         <record id="planning_slot_11" model="planning.slot">
-            <field name="start_datetime" eval="DateTime.now().replace(hour=7) - relativedelta(days=2)"/>
-            <field name="end_datetime" eval="DateTime.now().replace(hour=11) - relativedelta(days=2)"/>
+            <field name="start_datetime" eval="DateTime.now().replace(hour=7, minute=0, second=0, microsecond=0) - relativedelta(days=2)"/>
+            <field name="end_datetime" eval="DateTime.now().replace(hour=11, minute=0, second=0, microsecond=0) - relativedelta(days=2)"/>
             <field name="template_id" ref="booking_engine.planning_slot_template_1"/>
             <field name="role_id" ref="booking_engine.house_keeping_planning_role"/>
             <field name="x_nights">1</field>
@@ -247,8 +240,8 @@
         <function name="action_send" model="planning.send">
             <value model="planning.send" eval="[obj().env['planning.send'].create({
                 'employee_ids': [(6, 0, [ref('booking_engine.hr_employee_2'), ref('booking_engine.hr_employee_3'), ref('booking_engine.hr_employee_4')])],
-                'start_datetime': DateTime.now() - relativedelta(days=3),
-                'end_datetime': DateTime.now() + relativedelta(days=4),
+                'start_datetime': DateTime.now().replace(hour=0, minute=0, second=0, microsecond=0) - relativedelta(days=3),
+                'end_datetime': DateTime.now().replace(hour=23, minute=59, second=59, microsecond=999999) + relativedelta(days=4),
             }).id]"/>
         </function>
     </data>


### PR DESCRIPTION
The housekeeping demo data was no longer usable out of the box, making it difficult to validate the housekeeping planning flow in demo environments.

Several assumptions in the demo setup depended on the database creation time and on employee calendars being configured in a specific way. As a result, demo shifts could end up with unexpected durations, employees were not properly available for automatic planning, and some housekeeping planning indicators were not computed correctly.

This commit makes the demo data deterministic and aligned with the expected housekeeping workflow by:

- normalizing demo slot datetimes to fixed hour/minute boundaries to avoid database setup time affecting shift durations;
- configuring demo housekeeping employees with planning-friendly availability so shifts can be assigned and scheduled correctly;
- fixing the allocation computation used by housekeeping resources to ensure values are initialized and aggregated properly;
- aligning the Booking planning menu/action label with the standard Planning terminology used throughout the application.

The goal is to provide a fully functional demo environment where housekeeping planning, assignment and workload visualization behave consistently across databases.

task-6425559