### PR TITLE
[FIX] hotel: default_website module reference

### DIFF
--- a/hotel/demo/website/website.xml
+++ b/hotel/demo/website/website.xml
@@ -16,7 +16,7 @@
     <function name="write" model="ir.model.data">
         <value model="ir.model.data" search="[
             ('name', '=', 'default_website'),
-            ('module', '=', 'website'),
+            ('module', '=', 'base'),
             ('model', '=', 'website'),
         ]"/>
         <value eval="{'res_id': ref('website_industry')}"/>


### PR DESCRIPTION
Adapt the `ir.model.data` to target base module instead of website. Refers to [ae81b6f](https://github.com/odoo/odoo/commit/ae81b6f)