### PR TITLE
[IMP] recurring_rental_billing: only write SO invoiced date on invoice confirm

### DIFF
--- a/recurring_rental_billing/__manifest__.py
+++ b/recurring_rental_billing/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Recurring Rental Billing',
-    'version': '1.0',
+    'version': '1.1',
     'category': 'Construction',
     'author': 'Odoo S.A.',
     'depends': [
@@ -13,6 +13,7 @@
         'data/ir_model_fields.xml',
         'data/ir_actions_act_window.xml',
         'data/ir_actions_server.xml',
+        'data/base_automation.xml',
         'data/ir_ui_view.xml',
         'data/sale_order_template.xml',
         'data/product_category.xml',

--- a/recurring_rental_billing/data/base_automation.xml
+++ b/recurring_rental_billing/data/base_automation.xml
@@ -1,0 +1,11 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<odoo>
+    <record id="automation_write_rrb_invoice_date_on_confirm" model="base.automation">
+        <field name="name">Recurring Rental Billing: Write Invoice Billing Date</field>
+        <field name="model_id" ref="sale.model_account_move"/>
+        <field name="trigger">on_create_or_write</field>
+        <field name="filter_domain">[('x_is_rrb_invoice', '=', True), ('state', '=', 'posted'), ('x_provisional_date', '!=', False)]</field>
+        <field name="trigger_field_ids" eval="[(6, 0, [ref('account.field_account_move__state')])]"/>
+        <field name="action_server_ids" eval="[(6, 0, [ref('action_write_rrb_invoice_date_on_confirm')])]"/>
+    </record>
+</odoo>

--- a/recurring_rental_billing/data/ir_actions_server.xml
+++ b/recurring_rental_billing/data/ir_actions_server.xml
@@ -27,8 +27,9 @@ for partner in records:
             if quantity == 0: continue
             line.write({'quantity': quantity, 'sequence': (sequence := sequence + 1)})
             used_invoice_lines |= set([display_line, line])
-        so['x_last_invoice'] = next_date
-    invoice['invoice_line_ids'] = [Command.unlink(line.id) for line in invoice.invoice_line_ids if line not in used_invoice_lines]
+    invoice.write({'x_provisional_date': next_date, 'x_is_rrb_invoice': True,
+        'invoice_line_ids': [Command.unlink(line.id) for line in invoice.invoice_line_ids if line not in used_invoice_lines]
+    })
     if len(invoice.invoice_line_ids) == 0: invoice.unlink()
     else: invoices.append(invoice.id)
 if len(invoices) > 0:
@@ -44,5 +45,15 @@ else: action = {
         <field name="model_id" ref="base.model_res_partner"/>
         <field name="state">code</field>
         <field name="name">Consolidated Down Payment</field>
+    </record>
+
+    <record id="action_write_rrb_invoice_date_on_confirm" model="ir.actions.server">
+        <field name="name">Recurring Rental Billing: Write Invoice Billing Date on Confirm</field>
+        <field name="model_id" ref="sale.model_account_move"/>
+        <field name="state">code</field>
+        <field name="code">
+for record in records:
+    env['sale.order'].search([('invoice_ids', 'in', record.id)]).write({'x_last_invoice': record.x_provisional_date})
+</field>
     </record>
 </odoo>

--- a/recurring_rental_billing/data/ir_model_fields.xml
+++ b/recurring_rental_billing/data/ir_model_fields.xml
@@ -5,12 +5,13 @@
 for record in self:
     record['x_amount_to_invoice'] = 0
     for so in record.sale_order_ids:
-        record['x_amount_to_invoice'] += so.amount_to_invoice
-        if so.invoice_status == 'to invoice' and so.is_rental_order:
-            rental_amount = sum(so.order_line.filtered('is_product_rentable').mapped('amount_to_invoice'))
-            last_date = so.x_last_invoice or so.rental_start_date.date()
-            next_date = min(so.rental_return_date, datetime.datetime.today()).date()
-            record['x_amount_to_invoice'] += rental_amount * ((next_date - last_date).days / so.duration_days - 1)
+        if so.state != 'cancel':
+            record['x_amount_to_invoice'] += so.amount_to_invoice
+            if so.invoice_status == 'to invoice' and so.is_rental_order:
+                rental_amount = sum(so.order_line.filtered('is_product_rentable').mapped('amount_to_invoice'))
+                last_date = so.x_last_invoice or so.rental_start_date.date()
+                next_date = min(so.rental_return_date, datetime.datetime.today()).date()
+                record['x_amount_to_invoice'] += rental_amount * ((next_date - last_date).days / so.duration_days - 1)
 ]]></field>
     <field name="ttype">monetary</field>
     <field name="field_description">Total Uninvoiced</field>
@@ -26,6 +27,20 @@ for record in self:
     <field name="field_description">Last invoice</field>
     <field name="model_id" ref="sale.model_sale_order"/>
     <field name="name">x_last_invoice</field>
+    <field name="readonly" eval="True"/>
+  </record>
+  <record id="field_account_move_x_is_rrb_invoice" model="ir.model.fields">
+    <field name="model_id" ref="sale.model_account_move"/>
+    <field name="name">x_is_rrb_invoice</field>
+    <field name="field_description">Is Recurring Rental Billing Invoice</field>
+    <field name="ttype">boolean</field>
+    <field name="readonly" eval="True"/>
+  </record>
+  <record id="field_account_move_x_provisional_date" model="ir.model.fields">
+    <field name="model_id" ref="sale.model_account_move"/>
+    <field name="name">x_provisional_date</field>
+    <field name="field_description">Provisional Rental Billing Invoice Date</field>
+    <field name="ttype">date</field>
     <field name="readonly" eval="True"/>
   </record>
 </odoo>

--- a/recurring_rental_billing/data/ir_ui_view.xml
+++ b/recurring_rental_billing/data/ir_ui_view.xml
@@ -40,4 +40,24 @@
     <field name="type">form</field>
     <field name="active" eval="True"/>
   </record>
+  <record id="view_partner_tree_inherit" model="ir.ui.view">
+    <field name="name">res.partner.list.recurring_rental_billing</field>
+    <field name="model">res.partner</field>
+    <field name="inherit_id" ref="base.view_partner_tree"/>
+    <field name="mode">extension</field>
+    <field name="type">list</field>
+    <field name="priority">160</field>
+    <field name="active" eval="True"/>
+    <field name="arch" type="xml">
+      <list position="inside">
+        <header>
+          <button name="%(consolidated_down_payment_server_action)d"
+                  string="Consolidated Down Payment"
+                  type="action" 
+                  class="btn-primary"
+          />
+        </header>
+      </list>
+    </field>
+  </record>
 </odoo>


### PR DESCRIPTION
Before this commit, when creating a draft invoice using the custom button Consolidated Down Payment, all the invoice amount was immediately considered invoiced, even if the draft invoice was deleted, with no way of creating another one with said button.

In this commit, we add new fields and an automation on invoice confirmation to allow the creation of multiple draft invoices at the same time, deletions, etc., only considering the amount invoice when one of those invoices is confirmed by storing the invoice's date and delaying the SO's x_last_invoice date field write.

In addition, this commit changes the 'to invoice' amount computation by not considering the cancelled SOs anymore.

task-6512188