### PR TITLE
[FIX] industry_real_estate: renewals not including property

### DIFF
--- a/industry_real_estate/__manifest__.py
+++ b/industry_real_estate/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Property Management',
-    'version': '2.3',
+    'version': '2.4',
     'category': 'Services',
     'depends': [
         'base_automation',

--- a/industry_real_estate/data/base_automation.xml
+++ b/industry_real_estate/data/base_automation.xml
@@ -7,6 +7,13 @@
         <field name="trigger">on_state_set</field>
         <field name="trg_selection_field_id" ref="sale.selection__sale_order__state__sale"/>
         <field name="filter_pre_domain" eval="[('state', 'in', ['draft', 'sent'])]"/>
-        <field name="filter_domain" eval="[('state', '=', 'sale'), ('x_property_id', '!=', False), ('plan_id', '!=', False)]"/>
+        <field name="filter_domain" eval="[('state', '=', 'sale'), ('x_property_id', '!=', False), ('plan_id', '!=', False), ('subscription_state', '!=', '7_upsell')]"/>
+    </record>
+    <record id="automation_copy_property_from_parent" model="base.automation">
+        <field name="name">Copy property on renew/upsell</field>
+        <field name="model_id" ref="sale.model_sale_order"/>
+        <field name="action_server_ids" eval="[(6, 0, [ref('action_copy_property_from_parent')])]"/>
+        <field name="trigger">on_create</field>
+        <field name="filter_domain" eval="[('subscription_id', '!=', False)]"/>
     </record>
 </odoo>

--- a/industry_real_estate/data/ir_actions_server.xml
+++ b/industry_real_estate/data/ir_actions_server.xml
@@ -42,15 +42,88 @@ action['context'] = {'default_is_subscription': True}
         <field name="state">code</field>
         <field name="name">Add Tenant</field>
         <field name="usage">base_automation</field>
-        <field name="code">
+        <field name="code"><![CDATA[
 for order in record:
-    stake_holder = env['x_stake_holder'].create({
+    start = order.start_date
+    domain = [('x_property_id', '=', order.x_property_id.id), ('x_type', '=', 'tenant'), ('x_start_date', '!=', False), '|', ('x_end_date', '=', False), ('x_end_date', '>=', start)]
+    if order.end_date:
+        domain = [('x_start_date', '<=', order.end_date)] + domain
+    previous = env['x_stake_holder'].search(domain)
+    new_end = start - datetime.timedelta(days=1) if start else False
+    for rec in previous:
+        if new_end and rec.x_start_date <= new_end:
+            rec['x_end_date'] = new_end
+        else:
+            rec.unlink()
+    env['x_stake_holder'].create({
         'x_stake_holder': order.partner_id.id,
         'x_property_id': order.x_property_id.id,
         'x_start_date': order.start_date,
         'x_end_date': order.end_date,
         'x_type': 'tenant',
     })
-        </field>
+]]></field>
+    </record>
+    <record id="action_open_leasing_so_form" model="ir.actions.server">
+        <field name="name">Open Leasing Form</field>
+        <field name="model_id" ref="sale.model_sale_order"/>
+        <field name="state">code</field>
+        <field name="code"><![CDATA[
+method = env.context.get('leasing_so_method')
+if method == 'prepare_renewal_order':
+    action = record.prepare_renewal_order()
+elif method == 'prepare_upsell_order':
+    action = record.prepare_upsell_order()
+elif method == 'open_subscription_renewal':
+    action = record.open_subscription_renewal()
+elif method == 'open_subscription_upsell':
+    action = record.open_subscription_upsell()
+elif method == 'create_alternative':
+    action = record.create_alternative()
+else:
+    action = False
+if action:
+    rental = env['ir.actions.act_window']._for_xml_id('industry_real_estate.action_rental_contracts')
+    form_id = env.ref('industry_real_estate.rental_form_view').id
+    views = []
+    for view in action.get('views') or []:
+        if view[1] == 'form':
+            views.append((form_id, 'form'))
+        else:
+            views.append((view[0], view[1]))
+    if not views:
+        views = [(form_id, 'form')]
+    modes = []
+    for view in views:
+        modes.append(view[1])
+    rental['views'] = views
+    rental['view_mode'] = ','.join(modes)
+    if action.get('res_id'):
+        rental['res_id'] = action['res_id']
+    if action.get('domain') is not None:
+        rental['domain'] = action['domain']
+    if action.get('name'):
+        rental['name'] = action['name']
+    if action.get('context'):
+        rental['context'] = action['context']
+    action = rental
+]]></field>
+    </record>
+    <record id="action_copy_property_from_parent" model="ir.actions.server">
+        <field name="model_id" ref="sale.model_sale_order"/>
+        <field name="state">code</field>
+        <field name="name">Copy Property from Parent Contract</field>
+        <field name="usage">base_automation</field>
+        <field name="code"><![CDATA[
+for order in records:
+    parent = order.subscription_id
+    vals = {}
+    if parent.x_property_id and not order.x_property_id:
+        vals['x_property_id'] = parent.x_property_id.id
+    if parent.x_guarant_partner_id and not order.x_guarant_partner_id:
+        vals['x_guarant_partner_id'] = parent.x_guarant_partner_id.id
+    if vals:
+        order.write(vals)
+]]></field>
     </record>
 </odoo>

--- a/industry_real_estate/data/ir_ui_views.xml
+++ b/industry_real_estate/data/ir_ui_views.xml
@@ -136,6 +136,36 @@
                     <field name="end_date" required="True"/>
                 </div>
             </xpath>
+            <button name="prepare_renewal_order" position="attributes">
+                <attribute name="name">%(action_open_leasing_so_form)d</attribute>
+                <attribute name="type">action</attribute>
+                <attribute name="context">{'leasing_so_method': 'prepare_renewal_order'}</attribute>
+            </button>
+            <button name="prepare_upsell_order" position="attributes">
+                <attribute name="name">%(action_open_leasing_so_form)d</attribute>
+                <attribute name="type">action</attribute>
+                <attribute name="context">{'leasing_so_method': 'prepare_upsell_order'}</attribute>
+            </button>
+            <button name="open_subscription_renewal" position="attributes">
+                <attribute name="name">%(action_open_leasing_so_form)d</attribute>
+                <attribute name="type">action</attribute>
+                <attribute name="context">{'leasing_so_method': 'open_subscription_renewal'}</attribute>
+            </button>
+            <button name="open_subscription_upsell" position="attributes">
+                <attribute name="name">%(action_open_leasing_so_form)d</attribute>
+                <attribute name="type">action</attribute>
+                <attribute name="context">{'leasing_so_method': 'open_subscription_upsell'}</attribute>
+            </button>
+            <xpath expr="//button[@name='create_alternative' and contains(@context, '7_upsell')]" position="attributes">
+                <attribute name="name">%(action_open_leasing_so_form)d</attribute>
+                <attribute name="type">action</attribute>
+                <attribute name="context">{'default_subscription_state': '7_upsell', 'leasing_so_method': 'create_alternative'}</attribute>
+            </xpath>
+            <xpath expr="//button[@name='create_alternative'][not(@context)]" position="attributes">
+                <attribute name="name">%(action_open_leasing_so_form)d</attribute>
+                <attribute name="type">action</attribute>
+                <attribute name="context">{'leasing_so_method': 'create_alternative'}</attribute>
+            </xpath>
         </field>
     </record>
     <record id="meters_list_view_inherit" model="ir.ui.view">

--- a/tests/test_industry_real_estate/tests/__init__.py
+++ b/tests/test_industry_real_estate/tests/__init__.py
@@ -1,3 +1,4 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import test_computed_fields
+from . import test_rental_renewal

--- a/tests/test_industry_real_estate/tests/test_rental_renewal.py
+++ b/tests/test_industry_real_estate/tests/test_rental_renewal.py
@@ -1,0 +1,78 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from datetime import timedelta
+
+from odoo import Command, fields
+from odoo.tests import freeze_time, tagged
+from odoo.tests.common import TransactionCase
+
+
+@tagged('post_install', '-at_install')
+class TestRentalContractRenew(TransactionCase):
+
+    def _create_invoiced_rental(self):
+        partner = self.env['res.partner'].create({'name': 'OPW 6390673 Tenant'})
+        guarant = self.env['res.partner'].create({'name': 'OPW 6390673 Guarant'})
+        building = self.env['x_buildings'].create({'x_name': 'OPW 6390673 Building'})
+        prop = self.env['x_property'].create({
+            'x_name': 'OPW 6390673 Property',
+            'x_building': building.id,
+            'x_type': self.env.ref('property_assets_distribution.x_properties_types_office').id,
+        })
+        with freeze_time('2026-01-15'):
+            order = self.env['sale.order'].create({
+                'partner_id': partner.id,
+                'plan_id': self.env.ref('sale_subscription.subscription_plan_month').id,
+                'require_payment': False,
+                'start_date': fields.Date.to_date('2026-01-15'),
+                'end_date': fields.Date.to_date('2026-07-14'),
+                'x_property_id': prop.id,
+                'x_guarant_partner_id': guarant.id,
+                'order_line': [Command.create({
+                    'product_id': self.env.ref('industry_real_estate.product_product_42').id,
+                    'product_uom_qty': 1,
+                    'price_unit': 1000,
+                })],
+            })
+            order.action_confirm()
+            order._create_recurring_invoice()
+            self.assertNotEqual(
+                order.start_date, order.next_invoice_date,
+                "The first period must be invoiced before creating a renewal",
+            )
+        return order, prop, guarant
+
+    def test_leasing_renewal_keeps_property(self):
+        """Leasing Renew copies Property, stays on the rental form, and does not overlap tenants."""
+        order, prop, guarant = self._create_invoiced_rental()
+        rental_form_id = self.env.ref('industry_real_estate.rental_form_view').id
+
+        with freeze_time('2026-02-15'):
+            action = self.env.ref('industry_real_estate.action_open_leasing_so_form').with_context(
+                active_id=order.id,
+                active_ids=[order.id],
+                active_model='sale.order',
+                leasing_so_method='prepare_renewal_order',
+            ).run()
+            self.assertEqual(
+                action.get('id'),
+                self.env.ref('industry_real_estate.action_rental_contracts').id,
+                "Leasing renew must keep the Rental Contracts action so the client does not fall back to /sale.order/<id>",
+            )
+            self.assertIn((rental_form_id, 'form'), action.get('views') or [])
+            renewal = self.env['sale.order'].browse(action['res_id'])
+            self.assertEqual(
+                renewal.x_property_id, prop,
+                "Renewal quotation should keep the Property from the parent contract",
+            )
+            self.assertEqual(renewal.x_guarant_partner_id, guarant)
+            renewal.action_confirm()
+
+        tenants = self.env['x_stake_holder'].search([
+            ('x_property_id', '=', prop.id),
+            ('x_type', '=', 'tenant'),
+        ], order='x_start_date')
+        self.assertEqual(len(tenants), 2)
+        self.assertEqual(tenants[0].x_end_date, renewal.start_date - timedelta(days=1))
+        self.assertEqual(tenants[1].x_start_date, renewal.start_date)
+        self.assertLess(tenants[0].x_end_date, tenants[1].x_start_date)


### PR DESCRIPTION
### Current behavior:
Renewing a rental contract does not copy Property/Guarant, opens the generic subscription form (which shows Customer instead of Tenant), and confirming the renewal raises "Stakeholder dates cannot overlap"

### Expected behavior:
When renewing, property and other fields should still appear in the new subscription renewal

### Steps to reproduce:
1. Install Property Management, open a rental contract with a Property
2. Confirm, invoice, then Renew
3. Property is empty / hidden; Confirm raises stakeholder overlap

### Cause of the issue:
Renew/upsell create a new SO from a generic subscription form, so industry fields are omitted

### Fix:
- Copy Property and Guarant from the parent on child Sale Order
- Keep Tenant/Property/Guarant on the leasing form only
- Leasing Renew/Upsell will open that form via a server action
- End overlapping tenant occupancies before creating the new line, skip Add Tenant on upsell

opw-6390673