### PR TITLE
[FIX] .*: fix deposit product configuration

### DIFF
--- a/beverage_distributor/__manifest__.py
+++ b/beverage_distributor/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Beverage Distributor',
-    'version': '2.4',
+    'version': '2.5',
     'category': 'Supply Chain',
     'depends': [
         'base_automation',

--- a/beverage_distributor/data/product_template.xml
+++ b/beverage_distributor/data/product_template.xml
@@ -415,4 +415,11 @@
         <field name="x_excise_quantity">0.007</field>
         <field name="x_packaging_units">1</field>
     </record>
+    <record id="pos_settle_due.product_product_deposit_product_template" model="product.template" forcecreate="0">
+        <field name="categ_id" ref="deposit_management.product_category_deposit"/>
+        <field name="type">consu</field>
+        <field name="list_price" eval="False"/>
+        <field name="invoice_policy">delivery</field>
+        <field name="is_storable" eval="True"/>
+    </record>
 </odoo>

--- a/micro_brewery/__manifest__.py
+++ b/micro_brewery/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Microbrewery',
-    'version': '2.6',
+    'version': '2.7',
     'category': 'Supply Chain',
     'depends': [
         'account',

--- a/micro_brewery/data/product_product.xml
+++ b/micro_brewery/data/product_product.xml
@@ -221,7 +221,9 @@
     </record>
     <record id="product_product_39" model="product.product">
         <field name="name">Deposit Keg</field>
-        <field name="list_price">35.0</field>
+        <field name="list_price">0.0</field>
+        <field name="invoice_policy">delivery</field>
+        <field name="is_storable" eval="True"/>
         <field name="categ_id" ref="deposit_management.product_category_deposit"/>
         <field name="x_deposit_amount">35</field>
         <field name="taxes_id" eval="[(6, 0, [ref('account_tax_46_sale')])]"/>

--- a/micro_brewery/data/product_template.xml
+++ b/micro_brewery/data/product_template.xml
@@ -242,7 +242,7 @@
     <record id="product_template_90" model="product.template" >
         <field name="name">Bottle 33cl</field>
         <field name="categ_id" ref="deposit_management.product_category_deposit"/>
-        <field name="list_price">10.0</field>
+        <field name="list_price">0.0</field>
         <field name="x_deposit_amount">0.1</field>
         <field name="invoice_policy">delivery</field>
         <field name="available_in_pos" eval="True"/>
@@ -254,5 +254,12 @@
         <field name="supplier_taxes_id" eval="[(6, 0, [ref('deposit_management.account_tax_01_purchase')])]"/>
         <field name="pos_categ_ids" eval="[(6, 0, [ref('pos_category_5')])]"/>
         <field name="purchase_ok" eval="False"/>
+    </record>
+    <record id="pos_settle_due.product_product_deposit_product_template" model="product.template" forcecreate="0">
+        <field name="categ_id" ref="deposit_management.product_category_deposit"/>
+        <field name="type">consu</field>
+        <field name="list_price" eval="False"/>
+        <field name="invoice_policy">delivery</field>
+        <field name="is_storable" eval="True"/>
     </record>
 </odoo>


### PR DESCRIPTION
Deposit products are used to account for returned containers, so their
sale price must not be included in the invoice amount. The deposit amount
is tracked separately through the deposit management module.

* Set the Bottle 33cl sale price to 0 in `micro_brewery`.
* Set the Deposit Keg sale price to 0 in `micro_brewery`.
* Keep the deposit amount on the deposit products separately from their
  sale price.
* Configure deposit products with delivery-based invoicing.
* Mark deposit products as storable products so returned deposits can be
  properly handled in stock operations.
* Apply the same configuration to the shared deposit product template used
  by dependent industries.
* Bump the demo module versions to reflect the updated product data.

This ensures returned deposit products can be invoiced without increasing
the invoice amount by their deposit value while retaining the deposit
amount required for return handling.

Task-6469818
