### PR TITLE
[IMP] booking_engine: add automated survey settings

### DIFF
--- a/booking_engine/__manifest__.py
+++ b/booking_engine/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Booking',
-    'version': '1.17',
+    'version': '1.18',
     'category': 'Hospitality',
     'author': 'Odoo S.A.',
     'depends': [
@@ -30,6 +30,7 @@
         'data/base_automation.xml',
         'data/resource_calendar_data.xml',
         'data/ir_cron.xml',
+        'data/survey_survey.xml',
         'data/res_config_settings.xml',
         'data/ir_actions_act_window.xml',
         'data/ir_ui_view.xml',
@@ -39,7 +40,6 @@
         'data/product_category.xml',
         'data/product_attribute.xml',
         'data/product_attribute_value.xml',
-        'data/survey_survey.xml',
         'data/survey_question.xml',
         'data/survey_question_answer.xml',
     ],

--- a/booking_engine/data/base_automation.xml
+++ b/booking_engine/data/base_automation.xml
@@ -159,11 +159,4 @@
         <field name="trigger">on_unlink</field>
         <field name="action_server_ids" eval="[(6, 0, [ref('booking_engine.server_action_update_availability_for_product_template_delete')])]"/>
     </record>
-    <record id="automation_to_archive_existing_surveys" model="base.automation">
-        <field name="name">Archive previous survey with is customer satisfaction survey</field>
-        <field name="model_id" ref="survey.model_survey_survey"/>
-        <field name="trigger">on_create_or_write</field>
-        <field name="trigger_field_ids" eval="[(6, 0, [ref('x_is_customer_satisfaction_survey_field')])]"/>
-        <field name="action_server_ids" eval="[(6, 0, [ref('server_action_to_archive_surveys')])]"/>
-    </record>
 </odoo>

--- a/booking_engine/data/ir_actions_server.xml
+++ b/booking_engine/data/ir_actions_server.xml
@@ -527,50 +527,37 @@ if (new_offers := records.filtered(lambda r: r.x_is_a_room_offer and r.active) -
 env.ref('booking_engine.server_action_update_availabilities').run()
 ]]></field>
     </record>
-    <record id="server_action_to_archive_surveys" model="ir.actions.server">
-        <field name="name">Archive previous survey with is customer satisfaction survey</field>
-        <field name="code"><![CDATA[
-if record.x_is_customer_satisfaction_survey:
-    other_surveys = env['survey.survey'].search([('id', '!=', record.id), ('x_is_customer_satisfaction_survey', '=', True), ('active', '=', True)])
-    other_surveys.write({'active': False, 'x_is_customer_satisfaction_survey': False})
-]]></field>
-        <field name="model_id" ref="survey.model_survey_survey"/>
-        <field name="state">code</field>
-    </record>
     <record id="ir_actions_server_send_survey" model="ir.actions.server">
         <field name="name">Booking Engine: Send Customer Satisfaction Survey</field>
         <field name="model_id" ref="sale.model_sale_order"/>
         <field name="state">code</field>
         <field name="usage">ir_cron</field>
         <field name="code"><![CDATA[
-survey = env['survey.survey'].search([
-    ('x_is_customer_satisfaction_survey', '=', True),
-], limit=1)
+if env['ir.config_parameter'].get_param('booking_engine.x_setting_automated_survey', '0') == '1':
+    survey = env.company.x_setting_survey_id
+    delay_days = int(env['ir.config_parameter'].get_param('booking_engine.x_setting_email_delay', 2))
 
-if survey:
-    delay_days = survey.x_email_delay or 0
-    today = datetime.datetime.today()
-
-    # Only include orders whose rental_return_date + x_email_delay has passed
-    orders = env['sale.order'].search([
-        ('state', '=', 'sale'),
-        ('x_order_involves_room', '=', True),
-        ('x_is_survey_sent', '=', False),
-        ('rental_return_date', '!=', False),
-        ('partner_id', '!=', False),
-    ])
-
-    orders_to_survey = orders.filtered(lambda o: today >= o.rental_return_date + datetime.timedelta(days=delay_days))
-    if orders_to_survey:
-        vals_list = [{
-            'survey_id': survey.id,
-            'partner_ids': [(6, 0, [order.partner_id.id])],
-            'send_email': True,
-        } for order in orders_to_survey]
-
-        invites = env['survey.invite'].create(vals_list)
-        for invite in invites:
-            invite.action_invite()
-        orders_to_survey.write({'x_is_survey_sent': True})]]></field>
+    if survey:
+        today = datetime.datetime.today()
+        orders = env['sale.order'].search([
+            ('state', '=', 'sale'),
+            ('x_order_involves_room', '=', True),
+            ('x_is_survey_sent', '=', False),
+            ('rental_return_date', '!=', False),
+            ('partner_id', '!=', False),
+        ])
+        orders_to_survey = orders.filtered(lambda o: today >= o.rental_return_date + datetime.timedelta(days=delay_days))
+        if orders_to_survey:
+            mail_template = env.ref('survey.mail_template_user_input_invite', raise_if_not_found=False)
+            vals_list = [{
+                'survey_id': survey.id,
+                'partner_ids': [(6, 0, [order.partner_id.id])],
+                'send_email': True,
+                'template_id': mail_template.id if mail_template else False,
+            } for order in orders_to_survey]
+            invites = env['survey.invite'].create(vals_list)
+            for invite in invites:
+                invite.action_invite()
+            orders_to_survey.write({'x_is_survey_sent': True})]]></field>
     </record>
 </odoo>

--- a/booking_engine/data/ir_actions_server.xml
+++ b/booking_engine/data/ir_actions_server.xml
@@ -527,50 +527,38 @@ if (new_offers := records.filtered(lambda r: r.x_is_a_room_offer and r.active) -
 env.ref('booking_engine.server_action_update_availabilities').run()
 ]]></field>
     </record>
-    <record id="server_action_to_archive_surveys" model="ir.actions.server">
-        <field name="name">Archive previous survey with is customer satisfaction survey</field>
-        <field name="code"><![CDATA[
-if record.x_is_customer_satisfaction_survey:
-    other_surveys = env['survey.survey'].search([('id', '!=', record.id), ('x_is_customer_satisfaction_survey', '=', True), ('active', '=', True)])
-    other_surveys.write({'active': False, 'x_is_customer_satisfaction_survey': False})
-]]></field>
-        <field name="model_id" ref="survey.model_survey_survey"/>
-        <field name="state">code</field>
-    </record>
     <record id="ir_actions_server_send_survey" model="ir.actions.server">
         <field name="name">Booking Engine: Send Customer Satisfaction Survey</field>
         <field name="model_id" ref="sale.model_sale_order"/>
         <field name="state">code</field>
         <field name="usage">ir_cron</field>
         <field name="code"><![CDATA[
-survey = env['survey.survey'].search([
-    ('x_is_customer_satisfaction_survey', '=', True),
-], limit=1)
+if env['ir.config_parameter'].get_param('booking_engine.x_setting_automated_survey', '0') == '1':
+    survey_id = int(env['ir.config_parameter'].get_param('booking_engine.x_setting_survey_id', 0))
+    survey = env['survey.survey'].browse(survey_id)
+    delay_days = int(env['ir.config_parameter'].get_param('booking_engine.x_setting_email_delay', 2))
 
-if survey:
-    delay_days = survey.x_email_delay or 0
-    today = datetime.datetime.today()
-
-    # Only include orders whose rental_return_date + x_email_delay has passed
-    orders = env['sale.order'].search([
-        ('state', '=', 'sale'),
-        ('x_order_involves_room', '=', True),
-        ('x_is_survey_sent', '=', False),
-        ('rental_return_date', '!=', False),
-        ('partner_id', '!=', False),
-    ])
-
-    orders_to_survey = orders.filtered(lambda o: today >= o.rental_return_date + datetime.timedelta(days=delay_days))
-    if orders_to_survey:
-        vals_list = [{
-            'survey_id': survey.id,
-            'partner_ids': [(6, 0, [order.partner_id.id])],
-            'send_email': True,
-        } for order in orders_to_survey]
-
-        invites = env['survey.invite'].create(vals_list)
-        for invite in invites:
-            invite.action_invite()
-        orders_to_survey.write({'x_is_survey_sent': True})]]></field>
+    if survey:
+        today = datetime.datetime.today()
+        orders = env['sale.order'].search([
+            ('state', '=', 'sale'),
+            ('x_order_involves_room', '=', True),
+            ('x_is_survey_sent', '=', False),
+            ('rental_return_date', '!=', False),
+            ('partner_id', '!=', False),
+        ])
+        orders_to_survey = orders.filtered(lambda o: today >= o.rental_return_date + datetime.timedelta(days=delay_days))
+        if orders_to_survey:
+            mail_template = env.ref('survey.mail_template_user_input_invite', raise_if_not_found=False)
+            vals_list = [{
+                'survey_id': survey.id,
+                'partner_ids': [(6, 0, [order.partner_id.id])],
+                'send_email': True,
+                'template_id': mail_template.id,
+            } for order in orders_to_survey]
+            invites = env['survey.invite'].create(vals_list)
+            for invite in invites:
+                invite.action_invite()
+            orders_to_survey.write({'x_is_survey_sent': True})]]></field>
     </record>
 </odoo>

--- a/booking_engine/data/ir_default.xml
+++ b/booking_engine/data/ir_default.xml
@@ -16,12 +16,4 @@
     <field name="field_id" ref="x_booked_field_x_availability"/>
     <field name="json_value">"0"</field>
   </record>
-  <record id="default_x_is_customer_satisfaction_survey" model="ir.default">
-      <field name="field_id" ref="x_is_customer_satisfaction_survey_field"/>
-      <field name="json_value">true</field>
-  </record>
-  <record id="default_x_email_delay" model="ir.default">
-      <field name="field_id" ref="x_email_delay_field"/>
-      <field name="json_value">2</field>
-  </record>
 </odoo>

--- a/booking_engine/data/ir_model_fields.xml
+++ b/booking_engine/data/ir_model_fields.xml
@@ -769,20 +769,6 @@ for r in self:
     <field name="relation">x_availability</field>
     <field name="readonly" eval="True"/>
   </record>
-  <record id="x_is_customer_satisfaction_survey_field" model="ir.model.fields">
-      <field name="name">x_is_customer_satisfaction_survey</field>
-      <field name="field_description">Is Customer Satisfaction Survey</field>
-      <field name="model_id" ref="survey.model_survey_survey"/>
-      <field name="ttype">boolean</field>
-      <field name="help"><![CDATA[When set, the survey email will be sent automatically to rental order customers.
-Note that saving a new survey with this set will archive previous survey with this setting to become the default satisfaction survey.]]></field>
-  </record>
-  <record id="x_email_delay_field" model="ir.model.fields">
-      <field name="name">x_email_delay</field>
-      <field name="field_description">Email Delay</field>
-      <field name="model_id" ref="survey.model_survey_survey"/>
-      <field name="ttype">integer</field>
-  </record>
   <record id="x_is_survey_sent_field" model="ir.model.fields">
       <field name="name">x_is_survey_sent</field>
       <field name="field_description">Is Survey Sent</field>

--- a/booking_engine/data/ir_ui_view.xml
+++ b/booking_engine/data/ir_ui_view.xml
@@ -1035,23 +1035,6 @@
         (0, 0, {'view_mode': 'gantt', 'view_id': ref('view_x_availability_occupancy_gantt')}),
     ]"/>
   </record>
-  <record id="survey_survey_view_form" model="ir.ui.view">
-      <field name="name">survey.survey.view.form.inherit.booking.engine</field>
-      <field name="model">survey.survey</field>
-      <field name="inherit_id" ref="survey.survey_survey_view_form"/>
-      <field name="active" eval="True"/>
-      <field name="type">form</field>
-      <field name="arch" type="xml">
-          <xpath expr="//page[@name='options']//group[@name='participants']/div" position="after">
-              <field name="x_is_customer_satisfaction_survey"/>
-              <label for="x_email_delay" invisible="not x_is_customer_satisfaction_survey"/>
-              <div name="x_email_delay_display" invisible="not x_is_customer_satisfaction_survey">
-                  <field name="x_email_delay" class="oe_inline"/>
-                  <span>Days</span>
-              </div>
-          </xpath>
-      </field>
-  </record>
   <record id="planning_search_view_inherit_booking_engine" model="ir.ui.view">
     <field name="name">planning.slot.search.inherit.booking_engine</field>
     <field name="model">planning.slot</field>

--- a/booking_engine/data/res_config_settings.xml
+++ b/booking_engine/data/res_config_settings.xml
@@ -166,7 +166,6 @@ self['x_setting_steering'] = (self.env['ir.config_parameter'].get_param('booking
         <field name="code"><![CDATA[
 records_archive = [
     'ir_cron_create_500_days_availability',
-    'ir_cron_send_survey',
     'automation_on_planning_slot_change',
     'automation_on_planning_slot_delete',
     'automation_on_resource_calendar_leaves_change',
@@ -175,7 +174,6 @@ records_archive = [
     'automation_on_resource_resource_delete',
     'automation_on_product_template_change',
     'automation_on_product_template_delete',
-    'automation_to_archive_existing_surveys',
 ]
 cloc_entries = [
     'x_availability_color_field_x_availability',
@@ -238,6 +236,65 @@ else:
         <field name="trigger_field_ids" eval="[(6, 0, [ref('x_setting_field_steering')])]"/>
     </record>
 
+    <!-- Automated Survey Settings-->
+    <record id="x_setting_field_automated_survey" model="ir.model.fields">
+        <field name="name">x_setting_automated_survey</field>
+        <field name="field_description">Automated Survey</field>
+        <field name="model_id" ref="base_setup.model_res_config_settings"/>
+        <field name="ttype">boolean</field>
+        <field name="compute"><![CDATA[
+self['x_setting_automated_survey'] = (self.env['ir.config_parameter'].get_param('booking_engine.x_setting_automated_survey', '0') != '0')]]></field>
+    </record>
+    <record id="x_company_field_survey_id" model="ir.model.fields">
+        <field name="name">x_setting_survey_id</field>
+        <field name="field_description">Customer Satisfaction Survey</field>
+        <field name="model_id" ref="base.model_res_company"/>
+        <field name="ttype">many2one</field>
+        <field name="relation">survey.survey</field>
+    </record>
+    <record id="x_setting_field_survey_id" model="ir.model.fields">
+        <field name="name">x_setting_survey_id</field>
+        <field name="field_description">Survey</field>
+        <field name="model_id" ref="base_setup.model_res_config_settings"/>
+        <field name="ttype">many2one</field>
+        <field name="relation">survey.survey</field>
+        <field name="related">company_id.x_setting_survey_id</field>
+    </record>
+    <record id="x_setting_field_email_delay" model="ir.model.fields">
+        <field name="name">x_setting_email_delay</field>
+        <field name="field_description">Email Delay</field>
+        <field name="model_id" ref="base_setup.model_res_config_settings"/>
+        <field name="ttype">integer</field>
+        <field name="compute"><![CDATA[
+self['x_setting_email_delay'] = int(self.env['ir.config_parameter'].get_param('booking_engine.x_setting_email_delay', 2))]]></field>
+    </record>
+    <record id="server_action_set_x_setting_automated_survey" model="ir.actions.server">
+        <field name="name">Set Automated Survey Setting</field>
+        <field name="model_id" ref="base_setup.model_res_config_settings"/>
+        <field name="state">code</field>
+        <field name="code"><![CDATA[
+env['ir.config_parameter'].set_param('booking_engine.x_setting_automated_survey', record.x_setting_automated_survey)
+if record.x_setting_automated_survey:
+    if not record.x_setting_survey_id and (survey := env.ref('booking_engine.survey_survey_1', raise_if_not_found=False)):
+        record.write({'x_setting_survey_id': survey.id})
+    env['ir.config_parameter'].set_param('booking_engine.x_setting_email_delay', record.x_setting_email_delay)
+    env.ref('booking_engine.ir_cron_send_survey')['active'] = True
+else:
+    env.ref('booking_engine.ir_cron_send_survey')['active'] = False
+    ]]></field>
+    </record>
+
+    <record id="automation_on_x_setting_automated_survey_set" model="base.automation">
+        <field name="name">On Automated Survey setting set</field>
+        <field name="model_id" ref="base_setup.model_res_config_settings"/>
+        <field name="action_server_ids" eval="[(6, 0, [ref('server_action_set_x_setting_automated_survey')])]"/>
+        <field name="trigger">on_create_or_write</field>
+        <field name="trigger_field_ids" eval="[(6, 0, [
+            ref('x_setting_field_automated_survey'),
+            ref('x_setting_field_survey_id'),
+            ref('x_setting_field_email_delay'),
+        ])]"/>
+    </record>
 
     <record id="server_action_set_x_setting_approvers" model="ir.actions.server">
         <field name="name">HouseKeeping: Set approvers setting</field>
@@ -283,6 +340,20 @@ env['ir.config_parameter'].set_param('booking_engine.x_approvers_setting', ('1' 
                     <block title="Management" name="booking_management_config_block">
                         <setting id="booking_engine_steering_setting" help="Monitor availability, occupancy, average daily rate, revenue per available unit and pick-ups.">
                             <field name="x_setting_steering"/>
+                        </setting>
+                        <setting id="booking_engine_automated_survey_setting" help="Automatically send customer satisfaction survey after guest stay.">
+                            <field name="x_setting_automated_survey"/>
+                            <div class="mt-1" invisible="not x_setting_automated_survey">
+                                <div class="row align-items-center mb-2">
+                                    <label for="x_setting_survey_id" class="col-3 text-nowrap"/>
+                                    <field name="x_setting_survey_id" class="col-6 oe_inline" options="{'no_open': True}" required="x_setting_automated_survey"/>
+                                </div>
+                                <div class="row align-items-center">
+                                    <label for="x_setting_email_delay" class="col-3 text-nowrap"/>
+                                    <field name="x_setting_email_delay" class="col-3 oe_inline" required="x_setting_automated_survey"/>
+                                    <span class="text-muted col-3">Days</span>
+                                </div>
+                            </div>
                         </setting>
                     </block>
                 </app>

--- a/booking_engine/data/res_config_settings.xml
+++ b/booking_engine/data/res_config_settings.xml
@@ -175,7 +175,6 @@ records_archive = [
     'automation_on_resource_resource_delete',
     'automation_on_product_template_change',
     'automation_on_product_template_delete',
-    'automation_to_archive_existing_surveys',
 ]
 cloc_entries = [
     'x_availability_color_field_x_availability',
@@ -238,6 +237,62 @@ else:
         <field name="trigger_field_ids" eval="[(6, 0, [ref('x_setting_field_steering')])]"/>
     </record>
 
+    <!-- Automated Survey Settings-->
+    <record id="x_setting_field_automated_survey" model="ir.model.fields">
+        <field name="name">x_setting_automated_survey</field>
+        <field name="field_description">Automated Survey</field>
+        <field name="model_id" ref="base_setup.model_res_config_settings"/>
+        <field name="ttype">boolean</field>
+        <field name="store" eval="True"/>
+        <field name="compute"><![CDATA[
+self['x_setting_automated_survey'] = (self.env['ir.config_parameter'].get_param('booking_engine.x_setting_automated_survey', '0') != '0')]]></field>
+    </record>
+    <record id="x_setting_field_survey_id" model="ir.model.fields">
+        <field name="name">x_setting_survey_id</field>
+        <field name="field_description">Survey</field>
+        <field name="model_id" ref="base_setup.model_res_config_settings"/>
+        <field name="ttype">many2one</field>
+        <field name="relation">survey.survey</field>
+        <field name="compute"><![CDATA[
+survey_id = int(self.env['ir.config_parameter'].get_param('booking_engine.x_setting_survey_id', 0))
+self['x_setting_survey_id'] = survey_id and self.env['survey.survey'].browse(survey_id) or False
+        ]]></field>
+    </record>
+    <record id="x_setting_field_email_delay" model="ir.model.fields">
+        <field name="name">x_setting_email_delay</field>
+        <field name="field_description">Email Delay</field>
+        <field name="model_id" ref="base_setup.model_res_config_settings"/>
+        <field name="ttype">integer</field>
+        <field name="compute"><![CDATA[
+self['x_setting_email_delay'] = int(self.env['ir.config_parameter'].get_param('booking_engine.x_setting_email_delay', 2))]]></field>
+    </record>
+    <record id="server_action_set_x_setting_automated_survey" model="ir.actions.server">
+        <field name="name">Set Automated Survey Setting</field>
+        <field name="model_id" ref="base_setup.model_res_config_settings"/>
+        <field name="state">code</field>
+        <field name="code"><![CDATA[
+env['ir.config_parameter'].set_param('booking_engine.x_setting_automated_survey', ('1' if record.x_setting_automated_survey else '0'))
+if record.x_setting_automated_survey:
+    survey_id = record.x_setting_survey_id.id or env.ref('booking_engine.survey_survey_1', raise_if_not_found=False).id
+    env['ir.config_parameter'].set_param('booking_engine.x_setting_survey_id', survey_id)
+    env['ir.config_parameter'].set_param('booking_engine.x_setting_email_delay', record.x_setting_email_delay)
+    env.ref('booking_engine.ir_cron_send_survey')['active'] = True
+else:
+    env.ref('booking_engine.ir_cron_send_survey')['active'] = False
+    ]]></field>
+    </record>
+
+    <record id="automation_on_x_setting_automated_survey_set" model="base.automation">
+        <field name="name">On Automated Survey setting set</field>
+        <field name="model_id" ref="base_setup.model_res_config_settings"/>
+        <field name="action_server_ids" eval="[(6, 0, [ref('server_action_set_x_setting_automated_survey')])]"/>
+        <field name="trigger">on_create_or_write</field>
+        <field name="trigger_field_ids" eval="[(6, 0, [
+            ref('x_setting_field_automated_survey'),
+            ref('x_setting_field_survey_id'),
+            ref('x_setting_field_email_delay'),
+        ])]"/>
+    </record>
 
     <record id="server_action_set_x_setting_approvers" model="ir.actions.server">
         <field name="name">HouseKeeping: Set approvers setting</field>
@@ -283,6 +338,20 @@ env['ir.config_parameter'].set_param('booking_engine.x_approvers_setting', ('1' 
                     <block title="Management" name="booking_management_config_block">
                         <setting id="booking_engine_steering_setting" help="Monitor availability, occupancy, average daily rate, revenue per available unit and pick-ups.">
                             <field name="x_setting_steering"/>
+                        </setting>
+                        <setting id="booking_engine_automated_survey_setting" help="Automatically send customer satisfaction survey after guest stay.">
+                            <field name="x_setting_automated_survey"/>
+                            <div class="mt-1" invisible="not x_setting_automated_survey">
+                                <div class="row align-items-center mb-2">
+                                    <label for="x_setting_survey_id" class="col-3 text-nowrap"/>
+                                    <field name="x_setting_survey_id" class="col-6 oe_inline" options="{'no_open': True}" required="x_setting_automated_survey"/>
+                                </div>
+                                <div class="row align-items-center">
+                                    <label for="x_setting_email_delay" class="col-3 text-nowrap"/>
+                                    <field name="x_setting_email_delay" class="col-3 oe_inline" required="x_setting_automated_survey"/>
+                                    <span class="text-muted col-3">Days</span>
+                                </div>
+                            </div>
                         </setting>
                     </block>
                 </app>

--- a/campsite/__manifest__.py
+++ b/campsite/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Campsite',
-    'version': '1.5',
+    'version': '1.6',
     'category': 'Hospitality',
     'author': 'Odoo S.A.',
     'depends': [

--- a/campsite/data/knowledge_article.xml
+++ b/campsite/data/knowledge_article.xml
@@ -232,15 +232,13 @@
             <li>Proceed to the payment with your terminal and set the invoice as paid.</li>
             <li>Don't forget to send them their invoice!</li>
         </ul>
-        <div class="o-paragraph">
-            <br/>
-        </div><p>
+        <p>
             <em>Don't forget to thank your guests with a warm goodbye!</em>
         </p>
         <h4>Keep your guests satisfied</h4>
         <ul>
             <li>Open the Survey App to find the customer satisfaction survey.</li>
-            <li>In the Options tab, you can see it is made the customer satisfaction survey in the participants section.</li>
+            <li>You can create an alternative customer satisfaction survey and select it from the Automated Survey settings, as well as configure the email delay as you wish the email to be sent after the guest checkout.</li>
         </ul>
         <div
             class="o_editor_banner user-select-none o-contenteditable-false lh-1 d-flex align-items-center alert alert-success pb-0 pt-3"
@@ -248,20 +246,9 @@
             <i class="o_editor_banner_icon mb-3 fst-normal" data-oe-aria-label="Banner Success">✅</i>
             <div class="o_editor_banner_content o-contenteditable-true w-100 px-3">
                 <p>
-                    Any time you create a new survey and save it with the setting "is customer satisfaction survey", previous ones
-                    will be archived so that it becomes your new default survey.
+                    An automation is setup for an email to be sent automatically for you.
+                    You can find the participants and answers from the smart buttons of the survey.
                 </p>
-            </div>
-        </div>
-        <ul>
-            <li>Configure the email delay as you wish the email to be sent after the guest checkout.</li>
-            <li>An automation is setup for an email to be sent automatically for you.</li>
-            <li>You can find the participants and answers from the smart buttons of the survey.</li>
-        </ul>
-        <div class="o_editor_banner user-select-none o-contenteditable-false lh-1 d-flex align-items-center alert alert-info pb-0 pt-3" data-oe-role="status">
-            <i class="o_editor_banner_icon mb-3 fst-normal" data-oe-aria-label="Banner Info">💡</i>
-            <div class="o_editor_banner_content o-contenteditable-true w-100 px-3">
-                <p>To ensure your guests no longer receive the satisfaction survey, you can easily archive it at any time.</p>
             </div>
         </div>
         <p><em>Don't forget to check the results from time to time to make your guests happier!</em></p>

--- a/campsite/data/res_config_settings.xml
+++ b/campsite/data/res_config_settings.xml
@@ -17,6 +17,9 @@
         <record model="res.config.settings" id="res_config_settings_enable">
             <field name="x_module_house_keeping" eval="1"/>
             <field name="x_setting_steering" eval="1"/>
+            <field name="x_setting_automated_survey" eval="1"/>
+            <field name="x_setting_survey_id" ref="booking_engine.survey_survey_1"/>
+            <field name="x_setting_email_delay">2</field>
         </record>
         <function model="res.config.settings" name="execute" eval="[ref('res_config_settings_enable')]"/>
     </data>

--- a/campsite/data/res_config_settings.xml
+++ b/campsite/data/res_config_settings.xml
@@ -17,6 +17,8 @@
         <record model="res.config.settings" id="res_config_settings_enable">
             <field name="x_module_house_keeping" eval="1"/>
             <field name="x_setting_steering" eval="1"/>
+            <field name="x_setting_automated_survey" eval="1"/>
+            <field name="x_setting_email_delay">2</field>
         </record>
         <function model="res.config.settings" name="execute" eval="[ref('res_config_settings_enable')]"/>
     </data>

--- a/guest_house/__manifest__.py
+++ b/guest_house/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Guest House',
-    'version': '1.6',
+    'version': '1.7',
     'category': 'Hospitality',
     'author': 'Odoo S.A.',
     'depends': [

--- a/guest_house/data/knowledge_article.xml
+++ b/guest_house/data/knowledge_article.xml
@@ -225,6 +225,14 @@
         <h4>Record guest identity</h4>
         <p>You noticed that the Identity Check highlights whether you captured all the
             necessary information for a guest?</p>
+        <div
+            class="o_editor_banner user-select-none o-contenteditable-false lh-1 d-flex align-items-center alert alert-warning pb-0 pt-3"
+            data-oe-role="status">
+            <i class="o_editor_banner_icon mb-3 fst-normal" data-oe-aria-label="Banner Warning">⚠️</i>
+            <div class="o_editor_banner_content o-contenteditable-true w-100 px-3">
+                <p>To benefit from this capability, activate the corresponding setting.</p>
+            </div>
+        </div>
         <ul>
             <li>If not OK, then click the contact, fill in the Identity section and save the
                 contact.</li>
@@ -284,28 +292,14 @@
         <h4>Keep your guests satisfied</h4>
         <ul>
             <li>Open the Survey App to find the customer satisfaction survey.</li>
-            <li>In the Options tab, you can see it is made the customer satisfaction survey in the participants section.</li>
+            <li>You can create an alternative customer satisfaction survey and select it from the Automated Survey settings, as well as configure the email delay as you wish the email to be sent after the guest checkout.</li>
         </ul>
         <div
-            class="o_editor_banner user-select-none o-contenteditable-false lh-1 d-flex align-items-center alert alert-success pb-0 pt-3"
+            class="o_editor_banner user-select-none o-contenteditable-false lh-1 d-flex align-items-center alert alert-warning pb-0 pt-3"
             data-oe-role="status">
-            <i class="o_editor_banner_icon mb-3 fst-normal" data-oe-aria-label="Banner Success">✅</i>
+            <i class="o_editor_banner_icon mb-3 fst-normal" data-oe-aria-label="Banner Warning">⚠️</i>
             <div class="o_editor_banner_content o-contenteditable-true w-100 px-3">
-                <p>
-                    Any time you create a new survey and save it with the setting "is customer satisfaction survey", previous ones
-                    will be archived so that it becomes your new default survey.
-                </p>
-            </div>
-        </div>
-        <ul>
-            <li>Configure the email delay as you wish the email to be sent after the guest checkout.</li>
-            <li>An automation is setup for an email to be sent automatically for you.</li>
-            <li>You can find the participants and answers from the smart buttons of the survey.</li>
-        </ul>
-        <div class="o_editor_banner user-select-none o-contenteditable-false lh-1 d-flex align-items-center alert alert-info pb-0 pt-3" data-oe-role="status">
-            <i class="o_editor_banner_icon mb-3 fst-normal" data-oe-aria-label="Banner Info">💡</i>
-            <div class="o_editor_banner_content o-contenteditable-true w-100 px-3">
-                <p>To ensure your guests no longer receive the satisfaction survey, you can easily archive it at any time.</p>
+                <p>To benefit from this capability, activate the corresponding setting.</p>
             </div>
         </div>
         <p><em>Don't forget to check the results from time to time to make your guests happier!</em></p>
@@ -415,6 +409,14 @@
         <h3>🧽 Managing house keeping</h3>
         <hr/>
         <p>On top of guest and stay management, you need to keep the place clean!</p>
+        <div
+            class="o_editor_banner user-select-none o-contenteditable-false lh-1 d-flex align-items-center alert alert-warning pb-0 pt-3"
+            data-oe-role="status">
+            <i class="o_editor_banner_icon mb-3 fst-normal" data-oe-aria-label="Banner Warning">⚠️</i>
+            <div class="o_editor_banner_content o-contenteditable-true w-100 px-3">
+                <p>To benefit from this capability, activate the corresponding setting.</p>
+            </div>
+        </div>
         <ul>
             <li>Open the Board from the accommodation app, House Keeping menu.<br/>Here you have an
                 overview of the cleanness state of your resources.</li>

--- a/guest_house/data/knowledge_article.xml
+++ b/guest_house/data/knowledge_article.xml
@@ -225,6 +225,14 @@
         <h4>Record guest identity</h4>
         <p>You noticed that the Identity Check highlights whether you captured all the
             necessary information for a guest?</p>
+        <div
+            class="o_editor_banner user-select-none o-contenteditable-false lh-1 d-flex align-items-center alert alert-warning pb-0 pt-3"
+            data-oe-role="status">
+            <i class="o_editor_banner_icon mb-3 fst-normal" data-oe-aria-label="Banner Warning">⚠️</i>
+            <div class="o_editor_banner_content o-contenteditable-true w-100 px-3">
+                <p>To benefit from this capability, activate the corresponding setting.</p>
+            </div>
+        </div>
         <ul>
             <li>If not OK, then click the contact, fill in the Identity section and save the
                 contact.</li>
@@ -284,7 +292,7 @@
         <h4>Keep your guests satisfied</h4>
         <ul>
             <li>Open the Survey App to find the customer satisfaction survey.</li>
-            <li>In the Options tab, you can see it is made the customer satisfaction survey in the participants section.</li>
+            <li>You can create an alternative customer satisfaction survey and select it from the Automated Survey settings, as well as configure the email delay as you wish the email to be sent after the guest checkout.</li>
         </ul>
         <div
             class="o_editor_banner user-select-none o-contenteditable-false lh-1 d-flex align-items-center alert alert-success pb-0 pt-3"
@@ -297,15 +305,12 @@
                 </p>
             </div>
         </div>
-        <ul>
-            <li>Configure the email delay as you wish the email to be sent after the guest checkout.</li>
-            <li>An automation is setup for an email to be sent automatically for you.</li>
-            <li>You can find the participants and answers from the smart buttons of the survey.</li>
-        </ul>
-        <div class="o_editor_banner user-select-none o-contenteditable-false lh-1 d-flex align-items-center alert alert-info pb-0 pt-3" data-oe-role="status">
-            <i class="o_editor_banner_icon mb-3 fst-normal" data-oe-aria-label="Banner Info">💡</i>
+        <div
+            class="o_editor_banner user-select-none o-contenteditable-false lh-1 d-flex align-items-center alert alert-warning pb-0 pt-3"
+            data-oe-role="status">
+            <i class="o_editor_banner_icon mb-3 fst-normal" data-oe-aria-label="Banner Warning">⚠️</i>
             <div class="o_editor_banner_content o-contenteditable-true w-100 px-3">
-                <p>To ensure your guests no longer receive the satisfaction survey, you can easily archive it at any time.</p>
+                <p>To benefit from this capability, activate the corresponding setting.</p>
             </div>
         </div>
         <p><em>Don't forget to check the results from time to time to make your guests happier!</em></p>
@@ -415,6 +420,14 @@
         <h3>🧽 Managing house keeping</h3>
         <hr/>
         <p>On top of guest and stay management, you need to keep the place clean!</p>
+        <div
+            class="o_editor_banner user-select-none o-contenteditable-false lh-1 d-flex align-items-center alert alert-warning pb-0 pt-3"
+            data-oe-role="status">
+            <i class="o_editor_banner_icon mb-3 fst-normal" data-oe-aria-label="Banner Warning">⚠️</i>
+            <div class="o_editor_banner_content o-contenteditable-true w-100 px-3">
+                <p>To benefit from this capability, activate the corresponding setting.</p>
+            </div>
+        </div>
         <ul>
             <li>Open the Board from the accommodation app, House Keeping menu.<br/>Here you have an
                 overview of the cleanness state of your resources.</li>

--- a/holiday_house/__manifest__.py
+++ b/holiday_house/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Holiday House',
-    'version': '1.5',
+    'version': '1.6',
     'category': 'Hospitality',
     'author': 'Odoo S.A.',
     'depends': [

--- a/holiday_house/data/knowledge_article.xml
+++ b/holiday_house/data/knowledge_article.xml
@@ -189,6 +189,14 @@ The Holiday House App relies on the Rental and Planning Apps binding, with a few
         </ul>
         <h4>Record guest identity</h4>
         <p>You noticed that the Identity Check highlights whether you captured all the necessary information for a guest?</p>
+        <div
+            class="o_editor_banner user-select-none o-contenteditable-false lh-1 d-flex align-items-center alert alert-warning pb-0 pt-3"
+            data-oe-role="status">
+            <i class="o_editor_banner_icon mb-3 fst-normal" data-oe-aria-label="Banner Warning">⚠️</i>
+            <div class="o_editor_banner_content o-contenteditable-true w-100 px-3">
+                <p>To benefit from this capability, activate the corresponding setting.</p>
+            </div>
+        </div>
         <ul>
             <li>If not OK, then click the contact, fill in the Identity section and save the contact.</li>
         </ul>
@@ -234,28 +242,14 @@ The Holiday House App relies on the Rental and Planning Apps binding, with a few
     <h4>Keep your guests satisfied</h4>
     <ul>
         <li>Open the Survey App to find the customer satisfaction survey.</li>
-        <li>In the Options tab, you can see it is made the customer satisfaction survey in the participants section.</li>
+        <li>You can create an alternative customer satisfaction survey and select it from the Automated Survey settings, as well as configure the email delay as you wish the email to be sent after the guest checkout.</li>
     </ul>
     <div
-        class="o_editor_banner user-select-none o-contenteditable-false lh-1 d-flex align-items-center alert alert-success pb-0 pt-3"
+        class="o_editor_banner user-select-none o-contenteditable-false lh-1 d-flex align-items-center alert alert-warning pb-0 pt-3"
         data-oe-role="status">
-        <i class="o_editor_banner_icon mb-3 fst-normal" data-oe-aria-label="Banner Success">✅</i>
+        <i class="o_editor_banner_icon mb-3 fst-normal" data-oe-aria-label="Banner Warning">⚠️</i>
         <div class="o_editor_banner_content o-contenteditable-true w-100 px-3">
-            <p>
-                Any time you create a new survey and save it with the setting "is customer satisfaction survey", previous ones
-                will be archived so that it becomes your new default survey.
-            </p>
-        </div>
-    </div>
-    <ul>
-        <li>Configure the email delay as you wish the email to be sent after the guest checkout.</li>
-        <li>An automation is setup for an email to be sent automatically for you.</li>
-        <li>You can find the participants and answers from the smart buttons of the survey.</li>
-    </ul>
-    <div class="o_editor_banner user-select-none o-contenteditable-false lh-1 d-flex align-items-center alert alert-info pb-0 pt-3" data-oe-role="status">
-        <i class="o_editor_banner_icon mb-3 fst-normal" data-oe-aria-label="Banner Info">💡</i>
-        <div class="o_editor_banner_content o-contenteditable-true w-100 px-3">
-            <p>To ensure your guests no longer receive the satisfaction survey, you can easily archive it at any time.</p>
+            <p>To benefit from this capability, activate the corresponding setting.</p>
         </div>
     </div>
     <p><em>Don't forget to check the results from time to time to make your guests happier!</em></p>
@@ -362,6 +356,14 @@ The Holiday House App relies on the Rental and Planning Apps binding, with a few
     <h3>🧽 Managing house keeping</h3>
         <hr/>
         <p>On top of guest and stay management, you need to keep the place clean!</p>
+        <div
+            class="o_editor_banner user-select-none o-contenteditable-false lh-1 d-flex align-items-center alert alert-warning pb-0 pt-3"
+            data-oe-role="status">
+            <i class="o_editor_banner_icon mb-3 fst-normal" data-oe-aria-label="Banner Warning">⚠️</i>
+            <div class="o_editor_banner_content o-contenteditable-true w-100 px-3">
+                <p>To benefit from this capability, activate the corresponding setting.</p>
+            </div>
+        </div>
         <ul>
             <li>Open the Board from the accommodation app, House Keeping menu.<br/>Here you have an
                 overview of the cleanness state of your resources.</li>

--- a/holiday_house/data/knowledge_article.xml
+++ b/holiday_house/data/knowledge_article.xml
@@ -189,6 +189,14 @@ The Holiday House App relies on the Rental and Planning Apps binding, with a few
         </ul>
         <h4>Record guest identity</h4>
         <p>You noticed that the Identity Check highlights whether you captured all the necessary information for a guest?</p>
+        <div
+            class="o_editor_banner user-select-none o-contenteditable-false lh-1 d-flex align-items-center alert alert-warning pb-0 pt-3"
+            data-oe-role="status">
+            <i class="o_editor_banner_icon mb-3 fst-normal" data-oe-aria-label="Banner Warning">⚠️</i>
+            <div class="o_editor_banner_content o-contenteditable-true w-100 px-3">
+                <p>To benefit from this capability, activate the corresponding setting.</p>
+            </div>
+        </div>
         <ul>
             <li>If not OK, then click the contact, fill in the Identity section and save the contact.</li>
         </ul>
@@ -234,7 +242,7 @@ The Holiday House App relies on the Rental and Planning Apps binding, with a few
     <h4>Keep your guests satisfied</h4>
     <ul>
         <li>Open the Survey App to find the customer satisfaction survey.</li>
-        <li>In the Options tab, you can see it is made the customer satisfaction survey in the participants section.</li>
+        <li>You can create an alternative customer satisfaction survey and select it from the Automated Survey settings, as well as configure the email delay as you wish the email to be sent after the guest checkout.</li>
     </ul>
     <div
         class="o_editor_banner user-select-none o-contenteditable-false lh-1 d-flex align-items-center alert alert-success pb-0 pt-3"
@@ -247,15 +255,12 @@ The Holiday House App relies on the Rental and Planning Apps binding, with a few
             </p>
         </div>
     </div>
-    <ul>
-        <li>Configure the email delay as you wish the email to be sent after the guest checkout.</li>
-        <li>An automation is setup for an email to be sent automatically for you.</li>
-        <li>You can find the participants and answers from the smart buttons of the survey.</li>
-    </ul>
-    <div class="o_editor_banner user-select-none o-contenteditable-false lh-1 d-flex align-items-center alert alert-info pb-0 pt-3" data-oe-role="status">
-        <i class="o_editor_banner_icon mb-3 fst-normal" data-oe-aria-label="Banner Info">💡</i>
+    <div
+        class="o_editor_banner user-select-none o-contenteditable-false lh-1 d-flex align-items-center alert alert-warning pb-0 pt-3"
+        data-oe-role="status">
+        <i class="o_editor_banner_icon mb-3 fst-normal" data-oe-aria-label="Banner Warning">⚠️</i>
         <div class="o_editor_banner_content o-contenteditable-true w-100 px-3">
-            <p>To ensure your guests no longer receive the satisfaction survey, you can easily archive it at any time.</p>
+            <p>To benefit from this capability, activate the corresponding setting.</p>
         </div>
     </div>
     <p><em>Don't forget to check the results from time to time to make your guests happier!</em></p>
@@ -362,6 +367,14 @@ The Holiday House App relies on the Rental and Planning Apps binding, with a few
     <h3>🧽 Managing house keeping</h3>
         <hr/>
         <p>On top of guest and stay management, you need to keep the place clean!</p>
+        <div
+            class="o_editor_banner user-select-none o-contenteditable-false lh-1 d-flex align-items-center alert alert-warning pb-0 pt-3"
+            data-oe-role="status">
+            <i class="o_editor_banner_icon mb-3 fst-normal" data-oe-aria-label="Banner Warning">⚠️</i>
+            <div class="o_editor_banner_content o-contenteditable-true w-100 px-3">
+                <p>To benefit from this capability, activate the corresponding setting.</p>
+            </div>
+        </div>
         <ul>
             <li>Open the Board from the accommodation app, House Keeping menu.<br/>Here you have an
                 overview of the cleanness state of your resources.</li>

--- a/hotel/__manifest__.py
+++ b/hotel/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Hotel',
-    'version': '1.6',
+    'version': '1.7',
     'category': 'Hospitality',
     'author': 'Odoo S.A.',
     'depends': [

--- a/hotel/data/knowledge_article.xml
+++ b/hotel/data/knowledge_article.xml
@@ -352,30 +352,8 @@
         <h4>Keep your guests satisfied</h4>
         <ul>
             <li>Open the Survey App to find the customer satisfaction survey.</li>
-            <li>In the Options tab, you can see it is made the customer satisfaction survey in the participants section.</li>
+            <li>You can create an alternative customer satisfaction survey and select it from the Automated Survey settings, as well as configure the email delay as you wish the email to be sent after the guest checkout.</li>
         </ul>
-        <div
-            class="o_editor_banner user-select-none o-contenteditable-false lh-1 d-flex align-items-center alert alert-success pb-0 pt-3"
-            data-oe-role="status">
-            <i class="o_editor_banner_icon mb-3 fst-normal" data-oe-aria-label="Banner Success">✅</i>
-            <div class="o_editor_banner_content o-contenteditable-true w-100 px-3">
-                <p>
-                    Any time you create a new survey and save it with the setting "is customer satisfaction survey", previous ones
-                    will be archived so that it becomes your new default survey.
-                </p>
-            </div>
-        </div>
-        <ul>
-            <li>Configure the email delay as you wish the email to be sent after the guest checkout.</li>
-            <li>An automation is setup for an email to be sent automatically for you.</li>
-            <li>You can find the participants and answers from the smart buttons of the survey.</li>
-        </ul>
-        <div class="o_editor_banner user-select-none o-contenteditable-false lh-1 d-flex align-items-center alert alert-info pb-0 pt-3" data-oe-role="status">
-            <i class="o_editor_banner_icon mb-3 fst-normal" data-oe-aria-label="Banner Info">💡</i>
-            <div class="o_editor_banner_content o-contenteditable-true w-100 px-3">
-                <p>To ensure your guests no longer receive the satisfaction survey, you can easily archive it at any time.</p>
-            </div>
-        </div>
         <p><em>Don't forget to check the results from time to time to make your guests happier!</em></p>
         <p>
             <a

--- a/hotel/data/knowledge_article.xml
+++ b/hotel/data/knowledge_article.xml
@@ -352,7 +352,7 @@
         <h4>Keep your guests satisfied</h4>
         <ul>
             <li>Open the Survey App to find the customer satisfaction survey.</li>
-            <li>In the Options tab, you can see it is made the customer satisfaction survey in the participants section.</li>
+            <li>You can create an alternative customer satisfaction survey and select it from the Automated Survey settings, as well as configure the email delay as you wish the email to be sent after the guest checkout.</li>
         </ul>
         <div
             class="o_editor_banner user-select-none o-contenteditable-false lh-1 d-flex align-items-center alert alert-success pb-0 pt-3"
@@ -363,17 +363,6 @@
                     Any time you create a new survey and save it with the setting "is customer satisfaction survey", previous ones
                     will be archived so that it becomes your new default survey.
                 </p>
-            </div>
-        </div>
-        <ul>
-            <li>Configure the email delay as you wish the email to be sent after the guest checkout.</li>
-            <li>An automation is setup for an email to be sent automatically for you.</li>
-            <li>You can find the participants and answers from the smart buttons of the survey.</li>
-        </ul>
-        <div class="o_editor_banner user-select-none o-contenteditable-false lh-1 d-flex align-items-center alert alert-info pb-0 pt-3" data-oe-role="status">
-            <i class="o_editor_banner_icon mb-3 fst-normal" data-oe-aria-label="Banner Info">💡</i>
-            <div class="o_editor_banner_content o-contenteditable-true w-100 px-3">
-                <p>To ensure your guests no longer receive the satisfaction survey, you can easily archive it at any time.</p>
             </div>
         </div>
         <p><em>Don't forget to check the results from time to time to make your guests happier!</em></p>

--- a/hotel/data/res_config_settings.xml
+++ b/hotel/data/res_config_settings.xml
@@ -17,6 +17,9 @@
         <record model="res.config.settings" id="res_config_settings_enable">
             <field name="x_module_house_keeping" eval="1"/>
             <field name="x_setting_steering" eval="1"/>
+            <field name="x_setting_automated_survey" eval="1"/>
+            <field name="x_setting_survey_id" ref="booking_engine.survey_survey_1"/>
+            <field name="x_setting_email_delay">2</field>
         </record>
         <function model="res.config.settings" name="execute" eval="[ref('res_config_settings_enable')]"/>
     </data>

--- a/hotel/data/res_config_settings.xml
+++ b/hotel/data/res_config_settings.xml
@@ -17,6 +17,8 @@
         <record model="res.config.settings" id="res_config_settings_enable">
             <field name="x_module_house_keeping" eval="1"/>
             <field name="x_setting_steering" eval="1"/>
+            <field name="x_setting_automated_survey" eval="1"/>
+            <field name="x_setting_email_delay">2</field>
         </record>
         <function model="res.config.settings" name="execute" eval="[ref('res_config_settings_enable')]"/>
     </data>


### PR DESCRIPTION
* Removed the previous implementation for sending surveys to customers.
* Added a new **Automated Survey** setting with:

  * **Survey**: Select the survey to be sent to the customer.
  * **Email Delay**: Define the delay before sending the survey email.
* Once the setting is enabled, the configured survey email will be automatically 
  sent to the customer after their stay is completed.
* This allows the survey process to be configured directly from the settings.

Task-6389420

