### PR TITLE
[FIX] software_reseller: adding missing dependency:

### DIFF
--- a/software_reseller/__manifest__.py
+++ b/software_reseller/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Software Reseller',
-    'version': '1.1',
+    'version': '1.2',
     'category': 'Services',
     'depends': [
         'base_industry_data',
@@ -9,7 +9,7 @@
         'sale_planning',
         'sale_purchase',
         'sale_subscription',
-        'sale_timesheet',
+        'sale_timesheet_enterprise',
         'web_studio',
     ],
     'data': [

--- a/software_reseller/data/ir_ui_menu.xml
+++ b/software_reseller/data/ir_ui_menu.xml
@@ -2,7 +2,7 @@
 <odoo>
     <record id="licenses_menu" model="ir.ui.menu">
         <field name="name">Licenses</field>
-        <field name="web_icon">fa fa-code,#0079BF,#FFFFFF</field>
+        <field name="web_icon_data" type="base64" file="software_reseller/static/description/icon.png"/>
     </record>
     <record id="licenses_by_software_menu" model="ir.ui.menu">
         <field name="name">Licenses</field>


### PR DESCRIPTION
- Added`sale_timesheet_enterprise` to make sure `hr.employee.timesheet_manager_id` and related functionalities are available.
- Updated license app icon to match industry module icon

task-6048303