### PR TITLE
[REV] software_reseller: remove demo service_tracking

### DIFF
--- a/software_reseller/demo/product_product.xml
+++ b/software_reseller/demo/product_product.xml
@@ -1,15 +1,12 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
     <record id="product_product_1" model="product.product">
-        <field name="service_tracking">subcontract</field>
         <field name="seller_ids" eval="[(6, 0, [ref('product_supplierinfo_3')])]"/>
     </record>
     <record id="product_product_2" model="product.product">
-        <field name="service_tracking">subcontract</field>
         <field name="seller_ids" eval="[(6, 0, [ref('product_supplierinfo_1')])]"/>
     </record>
     <record id="product_product_3" model="product.product">
-        <field name="service_tracking">subcontract</field>
         <field name="seller_ids" eval="[(6, 0, [ref('product_supplierinfo_2')])]"/>
     </record>
 </odoo>


### PR DESCRIPTION
Revert a part of https://github.com/odoo/industry/pull/2091 that overrides the `service_tracking` field in demo due to upgrade script forgeting to check if it is being redefined from data.

task-6048303