### PR TITLE
[IMP] hotel: automate city tax and improve defaults

### DIFF
--- a/booking_engine/__manifest__.py
+++ b/booking_engine/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Booking',
-    'version': '1.25',
+    'version': '1.26',
     'category': 'Hospitality',
     'author': 'Odoo S.A.',
     'depends': [

--- a/booking_engine/data/base_automation.xml
+++ b/booking_engine/data/base_automation.xml
@@ -208,4 +208,11 @@
         <field name="name">Daily Lines: On SO rental date changed</field>
         <field name="trigger_field_ids" eval="[(6, 0, [ref('sale_renting.field_sale_order__rental_start_date'), ref('sale_renting.field_sale_order__rental_return_date')])]"/>
     </record>
+    <record id="automation_add_city_tax_line_on_so_creation" model="base.automation">
+        <field name="model_id" ref="sale.model_sale_order_line"/>
+        <field name="action_server_ids" eval="[(6, 0, [ref('booking_engine.ir_actions_add_city_tax_line_on_so_creation')])]"/>
+        <field name="trigger">on_create</field>
+        <field name="filter_domain">[("product_id.x_has_city_tax", "=", True)]</field>
+        <field name="name">Booking Engine: Add city tax line on SO creation</field>
+    </record>
 </odoo>

--- a/booking_engine/data/ir_actions_act_window.xml
+++ b/booking_engine/data/ir_actions_act_window.xml
@@ -18,7 +18,20 @@
     <field name="name">Stay Offers</field>
     <field name="res_model">product.template</field>
     <field name="domain">[("x_is_a_room_offer", "=", True)]</field>
-    <field name="context">{'default_x_is_a_room_offer': True, 'default_purchase_ok': False, 'default_sale_ok': True, 'default_rent_periodicity': 'nights', 'default_pickup_time': 18, 'default_return_time': 9,'default_type': 'service', 'default_planning_enabled': True}</field>
+    <field name="context" eval="{
+        'default_x_is_a_room_offer': True,
+        'default_purchase_ok': False,
+        'default_sale_ok': True,
+        'default_rent_periodicity': 'nights',
+        'default_pickup_time': 18,
+        'default_return_time': 9,
+        'default_type': 'service',
+        'default_planning_enabled': True,
+        'default_categ_id': ref('product_category_6', raise_if_not_found=False),
+        'default_x_has_city_tax': True,
+        'default_x_stayover_cleaning': 1.0,
+        'default_x_checkout_cleaning': 2.0,
+    }"/>
     <field name="view_mode">kanban,list,form</field>
   </record>
   <record id="booking_engine_rooms_roles_action" model="ir.actions.act_window">

--- a/booking_engine/data/ir_actions_server.xml
+++ b/booking_engine/data/ir_actions_server.xml
@@ -15,6 +15,19 @@ elif record.x_total > 0:
     env['sale.order.line'].create({'order_id': record.x_sale_order_id.id, 'product_id': product.id, 'product_uom_qty': record.x_total, 'qty_delivered': record.x_total})
 ]]></field>
     </record>
+    <record id="ir_actions_add_city_tax_line_on_so_creation" model="ir.actions.server">
+        <field name="name">Booking Engine: Add city tax line on SO creation</field>
+        <field name="model_id" ref="sale.model_sale_order_line"/>
+        <field name="state">code</field>
+        <field name="usage">base_automation</field>
+        <field name="code"><![CDATA[
+if city_tax_product := env['product.product'].search([('x_accommodation_product', '=', 'stay_tax')], limit=1):
+    for order in records.order_id:
+        if not any(line.product_id.id == city_tax_product.id for line in order.order_line):
+            max_seq = max((line.sequence for line in order.order_line), default=10)
+            env['sale.order.line'].create({'order_id': order.id, 'product_id': city_tax_product.id, 'product_uom_qty': 0, 'sequence': max_seq + 1})
+]]></field>
+    </record>
     <record id="open_x_city_tax_action" model="ir.actions.act_window">
         <field name="name">City Tax</field>
         <field name="res_model">x_city_tax</field>
@@ -94,7 +107,7 @@ for slot in records.order_line.planning_slot_ids:
     <record id="server_action_set_task_ready_if_no_approvers" model="ir.actions.server">
         <field name="name">HouseKeeping: Set task ready if no approvers required after cleaning</field>
         <field name="code"><![CDATA[
-if not env['ir.config_parameter'].get_bool('booking_engine.x_approvers_setting', False) and (stage := env.ref('booking_engine.project_task_type_18', raise_if_not_found=False)): 
+if not env['ir.config_parameter'].get_bool('booking_engine.x_approvers_setting', False) and (stage := env.ref('booking_engine.project_task_type_18', raise_if_not_found=False)):
     record.write({'stage_id': stage.id, 'state': '1_done'})
 ]]></field>
         <field name="model_id" ref="project.model_project_task"/>
@@ -179,7 +192,7 @@ if (tasks := records.filtered(lambda e: not e.x_employee_id) if records else env
         ]]></field>
     </record>
 
-    <!-- 
+    <!--
         Availabilities: create & update logic
     -->
     <record id="server_action_update_availabilities" model="ir.actions.server">
@@ -200,7 +213,7 @@ if (records := env['x_availability'].search([('x_to_recompute', '=', True)])):
 
     # Fetch leaves in the time frame (Resource specific OR Calendar specific)
     leaves = env['resource.calendar.leaves'].search([
-        '|', ('resource_id', 'in', all_resources.ids), 
+        '|', ('resource_id', 'in', all_resources.ids),
             '&', ('calendar_id', 'in', all_resources.calendar_id.ids), ('resource_id', '=', False),
         ('date_to', '>=', dt_min), ('date_from', '<=', dt_max)])
 
@@ -209,7 +222,7 @@ if (records := env['x_availability'].search([('x_to_recompute', '=', True)])):
     # resource: date mapping (/!\ nightly stays)
     for slot in slots:
         start_d, end_d = slot.start_datetime.date(), slot.end_datetime.date()
-        
+
         for r_id in slot.resource_ids.ids:
             if r_id not in res_bookings: res_bookings[r_id] = set()
 
@@ -261,7 +274,7 @@ if (records := env['x_availability'].search([('x_to_recompute', '=', True)])):
 #   (it's not informative to see them and clutters the view)
 # 2. Create new ones at the start of the day
 #   (so that we always have the right window of availabilities for Channex)
-# 3. Trigger a recomputation of all the availabilities 
+# 3. Trigger a recomputation of all the availabilities
 #   (to make sure we don't have a bugged/false state that does not reflect reality,
 #    because unavoidable race conditions)
 
@@ -306,7 +319,7 @@ records, resources, start_f, end_f = [env.context.get(a) for a in ['records', 'r
 # 2. The offer (and its resources)
 # So, in this server action, we fetch all these for the leaves/slots we were given as a parameter,
 # then 3. we fetch all the corresponding availabilities
-# 4. Assign these new abilities to the leaves/slots to match their updated values (resources/dates) 
+# 4. Assign these new abilities to the leaves/slots to match their updated values (resources/dates)
 
 # We also perform the optimization of fetching all records in one query for performance optimization,
 # which makes the code harder to understand, which is the reason for these lengthy comments.
@@ -318,7 +331,7 @@ records, resources, start_f, end_f = [env.context.get(a) for a in ['records', 'r
 dates, unique_dates = {}, set()
 for rec in records:
     if not rec[start_f] or not rec[end_f]: continue        # skip this record if it has no date (unusable)
-    
+
     # find the start and end date of this leave/slot and find all dates in between
     d_min, d_max = rec[start_f].date(), rec[end_f].date()
     dates[rec.id] = [d_min + datetime.timedelta(days=i) for i in range((d_max - d_min).days + 1)]
@@ -343,7 +356,7 @@ for rec in records.filtered(lambda r: r.id in dates):
         target_res_ids = rec.resource_ids.ids
     else: # resource.calendar.leaves
         # If it has no resources, it means the record (leave) is global, and applies to all the resources.
-        # Conversely, if the record (leave) has a resource, it means that the record (leave) is only for this resource. 
+        # Conversely, if the record (leave) has a resource, it means that the record (leave) is only for this resource.
         target_res_ids = [rec.resource_id.id] if rec.resource_id else resources.filtered(lambda r: r.calendar_id.id == rec.calendar_id.id).ids
 
     if (target_offers := offers.filtered(lambda o: set(target_res_ids) & set(o.x_resource_ids.ids))):
@@ -426,7 +439,7 @@ env['x_availability'].search([('x_stay_offer_id', 'in', records.ids)]).unlink()
 ]]></field>
     </record>
 
-    <!-- 
+    <!--
         Availability dependencies: Update
     -->
     <record id="server_action_update_availability_for_planning_slot" model="ir.actions.server">
@@ -441,7 +454,7 @@ records.x_availability_ids.write({'x_to_recompute': True})
 # Now that the resource/dates have changed, we need to propagate the info to the corresponding availabilities
 if (valid_slots := records.filtered('resource_ids')):
     env.ref('booking_engine.server_action_helper_compute_new_avails_to_recompute').with_context(
-        records=valid_slots, field_start='start_datetime', field_end='end_datetime', 
+        records=valid_slots, field_start='start_datetime', field_end='end_datetime',
         resources=valid_slots.resource_ids).run()
 ]]></field>
     </record>
@@ -483,8 +496,8 @@ env.ref('booking_engine.server_action_update_availabilities').run()
         <field name="state">code</field>
         <field name="code"><![CDATA[
 # Impacting field changes: x_is_a_room_offer, x_resource_ids, active
-# We cannot filter on the domain because we need to catch 
-# x_is_a_room_offer True -> False and False -> True 
+# We cannot filter on the domain because we need to catch
+# x_is_a_room_offer True -> False and False -> True
 # but don't want to execute the availabilities code on not room offers
 
 domain = [('x_date', '>=', (today := datetime.date.today())), ('x_stay_offer_id', 'in', records.ids)]
@@ -502,7 +515,7 @@ env['x_availability'].search(domain + [('x_stay_offer_id.x_is_a_room_offer', '='
 # and create 500 days ONLY for them
 if (new_offers := records.filtered(lambda r: r.x_is_a_room_offer and r.active) - existing_avails.x_stay_offer_id):
     env['x_availability'].create([
-        {'x_stay_offer_id': offer.id, 'x_date': today + datetime.timedelta(days=i), 'x_to_recompute': True} 
+        {'x_stay_offer_id': offer.id, 'x_date': today + datetime.timedelta(days=i), 'x_to_recompute': True}
         for i in range(500) for offer in new_offers])
 
 env.ref('booking_engine.server_action_update_availabilities').run()

--- a/booking_engine/data/ir_ui_view.xml
+++ b/booking_engine/data/ir_ui_view.xml
@@ -314,7 +314,7 @@
           </group>
         </group>
         <group>
-          <group name="channel_manager" string="Channel Manager">
+          <group name="channel_manager" string="Channel Manager" invisible="1">
             <field name="x_offer_type"/>
           </group>
           <group name="house_keeping" string="House Keeping" groups="booking_engine.group_house_keeping">
@@ -471,7 +471,7 @@
         <xpath expr="//field[@name='role_ids']" position="attributes">
           <attribute name="string">Stay Offers</attribute>
           <attribute name="invisible">context.get('has_product')</attribute>
-          <attribute name="options">{"no_create": True}</attribute> 
+          <attribute name="options">{"no_create": True}</attribute>
           <attribute name="domain">[("x_resource_category", "=", "stay_offer")]</attribute>
         </xpath>
         <xpath expr="//field[@name='default_role_id']" position="attributes">
@@ -598,7 +598,7 @@
     <record id="resource_resource_form_view_extension" model="ir.ui.view">
         <field name="arch" type="xml">
             <xpath expr="/form/sheet/group" position="after">
-                <group invisible="x_category != 'stay_offer'">
+                <group invisible="x_category != 'stay_offer' or not x_occupancy">
                     <group string="House Keeping" groups="booking_engine.group_house_keeping">
                         <field name="x_occupancy" options="{}"/>
                         <field name="x_house_keeping_stage_id" domain="[('project_ids.x_is_house_keeping_project', '!=', False)]"/>
@@ -953,7 +953,7 @@
             <t t-set="bar_color" t-value="x_availability_color"/>
             <t t-set="bar_pct" t-value="x_availability"/>
             <t t-set="main_title" t-value="'Availability:'"/>
-            
+
             <t t-set="heat_scale" t-value="['#ffdc00', '#fbc904', '#f6b609', '#f2a30d', '#ed9011', '#e97d16', '#e4691a', '#e0561e', '#db4323', '#d73027']"/>
 
             <div class="oe_kanban_global_click p-2">
@@ -961,13 +961,13 @@
                 .o_gantt_popover_footer, .o_popover_footer, .o_kanban_record_footer, footer, .o_gantt_popover button.btn, .o_popover button { display: none !important; }
                 .o_booking_occupancy_gantt .o_gantt_pill_title { max-width: 100% !important; text-align: center; overflow: hidden; text-overflow: clip; }
               </style>
-              
+
               <div class="o_kanban_record_top mb-1">
                 <div class="o_kanban_record_title fw-bold">
                   <span t-out="new Date(x_date).toLocaleDateString(undefined, { month: 'short', day: 'numeric' })"/>
                 </div>
               </div>
-              
+
               <div class="o_kanban_record_body" style="min-width: 160px;">
                 <div class="progress mt-1" style="height: 8px; background-color: #e9ecef;">
                     <div
@@ -975,12 +975,12 @@
                         t-attf-style="width: {{bar_pct * 100}}%; background-color: {{heat_scale[bar_color]}} !important;"
                         t-att-aria-valuenow="bar_pct * 100" aria-valuemin="0" aria-valuemax="100"/>
                 </div>
-                
+
                 <div class="d-flex justify-content-between align-items-center mt-2 gap-2">
                     <strong><t t-out="main_title"/></strong>
                     <span class="ms-1"><strong><span t-out="Math.round(bar_pct * 100) + '%'"/></strong></span>
                 </div>
-                
+
                 <div class="d-flex justify-content-between align-items-center gap-2">
                   <span>Total Units:</span>
                   <span class="ms-1" t-out="x_total_units"/>


### PR DESCRIPTION
Stay offers need consistent city tax handling and sensible defaults to avoid
 manual configuration and irrelevant fields during room setup.

Add a server action and base automation to automatically insert the city tax line with zero quantity when a stay offer product is added to a sale order. Keep the tax line last so POS-added lines remain grouped correctly at checkout.

Also improve the hotel configuration defaults by:

- Hiding House Keeping fields when the resource has no occupancy.
- Defaulting the Working Schedule to "Rental 24/7" for new hotel resources.
- Hiding the Channel Manager section on Stay Offer products while preserving `x_offer_type` for the Channel module.
- Applying sensible defaults to new Stay Offer products, including the Stay Offer category, city tax, one stayover point, and two checkout points.

Task-6470079