### PR TITLE
[IMP] hvac_services: configure field service and improve demo data

### DIFF
--- a/hvac_services/__manifest__.py
+++ b/hvac_services/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'HVAC Services',
-    'version': '1.6',
+    'version': '1.7',
     'category': 'Services',
     'depends': [
         'appointment_account_payment',

--- a/hvac_services/data/product_template.xml
+++ b/hvac_services/data/product_template.xml
@@ -4,22 +4,6 @@
         <field name="name">Installation</field>
         <field name="image_1920" type="bytes" file="hvac_services/static/src/binary/product_template/5-image_1920"/>
         <field name="type">service</field>
-        <field name="service_tracking">task_global_project</field>
-        <field name="categ_id" ref="product.product_category_services"/>
-        <field name="list_price">250.0</field>
-        <field name="purchase_ok" eval="False"/>
-        <field name="is_favorite" eval="True"/>
-        <field name="purchase_method">purchase</field>
-        <field name="service_type">timesheet</field>
-        <field name="invoice_policy">order</field>
-        <field name="project_id" ref="planning_field_service_sale_timesheet.fsm_project"/>
-        <field name="worksheet_template_id" ref="worksheet_template"/>
-    </record>
-    <record id="product_template_repair" model="product.template" context="{'create_product_product': False}">
-        <field name="name">Repair</field>
-        <field name="image_1920" type="bytes" file="hvac_services/static/src/binary/product_template/10-image_1920"/>
-        <field name="type">service</field>
-        <field name="service_tracking">task_global_project</field>
         <field name="categ_id" ref="product.product_category_services"/>
         <field name="list_price">100.0</field>
         <field name="uom_id" ref="uom.product_uom_hour"/>
@@ -28,25 +12,40 @@
         <field name="purchase_method">purchase</field>
         <field name="service_type">timesheet</field>
         <field name="invoice_policy">delivery</field>
-        <field name="project_id" ref="planning_field_service_sale_timesheet.fsm_project"/>
-        <field name="worksheet_template_id" ref="worksheet_template"/>
+        <field name="planning_role_id" ref="planning_field_service_sale_timesheet.field_service_technician_role"/>
+        <field name="worksheet_template_id" ref="worksheet_template_installation"/>
+    </record>
+    <record id="product_template_repair" model="product.template" context="{'create_product_product': False}">
+        <field name="name">Repair</field>
+        <field name="image_1920" type="bytes" file="hvac_services/static/src/binary/product_template/10-image_1920"/>
+        <field name="type">service</field>
+        <field name="categ_id" ref="product.product_category_services"/>
+        <field name="list_price">100.0</field>
+        <field name="uom_id" ref="uom.product_uom_hour"/>
+        <field name="purchase_ok" eval="False"/>
+        <field name="is_favorite" eval="True"/>
+        <field name="purchase_method">purchase</field>
+        <field name="service_type">timesheet</field>
+        <field name="invoice_policy">delivery</field>
+        <field name="planning_role_id" ref="planning_field_service_sale_timesheet.field_service_technician_role"/>
+        <field name="worksheet_template_id" ref="worksheet_template_maint_repair"/>
         <field name="x_is_maintenance" eval="True"/>
     </record>
     <record id="product_template_maintenance" model="product.template" context="{'create_product_product': False}">
         <field name="name">Maintenance</field>
         <field name="image_1920" type="bytes" file="hvac_services/static/src/binary/product_template/7-image_1920"/>
         <field name="type">service</field>
-        <field name="service_tracking">task_global_project</field>
         <field name="categ_id" ref="product.product_category_services"/>
         <field name="list_price">100.0</field>
+        <field name="uom_id" ref="uom.product_uom_hour"/>
         <field name="purchase_ok" eval="False"/>
         <field name="is_favorite" eval="True"/>
         <field name="purchase_method">purchase</field>
         <field name="service_type">timesheet</field>
-        <field name="invoice_policy">order</field>
+        <field name="invoice_policy">delivery</field>
         <field name="recurring_invoice" eval="True"/>
-        <field name="project_id" ref="planning_field_service_sale_timesheet.fsm_project"/>
-        <field name="worksheet_template_id" ref="worksheet_template"/>
+        <field name="planning_role_id" ref="planning_field_service_sale_timesheet.field_service_technician_role"/>
+        <field name="worksheet_template_id" ref="worksheet_template_maint_repair"/>
         <field name="x_is_maintenance" eval="True"/>
     </record>
     <record id="product_template_4" model="product.template" context="{'create_product_product': False}">

--- a/hvac_services/data/res_config_settings.xml
+++ b/hvac_services/data/res_config_settings.xml
@@ -6,6 +6,8 @@
         <field name="group_product_pricelist" eval="True"/>
         <field name="documents_product_settings" eval="True"/>
         <field name="group_lot_on_invoice" eval="True"/>
+        <field name="planning_project_id" ref="planning_field_service_sale_timesheet.fsm_project"/>
+        <field name="group_field_service_allow_equipment" eval="True"/>
     </record>
     <function model="res.config.settings" name="execute">
         <value eval="[ref('res_config_settings_enable')]"/>

--- a/hvac_services/data/worksheet_template.xml
+++ b/hvac_services/data/worksheet_template.xml
@@ -1,14 +1,23 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
-    <record id="worksheet_template" model="worksheet.template">
-        <field name="name">INST/MAIN/REPA Worksheet</field>
+    <record id="worksheet_template_installation" model="worksheet.template">
+        <field name="name">Installation Worksheet</field>
+        <field name="res_model">planning.slot</field>
+        <field name="worksheet_properties_definition" eval="[{
+        'name': '1e3fda2ad9a42865', 'type': 'many2one', 'domain': False, 'string': 'Refrigerant Product', 'comodel': 'product.template', 'default': False}, {
+        'name': '7d37c31a412cf224', 'type': 'float', 'string': 'Removed Refrigerant', 'default': 0.0},{
+        'name': '7d37c31a412cf227', 'type': 'float', 'string': 'Added Refrigerant', 'default': 0.0},{
+        'name': 'cfed639df1c4906e', 'type': 'boolean', 'string': 'Product is functional after operation.', 'default': False}, {
+        'name': '7d37c31a412cf226_html', 'type': 'html', 'string': 'Comments', 'default': False}, {
+        'name': 'df81b419282b4e86', 'type': 'signature', 'string': 'Technician Signature', 'default': False
+        }]"/>
+    </record>
+    <record id="worksheet_template_maint_repair" model="worksheet.template">
+        <field name="name">Maint/Repair Worksheet</field>
         <field name="res_model">planning.slot</field>
         <field name="worksheet_properties_definition" eval="[{
         'name': '4e67e5166cfca465', 'type': 'selection', 'string': 'Operation', 'default': False,
-            'selection': [['89b565d13c43c300', 'Installation'], ['89b565d13c43c301', 'Maintenance'], ['ecedd4f18ff40164', 'Repair']]}, {
-        'name': '7d37c31a412cf225', 'type': 'date', 'string': 'Date', 'default': False}, {
-        'name': '4e67e5166cfca466', 'type': 'selection', 'string': 'Primary Root Cause', 'default': False,
-            'selection': [['89b565d13c43c300', 'Misuse'], ['89b565d13c43c301', 'Defect'], ['ecedd4f18ff40164', 'Natural Failure'], ['ecedd4f18ff40165', 'Unknown']]}, {
+            'selection': [['89b565d13c43c300', 'Maintenance'], ['ecedd4f18ff40164', 'Repair']]}, {
         'name': '7d37c31a412cf225_html', 'type': 'html', 'string': 'Root Cause Comments', 'default': False}, {
         'name': '1e3fda2ad9a42865', 'type': 'many2one', 'domain': False, 'string': 'Refrigerant Product', 'comodel': 'product.template', 'default': False}, {
         'name': '7d37c31a412cf224', 'type': 'float', 'string': 'Removed Refrigerant', 'default': 0.0},{

--- a/hvac_services/demo/planning_slot.xml
+++ b/hvac_services/demo/planning_slot.xml
@@ -2,10 +2,14 @@
 <odoo noupdate="1">
     <record id="planning_slot_1" model="planning.slot">
         <field name="sale_line_id" ref="sale_order_line_5"/>
-        <field name="worksheet_template_id" ref="worksheet_template"/>
+        <field name="role_id" ref="planning_field_service_sale_timesheet.field_service_technician_role"/>
+        <field name="resource_ids" model="resource.resource" eval="obj().env.ref('hvac_services.hr_employee_2').resource_id.ids"/>
+        <field name="start_datetime" eval="datetime.now().strftime('%Y-%m-%d 09:00:00')"/>
+        <field name="end_datetime" eval="datetime.now().strftime('%Y-%m-%d 17:00:00')"/>
+        <field name="state">2_published</field>
+        <field name="worksheet_template_id" ref="worksheet_template_maint_repair"/>
         <field name="worksheet_properties" eval="{
             '4e67e5166cfca465': '89b565d13c43c300',
-            '7d37c31a412cf225': (datetime.now() - relativedelta(days=3)).strftime('%Y-%m-%d'),
             '1e3fda2ad9a42865': ref('product_template_9'),
             '7d37c31a412cf227': 1.2,
             'cfed639df1c4906e': True,
@@ -14,10 +18,13 @@
     </record>
     <record id="planning_slot_2" model="planning.slot">
         <field name="sale_line_id" ref="sale_order_line_9"/>
-        <field name="worksheet_template_id" ref="worksheet_template"/>
+        <field name="role_id" ref="planning_field_service_sale_timesheet.field_service_technician_role"/>
+        <field name="resource_ids" model="resource.resource" eval="obj().env.ref('hvac_services.hr_employee_1').resource_id.ids"/>
+        <field name="start_datetime" eval="(datetime.now() - relativedelta(days=1)).strftime('%Y-%m-%d 09:00:00')"/>
+        <field name="end_datetime" eval="(datetime.now() - relativedelta(days=1)).strftime('%Y-%m-%d 17:00:00')"/>
+        <field name="state">4_completed</field>
+        <field name="worksheet_template_id" ref="worksheet_template_installation"/>
         <field name="worksheet_properties" eval="{
-            '4e67e5166cfca465': '89b565d13c43c300',
-            '7d37c31a412cf225': (datetime.now() - relativedelta(days=3)).strftime('%Y-%m-%d'),
             '1e3fda2ad9a42865': ref('product_template_9'),
             '7d37c31a412cf227': 5.2,
             'cfed639df1c4906e': True,
@@ -27,10 +34,13 @@
     </record>
     <record id="planning_slot_3" model="planning.slot">
         <field name="sale_line_id" ref="sale_order_line_13"/>
-        <field name="worksheet_template_id" ref="worksheet_template"/>
+        <field name="role_id" ref="planning_field_service_sale_timesheet.field_service_technician_role"/>
+        <field name="resource_ids" model="resource.resource" eval="obj().env.ref('hvac_services.hr_employee_2').resource_id.ids"/>
+        <field name="start_datetime" eval="(datetime.now() - relativedelta(days=1)).strftime('%Y-%m-%d 09:00:00')"/>
+        <field name="end_datetime" eval="(datetime.now() - relativedelta(days=1)).strftime('%Y-%m-%d 17:00:00')"/>
+        <field name="state">4_completed</field>
+        <field name="worksheet_template_id" ref="worksheet_template_installation"/>
         <field name="worksheet_properties" eval="{
-            '4e67e5166cfca465': '89b565d13c43c300',
-            '7d37c31a412cf225': (datetime.now() - relativedelta(days=2)).strftime('%Y-%m-%d'),
             '1e3fda2ad9a42865': ref('product_template_9'),
             '7d37c31a412cf227': 2.2,
             'cfed639df1c4906e': True,
@@ -38,27 +48,16 @@
             'df81b419282b4e86': False
         }"/>
     </record>
-    <record id="planning_slot_4" model="planning.slot">
-        <field name="sale_line_id" ref="sale_order_line_18"/>
-        <field name="worksheet_template_id" ref="worksheet_template"/>
-        <field name="worksheet_properties" eval="{
-            '4e67e5166cfca465': '89b565d13c43c301',
-            '7d37c31a412cf225': (datetime.now() - relativedelta(days=7)).strftime('%Y-%m-%d'),
-            '1e3fda2ad9a42865': ref('product_template_9'),
-            '7d37c31a412cf224': 1.2,
-            '7d37c31a412cf227': 1.2,
-            'cfed639df1c4906e': True,
-            '7d37c31a412cf226_html': '&lt;div data-oe-version=&quot;2.0&quot;&gt;All works fine, ready for summer heat!&lt;/div&gt;',
-            'df81b419282b4e86': False
-        }"/>
-    </record>
     <record id="planning_slot_5" model="planning.slot">
         <field name="sale_line_id" ref="sale_order_line_19"/>
-        <field name="worksheet_template_id" ref="worksheet_template"/>
+        <field name="role_id" ref="planning_field_service_sale_timesheet.field_service_technician_role"/>
+        <field name="resource_ids" model="resource.resource" eval="obj().env.ref('hvac_services.hr_employee_2').resource_id.ids"/>
+        <field name="start_datetime" eval="(datetime.now() + relativedelta(days=1)).strftime('%Y-%m-%d 09:00:00')"/>
+        <field name="end_datetime" eval="(datetime.now() + relativedelta(days=1)).strftime('%Y-%m-%d 17:00:00')"/>
+        <field name="state">2_published</field>
+        <field name="worksheet_template_id" ref="worksheet_template_maint_repair"/>
         <field name="worksheet_properties" eval="{
             '4e67e5166cfca465': 'ecedd4f18ff40164',
-            '7d37c31a412cf225': (datetime.now() - relativedelta(days=10)).strftime('%Y-%m-%d'),
-            '4e67e5166cfca466': '89b565d13c43c301',
             '7d37c31a412cf225_html': '&lt;div data-oe-version=&quot;2.0&quot;&gt;The fan blade tip gap wasn&quot;t large enough which caused noises due to collisions.&lt;/div&gt;',
             'cfed639df1c4906e': True,
             '7d37c31a412cf226_html': '&lt;div data-oe-version=&quot;2.0&quot;&gt;The fan blades have been replaced.&lt;/div&gt;',
@@ -67,22 +66,16 @@
     </record>
     <record id="planning_slot_6" model="planning.slot">
         <field name="sale_line_id" ref="sale_order_line_23"/>
-        <field name="worksheet_template_id" ref="worksheet_template"/>
+        <field name="role_id" ref="planning_field_service_sale_timesheet.field_service_technician_role"/>
+        <field name="resource_ids" model="resource.resource" eval="obj().env.ref('hvac_services.hr_employee_1').resource_id.ids"/>
+        <field name="start_datetime" eval="datetime.now().strftime('%Y-%m-%d 09:00:00')"/>
+        <field name="end_datetime" eval="datetime.now().strftime('%Y-%m-%d 17:00:00')"/>
+        <field name="state">2_published</field>
+        <field name="worksheet_template_id" ref="worksheet_template_maint_repair"/>
         <field name="worksheet_properties" eval="{
             '4e67e5166cfca465': '89b565d13c43c300',
-            '7d37c31a412cf225': (datetime.now() - relativedelta(months=8)).strftime('%Y-%m-%d'),
             '1e3fda2ad9a42865': ref('product_template_9'),
             '7d37c31a412cf227': 2.2,
-            'cfed639df1c4906e': True,
-            'df81b419282b4e86': False
-        }"/>
-    </record>
-    <record id="planning_slot_7" model="planning.slot">
-        <field name="sale_line_id" ref="sale_order_line_24"/>
-        <field name="worksheet_template_id" ref="worksheet_template"/>
-        <field name="worksheet_properties" eval="{
-            '4e67e5166cfca465': '89b565d13c43c301',
-            '7d37c31a412cf225': (datetime.now() - relativedelta(days=2)).strftime('%Y-%m-%d'),
             'cfed639df1c4906e': True,
             'df81b419282b4e86': False
         }"/>

--- a/hvac_services/demo/sale_order_post.xml
+++ b/hvac_services/demo/sale_order_post.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True}">
+<odoo noupdate="1" context="{'mail_auto_subscribe_no_notify': True, 'mail_notrack': True}">
     <record id="sale_order_11" model="sale.order">
         <field name="x_maintained_serials_ids" eval="[(6, 0, [ref('stock_lot_14')])]"/>
     </record>
@@ -64,6 +64,19 @@
         <value model="project.task" search="[('sale_order_id', '=', ref('sale_order_11')), ('name', 'ilike', 'S00011 - Repair')]"/>
         <value eval="{'planned_date_begin': datetime.today().date() + relativedelta(days=5, hours=6), 'date_deadline': datetime.today().date() + relativedelta(days=5, hours=15), 'user_ids': [ref('res_users_1')]}"/>
     </function>
+    <function name="action_confirm" model="sale.order" eval="[[
+        ref('sale_order_1'),
+        ref('sale_order_2'),
+        ref('sale_order_3'),
+        ref('sale_order_4'),
+        ref('sale_order_5'),
+        ref('sale_order_6'),
+        ref('sale_order_7'),
+        ref('sale_order_8'),
+        ref('sale_order_9'),
+        ref('sale_order_10'),
+        ref('sale_order_11'),
+    ]]"/>
     <function name="button_validate" model="stock.picking" context="{'skip_sms': True}">
         <value model="stock.picking" eval="(
             obj().env.ref('hvac_services.sale_order_1') +


### PR DESCRIPTION
Configure Field Service settings and improve the demo data.

- Configure billing to use the Field Service project.
- Enable equipment history and set the project to Field Service.
- Split the planning worksheet into Installation and Maintenance/Repair 
worksheets.
- Update Installation, Maintenance, and Repair service product data.
- Configure service products for timesheet-based invoicing and technician 
planning.
- Update the planning slots resulting from sales orders.

TaskId-6479448