### PR TITLE
[IMP] hvac_services: update planning and sales access rights for technician

### DIFF
--- a/hvac_services/__manifest__.py
+++ b/hvac_services/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'HVAC Services',
-    'version': '1.7',
+    'version': '1.8',
     'category': 'Services',
     'depends': [
         'appointment_account_payment',

--- a/hvac_services/demo/res_users.xml
+++ b/hvac_services/demo/res_users.xml
@@ -3,9 +3,11 @@
     <record id="res_users_1" model="res.users">
         <field name="partner_id" ref="res_partner_1"/>
         <field name="login">andrew.blake@example.com</field>
+        <field name="group_ids" eval="[(4, ref('sales_team.group_sale_salesman_all_leads')), (4, ref('planning.group_planning_user'))]"/>
     </record>
     <record id="res_users_2" model="res.users">
         <field name="partner_id" ref="res_partner_2"/>
         <field name="login">tom.white@example.com</field>
+        <field name="group_ids" eval="[(4, ref('sales_team.group_sale_salesman_all_leads')), (4, ref('planning.group_planning_user'))]"/>
     </record>
 </odoo>


### PR DESCRIPTION
- Set `Planning access to User` for technician employees so they can manage their shifts.
- Set `Sales access to All Documents` so technicians can add products to sales orders during planning shifts.

Task ID -  6487833