### PR TITLE
[FIX] .*: remove the url from the tours

### DIFF
--- a/agriculture_shop/static/src/js/my_tour.js
+++ b/agriculture_shop/static/src/js/my_tour.js
@@ -4,7 +4,6 @@ import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add("agriculture_shop_knowledge_tour", {
-    url: "/odoo",
     
     steps: () => [
         {

--- a/architects/static/src/js/my_tour.js
+++ b/architects/static/src/js/my_tour.js
@@ -4,7 +4,6 @@ import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add("architects_knowledge_tour", {
-    url: "/odoo",
     
     steps: () => [
         {

--- a/art_craft/static/src/js/my_tour.js
+++ b/art_craft/static/src/js/my_tour.js
@@ -4,7 +4,6 @@ import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add("art_craft_knowledge_tour", {
-    url: "/odoo",
     
     steps: () => [
         {

--- a/automobile/static/src/js/my_tour.js
+++ b/automobile/static/src/js/my_tour.js
@@ -4,7 +4,6 @@ import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add("automobile_knowledge_tour", {
-    url: "/odoo",
     
     steps: () => [
         {

--- a/bakery/static/src/js/my_tour.js
+++ b/bakery/static/src/js/my_tour.js
@@ -2,7 +2,6 @@ import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add("bakery_knowledge_tour", {
-    url: "/odoo",
     steps: () => [
         {
             trigger: '.o_app[data-menu-xmlid="knowledge.knowledge_menu_root"]',

--- a/beverage_distributor/static/src/js/my_tour.js
+++ b/beverage_distributor/static/src/js/my_tour.js
@@ -4,7 +4,6 @@ import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add("beverage_distributor_knowledge_tour", {
-    url: "/odoo",
     
     steps: () => [
         {

--- a/bike_leasing/static/src/js/my_tour.js
+++ b/bike_leasing/static/src/js/my_tour.js
@@ -4,7 +4,6 @@ import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add("bike_leasing_knowledge_tour", {
-    url: "/odoo",
     
     steps: () => [
         {

--- a/billboard_rental/static/src/js/my_tour.js
+++ b/billboard_rental/static/src/js/my_tour.js
@@ -4,7 +4,6 @@ import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add("billboard_rental_knowledge_tour", {
-    url: "/odoo",
     
     steps: () => [
         {

--- a/bookstore/static/src/js/my_tour.js
+++ b/bookstore/static/src/js/my_tour.js
@@ -4,7 +4,6 @@ import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add("bookstore_knowledge_tour", {
-    url: "/odoo",
     
     steps: () => [
         {

--- a/cake_shop/static/src/js/my_tour.js
+++ b/cake_shop/static/src/js/my_tour.js
@@ -4,7 +4,6 @@ import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add("cake_shop_knowledge_tour", {
-    url: "/odoo",
     
     steps: () => [
         {

--- a/certification_organism/static/src/js/my_tour.js
+++ b/certification_organism/static/src/js/my_tour.js
@@ -4,7 +4,6 @@ import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add("certification_organism_knowledge_tour", {
-    url: "/odoo",
     
     steps: () => [
         {

--- a/clothing_boutique/static/src/js/my_tour.js
+++ b/clothing_boutique/static/src/js/my_tour.js
@@ -4,7 +4,6 @@ import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add("clothing_boutique_knowledge_tour", {
-    url: "/odoo",
     
     steps: () => [
         {

--- a/coal_petroleum/static/src/js/my_tour.js
+++ b/coal_petroleum/static/src/js/my_tour.js
@@ -4,7 +4,6 @@ import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add("coal_petroleum_knowledge_tour", {
-    url: "/odoo",
     
     steps: () => [
         {

--- a/condominium/static/src/js/acquisition.js
+++ b/condominium/static/src/js/acquisition.js
@@ -1,7 +1,6 @@
 import { registry } from '@web/core/registry';
 
 registry.category("web_tour.tours").add("Condominium_Acquisition", {
-    url: "/odoo",
     steps: () => [
     {
         trigger: ".o_app[data-menu-xmlid='sale\\.sale_menu_root']",

--- a/corporate_gifts/static/src/js/my_tour.js
+++ b/corporate_gifts/static/src/js/my_tour.js
@@ -4,7 +4,6 @@ import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add("corporate_gifts_knowledge_tour", {
-    url: "/odoo",
     
     steps: () => [
         {

--- a/custom_furniture/static/src/js/my_tour.js
+++ b/custom_furniture/static/src/js/my_tour.js
@@ -4,7 +4,6 @@ import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add("custom_furniture_knowledge_tour", {
-    url: "/odoo",
     
     steps: () => [
         {

--- a/electronic_store/static/src/js/my_tour.js
+++ b/electronic_store/static/src/js/my_tour.js
@@ -4,7 +4,6 @@ import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add("electronic_store_knowledge_tour", {
-    url: "/odoo",
     
     steps: () => [
         {

--- a/fast_food/static/src/js/my_tour.js
+++ b/fast_food/static/src/js/my_tour.js
@@ -4,7 +4,6 @@ import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add("fast_food_knowledge_tour", {
-    url: "/odoo",
     
     steps: () => [
         {

--- a/fitness/static/src/js/my_tour.js
+++ b/fitness/static/src/js/my_tour.js
@@ -4,7 +4,6 @@ import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add("fitness_knowledge_tour", {
-    url: "/odoo",
     
     steps: () => [
         {

--- a/fmcg_store/static/src/js/my_tour.js
+++ b/fmcg_store/static/src/js/my_tour.js
@@ -4,7 +4,6 @@ import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add("fmcg_store_knowledge_tour", {
-    url: "/odoo",
     
     steps: () => [
         {

--- a/gardening/static/src/js/my_tour.js
+++ b/gardening/static/src/js/my_tour.js
@@ -4,7 +4,6 @@ import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add("gardening_knowledge_tour", {
-    url: "/odoo",
     
     steps: () => [
         {

--- a/hair_salon/static/src/js/my_tour.js
+++ b/hair_salon/static/src/js/my_tour.js
@@ -4,7 +4,6 @@ import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add("hair_salon_knowledge_tour", {
-    url: "/odoo",
     
     steps: () => [
         {

--- a/hardware_shop/static/src/js/my_tour.js
+++ b/hardware_shop/static/src/js/my_tour.js
@@ -4,7 +4,6 @@ import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add("hardware_shop_knowledge_tour", {
-    url: "/odoo",
     
     steps: () => [
         {

--- a/headhunter/static/src/js/my_tour.js
+++ b/headhunter/static/src/js/my_tour.js
@@ -4,7 +4,6 @@ import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add("headhunter_knowledge_tour", {
-    url: "/odoo",
     
     steps: () => [
         {

--- a/industry_lawyer/static/src/js/my_tour.js
+++ b/industry_lawyer/static/src/js/my_tour.js
@@ -4,7 +4,6 @@ import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add("industry_lawyer_knowledge_tour", {
-    url: "/odoo",
     
     steps: () => [
         {

--- a/industry_real_estate/static/src/js/my_tour.js
+++ b/industry_real_estate/static/src/js/my_tour.js
@@ -4,7 +4,6 @@ import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add("industry_real_estate_knowledge_tour", {
-    url: "/odoo",
     
     steps: () => [
         {

--- a/it_hardware/static/src/js/my_tour.js
+++ b/it_hardware/static/src/js/my_tour.js
@@ -4,7 +4,6 @@ import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add("it_hardware_knowledge_tour", {
-    url: "/odoo",
     
     steps: () => [
         {

--- a/odoo_partner/static/src/js/my_tour.js
+++ b/odoo_partner/static/src/js/my_tour.js
@@ -4,7 +4,6 @@ import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add("odoo_partner_knowledge_tour", {
-    url: "/odoo",
     
     steps: () => [
         {

--- a/outdoor_activities/static/src/js/my_tour.js
+++ b/outdoor_activities/static/src/js/my_tour.js
@@ -2,7 +2,6 @@ import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add("outdoor_activities_knowledge_tour", {
-    url: "/odoo",
     
     steps: () => [
         {

--- a/personal_trainer/static/src/js/my_tour.js
+++ b/personal_trainer/static/src/js/my_tour.js
@@ -2,7 +2,6 @@ import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add("personal_trainer_knowledge_tour", {
-    url: "/odoo",
     steps: () => [
         {
             trigger: '.o_app[data-menu-xmlid="knowledge.knowledge_menu_root"]',

--- a/pharmacy_retail/static/src/js/my_tour.js
+++ b/pharmacy_retail/static/src/js/my_tour.js
@@ -4,7 +4,6 @@ import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add("pharmacy_retail_knowledge_tour", {
-    url: "/odoo",
     
     steps: () => [
         {

--- a/photography/static/src/js/my_tour.js
+++ b/photography/static/src/js/my_tour.js
@@ -4,7 +4,6 @@ import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add("photography_knowledge_tour", {
-    url: "/odoo",
     
     steps: () => [
         {

--- a/solar_installation/static/src/js/my_tour.js
+++ b/solar_installation/static/src/js/my_tour.js
@@ -4,7 +4,6 @@ import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add("solar_installation_knowledge_tour", {
-    url: "/odoo",
     
     steps: () => [
         {

--- a/sport_events/static/src/js/my_tour.js
+++ b/sport_events/static/src/js/my_tour.js
@@ -2,7 +2,6 @@ import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add("sport_events_knowledge_tour", {
-    url: "/odoo",
     steps: () => [
         {
             trigger: '.o_app[data-menu-xmlid="knowledge.knowledge_menu_root"]',

--- a/sports_club/static/src/js/my_tour.js
+++ b/sports_club/static/src/js/my_tour.js
@@ -4,7 +4,6 @@ import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add("sports_club_knowledge_tour", {
-    url: "/odoo",
     
     steps: () => [
         {

--- a/surveyor/static/src/js/my_tour.js
+++ b/surveyor/static/src/js/my_tour.js
@@ -4,7 +4,6 @@ import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add("surveyor_knowledge_tour", {
-    url: "/odoo",
     
     steps: () => [
         {

--- a/toy_store/static/src/js/my_tour.js
+++ b/toy_store/static/src/js/my_tour.js
@@ -4,7 +4,6 @@ import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add("toy_store_knowledge_tour", {
-    url: "/odoo",
     
     steps: () => [
         {

--- a/wellness_practitioner/static/src/js/my_tour.js
+++ b/wellness_practitioner/static/src/js/my_tour.js
@@ -4,7 +4,6 @@ import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add("wellness_practitioner_knowledge_tour", {
-    url: "/odoo",
     
     steps: () => [
         {


### PR DESCRIPTION
Remove tour URLs from the industry modules to prevent migration failures when migrating from saas-19.2 to saas-19.3.
These URLs are removed starting from 19.0, ensuring they are no longer present in the data during the migration.

OPW - 6494072, 6498705, 6494120