### PR TITLE
[FIX] agri_equipment_rental: link stock quants to serial numbers

### DIFF
--- a/agri_equipment_rental/__manifest__.py
+++ b/agri_equipment_rental/__manifest__.py
@@ -1,5 +1,6 @@
 {
     'name': 'Agri-Equipment Rental',
+    'version': '1.1',
     'category': 'Supply Chain',
     'author': 'Odoo S.A.',
     'depends': [

--- a/agri_equipment_rental/demo/stock_picking.xml
+++ b/agri_equipment_rental/demo/stock_picking.xml
@@ -13,4 +13,11 @@
       ('state', '=', 'assigned'),
     ]).ids"/>
   </function>
+  <function name="write" model="stock.quant">
+    <value model="stock.quant" eval="obj().search([
+      ('lot_id', 'in', [ref('stock_lot_19'), ref('stock_lot_20'), ref('stock_lot_22')]),
+      ('location_id', '=', ref('stock.stock_location_stock')),
+    ]).ids"/>
+    <value eval="{'quantity': 0}"/>
+  </function>
 </odoo>

--- a/agri_equipment_rental/demo/stock_quant.xml
+++ b/agri_equipment_rental/demo/stock_quant.xml
@@ -2,46 +2,137 @@
 <odoo noupdate="1">
   <record id="stock_quant_1" model="stock.quant">
     <field name="product_id" ref="product_product_4"/>
-    <field name="inventory_quantity">4</field>
+    <field name="lot_id" ref="stock_lot_1"/>
+    <field name="inventory_quantity">1</field>
+  </record>
+  <record id="stock_quant_12" model="stock.quant">
+    <field name="product_id" ref="product_product_4"/>
+    <field name="lot_id" ref="stock_lot_2"/>
+    <field name="inventory_quantity">1</field>
   </record>
   <record id="stock_quant_2" model="stock.quant">
     <field name="product_id" ref="product_product_7"/>
-    <field name="inventory_quantity">3</field>
+    <field name="lot_id" ref="stock_lot_5"/>
+    <field name="inventory_quantity">1</field>
+  </record>
+  <record id="stock_quant_13" model="stock.quant">
+    <field name="product_id" ref="product_product_7"/>
+    <field name="lot_id" ref="stock_lot_6"/>
+    <field name="inventory_quantity">1</field>
+  </record>
+  <record id="stock_quant_14" model="stock.quant">
+    <field name="product_id" ref="product_product_7"/>
+    <field name="lot_id" ref="stock_lot_7"/>
+    <field name="inventory_quantity">1</field>
   </record>
   <record id="stock_quant_3" model="stock.quant">
     <field name="product_id" ref="product_product_9"/>
+    <field name="lot_id" ref="stock_lot_8"/>
     <field name="inventory_quantity">1</field>
   </record>
   <record id="stock_quant_4" model="stock.quant">
     <field name="product_id" ref="product_product_12"/>
-    <field name="inventory_quantity">4</field>
+    <field name="lot_id" ref="stock_lot_9"/>
+    <field name="inventory_quantity">1</field>
+  </record>
+  <record id="stock_quant_15" model="stock.quant">
+    <field name="product_id" ref="product_product_12"/>
+    <field name="lot_id" ref="stock_lot_10"/>
+    <field name="inventory_quantity">1</field>
+  </record>
+  <record id="stock_quant_16" model="stock.quant">
+    <field name="product_id" ref="product_product_12"/>
+    <field name="lot_id" ref="stock_lot_11"/>
+    <field name="inventory_quantity">1</field>
+  </record>
+  <record id="stock_quant_17" model="stock.quant">
+    <field name="product_id" ref="product_product_12"/>
+    <field name="lot_id" ref="stock_lot_12"/>
+    <field name="inventory_quantity">1</field>
   </record>
   <record id="stock_quant_5" model="stock.quant">
     <field name="product_id" ref="product_product_5"/>
-    <field name="inventory_quantity">2</field>
+    <field name="lot_id" ref="stock_lot_13"/>
+    <field name="inventory_quantity">1</field>
+  </record>
+  <record id="stock_quant_18" model="stock.quant">
+    <field name="product_id" ref="product_product_5"/>
+    <field name="lot_id" ref="stock_lot_14"/>
+    <field name="inventory_quantity">1</field>
   </record>
   <record id="stock_quant_6" model="stock.quant">
     <field name="product_id" ref="product_product_10"/>
-    <field name="inventory_quantity">4</field>
+    <field name="lot_id" ref="stock_lot_15"/>
+    <field name="inventory_quantity">1</field>
+  </record>
+  <record id="stock_quant_19" model="stock.quant">
+    <field name="product_id" ref="product_product_10"/>
+    <field name="lot_id" ref="stock_lot_16"/>
+    <field name="inventory_quantity">1</field>
+  </record>
+  <record id="stock_quant_20" model="stock.quant">
+    <field name="product_id" ref="product_product_10"/>
+    <field name="lot_id" ref="stock_lot_17"/>
+    <field name="inventory_quantity">1</field>
+  </record>
+  <record id="stock_quant_21" model="stock.quant">
+    <field name="product_id" ref="product_product_10"/>
+    <field name="lot_id" ref="stock_lot_18"/>
+    <field name="inventory_quantity">1</field>
   </record>
   <record id="stock_quant_7" model="stock.quant">
     <field name="product_id" ref="product_product_6"/>
+    <field name="lot_id" ref="stock_lot_21"/>
     <field name="inventory_quantity">1</field>
   </record>
   <record id="stock_quant_8" model="stock.quant">
     <field name="product_id" ref="product_product_14"/>
-    <field name="inventory_quantity">4</field>
+    <field name="lot_id" ref="stock_lot_23"/>
+    <field name="inventory_quantity">1</field>
+  </record>
+  <record id="stock_quant_22" model="stock.quant">
+    <field name="product_id" ref="product_product_14"/>
+    <field name="lot_id" ref="stock_lot_24"/>
+    <field name="inventory_quantity">1</field>
+  </record>
+  <record id="stock_quant_23" model="stock.quant">
+    <field name="product_id" ref="product_product_14"/>
+    <field name="lot_id" ref="stock_lot_25"/>
+    <field name="inventory_quantity">1</field>
+  </record>
+  <record id="stock_quant_24" model="stock.quant">
+    <field name="product_id" ref="product_product_14"/>
+    <field name="lot_id" ref="stock_lot_26"/>
+    <field name="inventory_quantity">1</field>
   </record>
   <record id="stock_quant_9" model="stock.quant">
     <field name="product_id" ref="product_product_8"/>
-    <field name="inventory_quantity">2</field>
+    <field name="lot_id" ref="stock_lot_27"/>
+    <field name="inventory_quantity">1</field>
+  </record>
+  <record id="stock_quant_25" model="stock.quant">
+    <field name="product_id" ref="product_product_8"/>
+    <field name="lot_id" ref="stock_lot_28"/>
+    <field name="inventory_quantity">1</field>
   </record>
   <record id="stock_quant_10" model="stock.quant">
     <field name="product_id" ref="product_product_11"/>
-    <field name="inventory_quantity">3</field>
+    <field name="lot_id" ref="stock_lot_29"/>
+    <field name="inventory_quantity">1</field>
+  </record>
+  <record id="stock_quant_26" model="stock.quant">
+    <field name="product_id" ref="product_product_11"/>
+    <field name="lot_id" ref="stock_lot_30"/>
+    <field name="inventory_quantity">1</field>
+  </record>
+  <record id="stock_quant_27" model="stock.quant">
+    <field name="product_id" ref="product_product_11"/>
+    <field name="lot_id" ref="stock_lot_31"/>
+    <field name="inventory_quantity">1</field>
   </record>
   <record id="stock_quant_11" model="stock.quant">
     <field name="product_id" ref="product_product_13"/>
+    <field name="lot_id" ref="stock_lot_32"/>
     <field name="inventory_quantity">1</field>
   </record>
   <function name="action_apply_inventory" model="stock.quant" eval="[[
@@ -55,6 +146,22 @@
         ref('stock_quant_8'),
         ref('stock_quant_9'),
         ref('stock_quant_10'),
-        ref('stock_quant_11')
+        ref('stock_quant_11'),
+        ref('stock_quant_12'),
+        ref('stock_quant_13'),
+        ref('stock_quant_14'),
+        ref('stock_quant_15'),
+        ref('stock_quant_16'),
+        ref('stock_quant_17'),
+        ref('stock_quant_18'),
+        ref('stock_quant_19'),
+        ref('stock_quant_20'),
+        ref('stock_quant_21'),
+        ref('stock_quant_22'),
+        ref('stock_quant_23'),
+        ref('stock_quant_24'),
+        ref('stock_quant_25'),
+        ref('stock_quant_26'),
+        ref('stock_quant_27'),
     ]]"/>
 </odoo>


### PR DESCRIPTION
Issue:
- Rental products use Unique Serial Number tracking, but the demo data creates
bulk quants without linking them to specific Serial Numbers.
- The stock is not correctly distributed as one unit per Serial Number.

Solution:
- Replaced bulk quants with one quant per Serial Number (quantity=1) and linked
each to the correct lot_id.

TaskId-6515450