### PR TITLE
[FIX] campsite,hotel: restrict synchronization of resources

### DIFF
--- a/campsite/data/ir_actions_server.xml
+++ b/campsite/data/ir_actions_server.xml
@@ -2,7 +2,7 @@
 <odoo>
     <record id="ir_actions_to_link_resources_to_pos_checkout_payment" model="ir.actions.server">
         <field name="code"><![CDATA[
-if pos_checkout_payment_method := env.ref('campsite.pos_payment_method_1', raise_if_not_found=False):
+if (pos_checkout_payment_method := env.ref('campsite.pos_payment_method_1', raise_if_not_found=False)) and not pos_checkout_payment_method.open_session_ids:
     pos_checkout_payment_method['resource_ids'] |= records
         ]]></field>
         <field name="model_id" ref="resource.model_resource_resource"/>

--- a/hotel/data/ir_actions_server.xml
+++ b/hotel/data/ir_actions_server.xml
@@ -2,7 +2,7 @@
 <odoo>
     <record id="ir_actions_to_link_resources_to_pos_checkout_payment" model="ir.actions.server">
         <field name="code"><![CDATA[
-if pos_checkout_payment_method := env.ref('hotel.pos_payment_method_1', raise_if_not_found=False):
+if (pos_checkout_payment_method := env.ref('hotel.pos_payment_method_1', raise_if_not_found=False)) and not pos_checkout_payment_method.open_session_ids:
     pos_checkout_payment_method['resource_ids'] |= records
         ]]></field>
         <field name="model_id" ref="resource.model_resource_resource"/>


### PR DESCRIPTION
Before this commit, if you create a stay offer resource, an automation would link it to the payment method based on resources. But this is prevented if any pos.session is open. This commit fixes the issue by checking first that there is no open session before adding the resource to the pos.config.