### PR TITLE
[UPG] *: adapt product.pricelist.item definition

### DIFF
--- a/art_craft/__manifest__.py
+++ b/art_craft/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Arts & Crafts Store',
-    'version': '1.5',
+    'version': '1.6',
     'category': 'Retail',
     'depends': [
         'appointment',

--- a/art_craft/data/product_pricelist_item.xml
+++ b/art_craft/data/product_pricelist_item.xml
@@ -1,54 +1,47 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo noupdate="1">
     <record id="product_pricelist_item_1" model="product.pricelist.item">
-        <field name="percent_price">5.0</field>
+        <field name="price_discount">5.0</field>
         <field name="pricelist_id" ref="product_pricelist_2"/>
-        <field name="compute_price">percentage</field>
+        <field name="compute_price">discount</field>
     </record>
     <record id="product_pricelist_item_10" model="product.pricelist.item">
         <field name="fixed_price">50.0</field>
         <field name="product_id" ref="product_product_17"/>
         <field name="product_tmpl_id" ref="product_template_13"/>
         <field name="pricelist_id" ref="product_pricelist_3"/>
-        <field name="applied_on">0_product_variant</field>
     </record>
     <record id="product_pricelist_item_4" model="product.pricelist.item">
         <field name="fixed_price">80.0</field>
         <field name="product_id" ref="product_product_27"/>
         <field name="product_tmpl_id" ref="product_template_19"/>
         <field name="pricelist_id" ref="product_pricelist_3"/>
-        <field name="applied_on">0_product_variant</field>
     </record>
     <record id="product_pricelist_item_5" model="product.pricelist.item">
         <field name="fixed_price">150.0</field>
         <field name="product_id" ref="product_product_26"/>
         <field name="product_tmpl_id" ref="product_template_19"/>
         <field name="pricelist_id" ref="product_pricelist_3"/>
-        <field name="applied_on">0_product_variant</field>
     </record>
     <record id="product_pricelist_item_6" model="product.pricelist.item">
         <field name="fixed_price">200.0</field>
         <field name="product_tmpl_id" ref="product_template_18"/>
         <field name="pricelist_id" ref="product_pricelist_3"/>
-        <field name="applied_on">1_product</field>
     </record>
     <record id="product_pricelist_item_7" model="product.pricelist.item">
         <field name="fixed_price">300.0</field>
         <field name="product_tmpl_id" ref="product_template_20"/>
         <field name="pricelist_id" ref="product_pricelist_3"/>
-        <field name="applied_on">1_product</field>
     </record>
     <record id="product_pricelist_item_8" model="product.pricelist.item">
         <field name="fixed_price">250.0</field>
         <field name="product_tmpl_id" ref="product_template_21"/>
         <field name="pricelist_id" ref="product_pricelist_3"/>
-        <field name="applied_on">1_product</field>
     </record>
     <record id="product_pricelist_item_9" model="product.pricelist.item">
         <field name="fixed_price">50.0</field>
         <field name="product_id" ref="product_product_16"/>
         <field name="product_tmpl_id" ref="product_template_13"/>
         <field name="pricelist_id" ref="product_pricelist_3"/>
-        <field name="applied_on">0_product_variant</field>
     </record>
 </odoo>

--- a/bar_industry/__manifest__.py
+++ b/bar_industry/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Bar & Pub',
-    'version': '1.3',
+    'version': '1.4',
     'category': 'Hospitality',
     'depends': [
         'base_industry_data',

--- a/bar_industry/data/product_pricelist.xml
+++ b/bar_industry/data/product_pricelist.xml
@@ -3,12 +3,10 @@
     <record id="product_pricelist_2" model="product.pricelist">
         <field name="name">Happy Hour</field>
         <field name="item_ids" eval="[(0, 0, {
-            'display_applied_on': '2_product_category',
-            'applied_on' : '2_product_category',
             'categ_id': ref('product_category_1'),
-            'compute_price': 'percentage',
+            'compute_price': 'discount',
             'min_quantity': 2,
-            'percent_price': 50,
+            'price_discount': 50,
         })]"/>
     </record>
 </odoo>

--- a/bar_industry/demo/product_pricelist_item.xml
+++ b/bar_industry/demo/product_pricelist_item.xml
@@ -3,10 +3,8 @@
   <record id="product_pricelist_item_2" model="product.pricelist.item">
     <field name="pricelist_id" ref="product_pricelist_2"/>
     <field name="min_quantity">2.0</field>
-    <field name="applied_on">2_product_category</field>
-    <field name="display_applied_on">2_product_category</field>
     <field name="categ_id" ref="pos_restaurant.product_category_drinks"/>
-    <field name="compute_price">percentage</field>
-    <field name="percent_price">50.0</field>
+    <field name="compute_price">discount</field>
+    <field name="price_discount">50.0</field>
   </record>
 </odoo>

--- a/beverage_distributor/__manifest__.py
+++ b/beverage_distributor/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Beverage Distributor',
-    'version': '2.6',
+    'version': '2.7',
     'category': 'Supply Chain',
     'depends': [
         'base_automation',

--- a/beverage_distributor/data/product_pricelist.xml
+++ b/beverage_distributor/data/product_pricelist.xml
@@ -8,10 +8,8 @@
         <field name="sequence">11</field>
         <field name="name">B2B</field>
         <field name="item_ids" eval="[(0, 0, {
-            'display_applied_on': '2_product_category',
-            'applied_on': '2_product_category',
             'categ_id': ref('product_category_11'),
-            'compute_price': 'formula',
+            'compute_price': 'discount',
             'price_discount' : '10',
             'price_round' : '1.0',
             'price_surcharge' : '-0.01',

--- a/booking_engine/data/product_pricelist_item.xml
+++ b/booking_engine/data/product_pricelist_item.xml
@@ -5,11 +5,9 @@
     <field name="date_start" eval="datetime(datetime.today().year, 6, 15)"/>
     <field name="date_end" eval="datetime(datetime.today().year, 8, 21)"/>
     <field name="min_quantity">1.0</field>
-    <field name="applied_on">2_product_category</field>
-    <field name="display_applied_on">2_product_category</field>
     <field name="categ_id" ref="product_category_6"/>
-    <field name="compute_price">percentage</field>
-    <field name="percent_price">-30.0</field>
+    <field name="compute_price">markup</field>
+    <field name="price_markup">30.0</field>
     <field name="x_name">Summer High</field>
   </record>
   <record id="product_pricelist_item_2" model="product.pricelist.item">
@@ -17,11 +15,9 @@
     <field name="date_start" eval="datetime(datetime.today().year, 11, 1)"/>
     <field name="date_end" eval="datetime(datetime.today().year + 1, 3, 3)"/>
     <field name="min_quantity">1.0</field>
-    <field name="applied_on">2_product_category</field>
-    <field name="display_applied_on">2_product_category</field>
     <field name="categ_id" ref="product_category_6"/>
-    <field name="compute_price">percentage</field>
-    <field name="percent_price">15.0</field>
+    <field name="compute_price">discount</field>
+    <field name="price_discount">15.0</field>
     <field name="x_name">Winter Low</field>
   </record>
   <record id="product_pricelist_item_3" model="product.pricelist.item">
@@ -29,17 +25,13 @@
     <field name="date_start" eval="datetime(datetime.today().year, 12, 20)"/>
     <field name="date_end" eval="datetime(datetime.today().year + 1, 1, 2)"/>
     <field name="min_quantity">1.0</field>
-    <field name="applied_on">2_product_category</field>
-    <field name="display_applied_on">2_product_category</field>
     <field name="categ_id" ref="product_category_6"/>
-    <field name="compute_price">percentage</field>
-    <field name="percent_price">-50.0</field>
+    <field name="compute_price">markup</field>
+    <field name="price_markup">50.0</field>
     <field name="x_name">Christmas</field>
   </record>
   <record id="pricelist_item_block_future_booking" model="product.pricelist.item">
     <field name="pricelist_id" ref="product_pricelist_1" />
-    <field name="applied_on">2_product_category</field>
-    <field name="display_applied_on">2_product_category</field>
     <field name="categ_id" ref="product_category_6" />
     <field name="compute_price">fixed</field>
     <field name="fixed_price">0.0</field>

--- a/bookstore/__manifest__.py
+++ b/bookstore/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Bookstore',
-    'version': '1.2',
+    'version': '1.3',
     'category': 'Retail',
     'depends': [
         'account_followup',

--- a/bookstore/data/product_pricelist.xml
+++ b/bookstore/data/product_pricelist.xml
@@ -7,10 +7,8 @@
     <record id="product_pricelist_2" model="product.pricelist">
         <field name="name">Institutions</field>
         <field name="item_ids" eval="[(0, 0, {
-            'display_applied_on': '1_product',
-            'applied_on' : '3_global',
-            'compute_price': 'percentage',
-            'percent_price': 5,
+            'compute_price': 'discount',
+            'price_discount': 5,
         })]"/>
     </record>
 </odoo>

--- a/candy_shop/__manifest__.py
+++ b/candy_shop/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Candy Shop',
-    'version': '1.3',
+    'version': '1.4',
     'category': 'Retail',
     'author': 'Odoo S.A.',
     'depends': [

--- a/candy_shop/data/product_pricelist_item.xml
+++ b/candy_shop/data/product_pricelist_item.xml
@@ -2,15 +2,14 @@
 <odoo noupdate="1">
   <record id="product_pricelist_item_2" model="product.pricelist.item">
     <field name="pricelist_id" ref="product_pricelist_3"/>
-    <field name="compute_price">percentage</field>
-    <field name="percent_price">10.0</field>
+    <field name="compute_price">discount</field>
+    <field name="price_discount">10.0</field>
   </record>
   <record id="product_pricelist_item_1" model="product.pricelist.item">
     <field name="pricelist_id" ref="product_pricelist_2"/>
-    <field name="compute_price">formula</field>
-    <field name="price_discount">-12.0</field>
+    <field name="compute_price">markup</field>
+    <field name="price_markup">12.0</field>
     <field name="price_round">1.0</field>
     <field name="price_surcharge">-0.1</field>
-    <field name="price_markup">12.0</field>
   </record>
 </odoo>

--- a/construction_developer/__manifest__.py
+++ b/construction_developer/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Construction Developer',
-    'version': '2.4',
+    'version': '2.5',
     'category': 'Construction',
     'depends': [
         'base_industry_data',

--- a/construction_developer/data/views_standard.xml
+++ b/construction_developer/data/views_standard.xml
@@ -369,7 +369,7 @@
                 <filter name="not_x_is_remark" string="Tasks" domain="[('x_is_remark', '=', False)]"/>
                 <separator/>
             </xpath>
-            <xpath expr="//group/filter[@name='customer']" position="after">
+            <xpath expr="//group/filter[@name='stage']" position="after">
                 <filter string="Owner" name="owner" context="{'group_by': 'x_partner_id'}"/>
             </xpath>
         </field>

--- a/construction_developer/demo/product_pricelist.xml
+++ b/construction_developer/demo/product_pricelist.xml
@@ -7,32 +7,28 @@
     <record model="product.pricelist.item" id="product_pricelist_item_1">
         <field name="pricelist_id" ref="pricelist_default"/>
         <field name="categ_id" ref="construction.product_category_31"/>
-        <field name="applied_on">2_product_category</field>
-        <field name="compute_price">formula</field>
+        <field name="compute_price">markup</field>
         <field name="base">standard_price</field>
         <field name="price_markup">80</field>
     </record>
     <record model="product.pricelist.item" id="product_pricelist_item_2">
         <field name="pricelist_id" ref="pricelist_default"/>
         <field name="categ_id" ref="construction.product_category_29"/>
-        <field name="applied_on">2_product_category</field>
-        <field name="compute_price">formula</field>
+        <field name="compute_price">markup</field>
         <field name="base">standard_price</field>
         <field name="price_markup">40</field>
     </record>
     <record model="product.pricelist.item" id="product_pricelist_item_3">
         <field name="pricelist_id" ref="pricelist_default"/>
         <field name="categ_id" ref="construction.product_category_30"/>
-        <field name="applied_on">2_product_category</field>
-        <field name="compute_price">formula</field>
+        <field name="compute_price">markup</field>
         <field name="base">standard_price</field>
         <field name="price_markup">60</field>
     </record>
     <record model="product.pricelist.item" id="product_pricelist_item_4">
         <field name="pricelist_id" ref="pricelist_default"/>
         <field name="categ_id" ref="construction.product_category_5"/>
-        <field name="applied_on">2_product_category</field>
-        <field name="compute_price">formula</field>
+        <field name="compute_price">markup</field>
         <field name="base">standard_price</field>
         <field name="price_markup">50</field>
     </record>

--- a/cosmetics_store/__manifest__.py
+++ b/cosmetics_store/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Cosmetics Store',
-    'version': '1.4',
+    'version': '1.5',
     'category': 'Retail',
     'author': 'Odoo S.A.',
     'depends': [

--- a/cosmetics_store/data/product_pricelist_item.xml
+++ b/cosmetics_store/data/product_pricelist_item.xml
@@ -3,7 +3,7 @@
   <record id="product_pricelist_item_1" model="product.pricelist.item">
     <field name="pricelist_id" ref="product_pricelist_2"/>
     <field name="min_quantity">1.0</field>
-    <field name="compute_price">percentage</field>
-    <field name="percent_price">20.0</field>
+    <field name="compute_price">discount</field>
+    <field name="price_discount">20.0</field>
   </record>
 </odoo>

--- a/coworking/__manifest__.py
+++ b/coworking/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Coworking',
-    'version': '1.2',
+    'version': '1.3',
     'category': 'Services',
     'author': 'Odoo S.A.',
     'depends': [

--- a/coworking/data/product_pricelist_item.xml
+++ b/coworking/data/product_pricelist_item.xml
@@ -3,15 +3,13 @@
   <record id="product_pricelist_item_4" model="product.pricelist.item">
     <field name="pricelist_id" ref="product_pricelist_2"/>
     <field name="product_id" ref="product_product_3"/>
-    <field name="applied_on">1_product</field>
-    <field name="compute_price">percentage</field>
-    <field name="percent_price">100.0</field>
+    <field name="compute_price">discount</field>
+    <field name="price_discount">100.0</field>
   </record>
   <record id="product_pricelist_item_3" model="product.pricelist.item">
     <field name="pricelist_id" ref="product_pricelist_2"/>
     <field name="plan_id" ref="sale_subscription.subscription_plan_month"/>
     <field name="product_id" ref="product_product_13"/>
-    <field name="applied_on">1_product</field>
     <field name="fixed_price">500.0</field>
   </record>
 
@@ -22,7 +20,6 @@
     <field name="pricelist_id" ref="product_pricelist_1"/>
     <field name="plan_id" ref="sale_subscription.subscription_plan_month"/>
     <field name="product_id" ref="product_product_5"/>
-    <field name="applied_on">1_product</field>
     <field name="compute_price">fixed</field>
     <field name="fixed_price" eval="220.0"/>
   </record>
@@ -30,7 +27,6 @@
     <field name="pricelist_id" ref="product_pricelist_1"/>
     <field name="plan_id" ref="sale_subscription.subscription_plan_year"/>
     <field name="product_id" ref="product_product_5"/>
-    <field name="applied_on">1_product</field>
     <field name="compute_price">fixed</field>
     <field name="fixed_price" eval="2200.0"/>
   </record>
@@ -38,7 +34,6 @@
     <field name="pricelist_id" ref="product_pricelist_1"/>
     <field name="plan_id" ref="sale_subscription.subscription_plan_month"/>
     <field name="product_id" ref="product_product_6"/>
-    <field name="applied_on">1_product</field>
     <field name="compute_price">fixed</field>
     <field name="fixed_price" eval="390.0"/>
   </record>
@@ -46,7 +41,6 @@
     <field name="pricelist_id" ref="product_pricelist_1"/>
     <field name="plan_id" ref="sale_subscription.subscription_plan_year"/>
     <field name="product_id" ref="product_product_6"/>
-    <field name="applied_on">1_product</field>
     <field name="compute_price">fixed</field>
     <field name="fixed_price" eval="3900.0"/>
   </record>
@@ -54,7 +48,6 @@
     <field name="pricelist_id" ref="product_pricelist_2"/>
     <field name="plan_id" ref="sale_subscription.subscription_plan_month"/>
     <field name="product_id" ref="product_product_5"/>
-    <field name="applied_on">1_product</field>
     <field name="compute_price">fixed</field>
     <field name="fixed_price" eval="220.0"/>
   </record>
@@ -62,7 +55,6 @@
     <field name="pricelist_id" ref="product_pricelist_2"/>
     <field name="plan_id" ref="sale_subscription.subscription_plan_year"/>
     <field name="product_id" ref="product_product_5"/>
-    <field name="applied_on">1_product</field>
     <field name="compute_price">fixed</field>
     <field name="fixed_price" eval="2200.0"/>
   </record>
@@ -70,7 +62,6 @@
     <field name="pricelist_id" ref="product_pricelist_2"/>
     <field name="plan_id" ref="sale_subscription.subscription_plan_month"/>
     <field name="product_id" ref="product_product_6"/>
-    <field name="applied_on">1_product</field>
     <field name="compute_price">fixed</field>
     <field name="fixed_price" eval="390.0"/>
   </record>
@@ -78,7 +69,6 @@
     <field name="pricelist_id" ref="product_pricelist_2"/>
     <field name="plan_id" ref="sale_subscription.subscription_plan_year"/>
     <field name="product_id" ref="product_product_6"/>
-    <field name="applied_on">1_product</field>
     <field name="compute_price">fixed</field>
     <field name="fixed_price" eval="3900.0"/>
   </record>

--- a/diy_workshops/__manifest__.py
+++ b/diy_workshops/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'DIY Workshops',
-    'version': '1.2',
+    'version': '1.3',
     'category': 'Services',
     'author': 'Odoo S.A.',
     'depends': [

--- a/diy_workshops/data/product_pricelist_item.xml
+++ b/diy_workshops/data/product_pricelist_item.xml
@@ -4,15 +4,12 @@
     <field name="pricelist_id" eval="False"/>
     <field name="plan_id" ref="sale_subscription.subscription_plan_month"/>
     <field name="product_id" ref="product_product_12"/>
-    <field name="applied_on">1_product</field>
     <field name="fixed_price">100.0</field>
   </record>
   <record id="product_pricelist_item_1" model="product.pricelist.item">
     <field name="pricelist_id" ref="product_pricelist_2"/>
-    <field name="applied_on">2_product_category</field>
-    <field name="display_applied_on">2_product_category</field>
     <field name="categ_id" ref="product_category_7"/>
-    <field name="compute_price">percentage</field>
-    <field name="percent_price">100.0</field>
+    <field name="compute_price">discount</field>
+    <field name="price_discount">100.0</field>
   </record>
 </odoo>

--- a/fitness/__manifest__.py
+++ b/fitness/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Fitness Center',
-    'version': '1.5',
+    'version': '1.6',
     'category': 'Health and Fitness',
     'depends': [
         'base_industry_data',

--- a/fitness/data/product_pricelist.xml
+++ b/fitness/data/product_pricelist.xml
@@ -6,9 +6,8 @@
     <record id="product_pricelist_2" model="product.pricelist">
         <field name="name">Free courses</field>
         <field name="item_ids" eval="[(0, 0, {
-            'applied_on': '2_product_category',
             'categ_id': ref('product_category_9'),
-            'compute_price': 'formula',
+            'compute_price': 'discount',
             'base': 'list_price',
             'price_discount': 100,
         })]"/> 

--- a/florist/__manifest__.py
+++ b/florist/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Florist',
-    'version': '1.3',
+    'version': '1.4',
     'category': 'Retail',
     'author': 'Odoo S.A.',
     'depends': [

--- a/florist/data/product_pricelist_item.xml
+++ b/florist/data/product_pricelist_item.xml
@@ -2,10 +2,8 @@
 <odoo noupdate="1">
     <record id="product_pricelist_item_3" model="product.pricelist.item">
         <field name="pricelist_id" ref="product_pricelist_2"/>
-        <field name="applied_on">2_product_category</field>
-        <field name="display_applied_on">2_product_category</field>
         <field name="categ_id" ref="product_category_6"/>
-        <field name="compute_price">percentage</field>
-        <field name="percent_price">10.0</field>
+        <field name="compute_price">discount</field>
+        <field name="price_discount">10.0</field>
     </record>
 </odoo>

--- a/furniture_store/__manifest__.py
+++ b/furniture_store/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Furniture Store',
-    'version': '1.2',
+    'version': '1.3',
     'category': 'Retail',
     'depends': [
         'base_industry_data',

--- a/furniture_store/data/product_pricelist_item.xml
+++ b/furniture_store/data/product_pricelist_item.xml
@@ -2,8 +2,7 @@
 <odoo noupdate="1">
   <record id="product_pricelist_item_1" model="product.pricelist.item">
     <field name="product_tmpl_id" ref="product_template_8"/>
-    <field name="applied_on">1_product</field>
-    <field name="compute_price">percentage</field>
-    <field name="percent_price">15.0</field>
+    <field name="compute_price">discount</field>
+    <field name="price_discount">15.0</field>
   </record>
 </odoo>

--- a/gallery/__manifest__.py
+++ b/gallery/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Gallery',
-    'version': '1.5',
+    'version': '1.6',
     'category': 'Retail',
     'depends': [
         'base_industry_data',

--- a/gallery/data/product_pricelist_item.xml
+++ b/gallery/data/product_pricelist_item.xml
@@ -2,7 +2,7 @@
 <odoo noupdate="1">
   <record id="product_pricelist_item_1" model="product.pricelist.item">
     <field name="pricelist_id" ref="product_pricelist_2"/>
-    <field name="compute_price">percentage</field>
-    <field name="percent_price">10.0</field>
+    <field name="compute_price">discount</field>
+    <field name="price_discount">10.0</field>
   </record>
 </odoo>

--- a/hardware_shop/__manifest__.py
+++ b/hardware_shop/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Hardware Store',
-    'version': '1.1',
+    'version': '1.2',
     'category': 'Retail',
     'depends': [
         'barcodes',

--- a/hardware_shop/data/product_pricelist.xml
+++ b/hardware_shop/data/product_pricelist.xml
@@ -7,9 +7,8 @@
     <record id="product_pricelist_2" model="product.pricelist">
         <field name="name">Pricelist For Local Customer</field>
         <field name="item_ids" eval="[(0, 0, {
-            'applied_on': '3_global',
-            'compute_price': 'percentage',
-            'percent_price': 5,
+            'compute_price': 'discount',
+            'price_discount': 5,
         })]"/>
     </record>
 </odoo>

--- a/hardware_shop/data/product_pricelist_item.xml
+++ b/hardware_shop/data/product_pricelist_item.xml
@@ -2,7 +2,7 @@
 <odoo noupdate="1">
     <record id="product_pricelist_item_1" model="product.pricelist.item">
         <field name="pricelist_id" ref="product_pricelist_1"/>
-        <field name="compute_price">percentage</field>
-        <field name="percent_price">5.0</field>
+        <field name="compute_price">discount</field>
+        <field name="price_discount">5.0</field>
     </record>
 </odoo>

--- a/industry_restaurant/__manifest__.py
+++ b/industry_restaurant/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Fine Dining Restaurant',
-    'version': '1.2',
+    'version': '1.3',
     'category': 'Hospitality',
     'depends': [
         'account_followup',

--- a/industry_restaurant/data/product_pricelist.xml
+++ b/industry_restaurant/data/product_pricelist.xml
@@ -7,7 +7,7 @@
     <field name="name">Happy Hours</field>
     <field name="item_ids" eval="[(0, 0, {
             'categ_id': ref('product_category_6'),
-            'compute_price': 'formula',
+            'compute_price': 'discount',
             'base': 'list_price',
             'price_discount': 50,
     })]"/>

--- a/library/__manifest__.py
+++ b/library/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Library',
-    'version': '1.1',
+    'version': '1.2',
     'category': 'Services',
     'author': 'Odoo S.A.',
     'depends': [

--- a/library/data/product_pricelist_item.xml
+++ b/library/data/product_pricelist_item.xml
@@ -4,15 +4,12 @@
     <field name="pricelist_id" eval="False"/>
     <field name="plan_id" ref="sale_subscription.subscription_plan_year"/>
     <field name="product_id" ref="product_product_13"/>
-    <field name="applied_on">1_product</field>
     <field name="fixed_price">4.0</field>
   </record>
   <record id="product_pricelist_item_3" model="product.pricelist.item">
     <field name="pricelist_id" ref="product_pricelist_2"/>
-    <field name="applied_on">2_product_category</field>
-    <field name="display_applied_on">2_product_category</field>
     <field name="categ_id" ref="product.product_category_services"/>
-    <field name="compute_price">formula</field>
+    <field name="compute_price">discount</field>
   </record>
   <record id="product_pricelist_item_4" model="product.pricelist.item">
     <field name="pricelist_id" ref="product_pricelist_2"/>

--- a/members_club/__manifest__.py
+++ b/members_club/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Members Club',
-    'version': '1.4',
+    'version': '1.5',
     'category': 'Hospitality',
     'author': 'Odoo S.A.',
     'depends': [

--- a/members_club/data/product_pricelist_item.xml
+++ b/members_club/data/product_pricelist_item.xml
@@ -2,10 +2,8 @@
 <odoo noupdate="1">
   <record id="product_pricelist_item_1" model="product.pricelist.item">
     <field name="pricelist_id" ref="product_pricelist_2"/>
-    <field name="applied_on">2_product_category</field>
-    <field name="display_applied_on">2_product_category</field>
     <field name="categ_id" ref="event_product.product_category_events"/>
-    <field name="compute_price">percentage</field>
-    <field name="percent_price">100.0</field>
+    <field name="compute_price">discount</field>
+    <field name="price_discount">100.0</field>
   </record>
 </odoo>

--- a/micro_brewery/__manifest__.py
+++ b/micro_brewery/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Microbrewery',
-    'version': '2.8',
+    'version': '2.9',
     'category': 'Supply Chain',
     'depends': [
         'account',

--- a/micro_brewery/data/product_pricelist_item.xml
+++ b/micro_brewery/data/product_pricelist_item.xml
@@ -2,7 +2,7 @@
 <odoo noupdate="1">
     <record id="product_pricelist_item_1" model="product.pricelist.item">
         <field name="pricelist_id" ref="product_pricelist_2"/>
-        <field name="compute_price">percentage</field>
-        <field name="percent_price">40.0</field>
+        <field name="compute_price">discount</field>
+        <field name="price_discount">40.0</field>
     </record>
 </odoo>

--- a/sports_club/__manifest__.py
+++ b/sports_club/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Sports Facilities',
-    'version': '1.5',
+    'version': '1.6',
     'category': 'Health and Fitness',
     'depends': [
         'appointment_crm',

--- a/sports_club/demo/product_pricelist_item.xml
+++ b/sports_club/demo/product_pricelist_item.xml
@@ -2,16 +2,12 @@
 <odoo noupdate="1">
     <record id="product_pricelist_item_2" model="product.pricelist.item">
         <field name="pricelist_id" ref="product_pricelist_1" />
-        <field name="applied_on">2_product_category</field>
-        <field name="display_applied_on">2_product_category</field>
         <field name="categ_id" ref="product.product_category_services" />
     </record>
     <record id="product_pricelist_item_1" model="product.pricelist.item">
         <field name="pricelist_id" ref="product_pricelist_1" />
-        <field name="applied_on">2_product_category</field>
-        <field name="display_applied_on">2_product_category</field>
         <field name="categ_id" ref="point_of_sale.product_category_food" />
-        <field name="compute_price">percentage</field>
-        <field name="percent_price">20.0</field>
+        <field name="compute_price">discount</field>
+        <field name="price_discount">20.0</field>
     </record>
 </odoo>

--- a/student_organization/__manifest__.py
+++ b/student_organization/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Student Organization',
-    'version': '1.3',
+    'version': '1.4',
     'category': 'Hospitality',
     'author': 'Odoo S.A.',
     'depends': [

--- a/student_organization/data/product_pricelist_item.xml
+++ b/student_organization/data/product_pricelist_item.xml
@@ -2,14 +2,12 @@
 <odoo noupdate="1">
   <record id="product_pricelist_item_2" model="product.pricelist.item">
     <field name="pricelist_id" ref="product_pricelist_3"/>
-    <field name="display_applied_on">2_product_category</field>
-    <field name="compute_price">percentage</field>
-    <field name="percent_price">20.0</field>
+    <field name="compute_price">discount</field>
+    <field name="price_discount">20.0</field>
   </record>
   <record id="product_pricelist_item_1" model="product.pricelist.item">
     <field name="pricelist_id" ref="product_pricelist_2"/>
-    <field name="display_applied_on">2_product_category</field>
-    <field name="compute_price">percentage</field>
-    <field name="percent_price">50.0</field>
+    <field name="compute_price">discount</field>
+    <field name="price_discount">50.0</field>
   </record>
 </odoo>

--- a/theater/__manifest__.py
+++ b/theater/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Theater',
-    'version': '1.4',
+    'version': '1.5',
     'category': 'Hospitality',
     'author': 'Odoo S.A.',
     'depends': [

--- a/theater/data/product_pricelist_item.xml
+++ b/theater/data/product_pricelist_item.xml
@@ -2,9 +2,8 @@
 <odoo noupdate="1">
   <record id="product_pricelist_item_1" model="product.pricelist.item">
     <field name="pricelist_id" ref="product_pricelist_2"/>
-    <field name="applied_on">2_product_category</field>
     <field name="categ_id" ref="event_product.product_category_events"/>
-    <field name="compute_price">percentage</field>
-    <field name="percent_price">100.0</field>
+    <field name="compute_price">discount</field>
+    <field name="price_discount">100.0</field>
   </record>
 </odoo>

--- a/wine_merchant/__manifest__.py
+++ b/wine_merchant/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Wine Shop',
-    'version': '1.3',
+    'version': '1.4',
     'category': 'Retail',
     'author': 'Odoo S.A.',
     'depends': [

--- a/wine_merchant/data/product_pricelist_item.xml
+++ b/wine_merchant/data/product_pricelist_item.xml
@@ -2,7 +2,7 @@
 <odoo noupdate="1">
   <record id="product_pricelist_item_1" model="product.pricelist.item">
     <field name="pricelist_id" ref="product_pricelist_2"/>
-    <field name="compute_price">percentage</field>
-    <field name="percent_price">10.0</field>
+    <field name="compute_price">discount</field>
+    <field name="price_discount">10.0</field>
   </record>
 </odoo>

--- a/yoga_pilates/__manifest__.py
+++ b/yoga_pilates/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Yoga & Pilates Studio',
-    'version': '1.2',
+    'version': '1.3',
     'category': 'Health and Fitness',
     'author': 'Odoo S.A.',
     'depends': [

--- a/yoga_pilates/data/product_pricelist_item.xml
+++ b/yoga_pilates/data/product_pricelist_item.xml
@@ -3,33 +3,29 @@
   <record id="product_pricelist_item_6" model="product.pricelist.item">
     <field name="pricelist_id" ref="product_pricelist_4"/>
     <field name="min_quantity">1.0</field>
-    <field name="applied_on">1_product</field>
     <field name="product_id" ref="product_product_2"/>
-    <field name="compute_price">percentage</field>
-    <field name="percent_price">100.0</field>
+    <field name="compute_price">discount</field>
+    <field name="price_discount">100.0</field>
   </record>
   <record id="product_pricelist_item_5" model="product.pricelist.item">
     <field name="pricelist_id" ref="product_pricelist_4"/>
     <field name="min_quantity">1.0</field>
-    <field name="applied_on">1_product</field>
     <field name="product_id" ref="product_product_12"/>
-    <field name="compute_price">percentage</field>
-    <field name="percent_price">100.0</field>
+    <field name="compute_price">discount</field>
+    <field name="price_discount">100.0</field>
   </record>
   <record id="product_pricelist_item_4" model="product.pricelist.item">
     <field name="pricelist_id" ref="product_pricelist_3"/>
     <field name="min_quantity">1.0</field>
-    <field name="applied_on">1_product</field>
     <field name="product_id" ref="product_product_12"/>
-    <field name="compute_price">percentage</field>
-    <field name="percent_price">100.0</field>
+    <field name="compute_price">discount</field>
+    <field name="price_discount">100.0</field>
   </record>
   <record id="product_pricelist_item_1" model="product.pricelist.item">
     <field name="pricelist_id" ref="product_pricelist_2"/>
     <field name="min_quantity">1.0</field>
-    <field name="applied_on">1_product</field>
     <field name="product_id" ref="product_product_2"/>
-    <field name="compute_price">percentage</field>
-    <field name="percent_price">100.0</field>
+    <field name="compute_price">discount</field>
+    <field name="price_discount">100.0</field>
   </record>
 </odoo>


### PR DESCRIPTION
Recent standard changes to pricelist requires changes in item
definition. Implied changes are:

- adapts `formula` (replaced with `discount`) and removes `percentage`
in product.pricelist.item[^1]

- makes `applied_on` non-inverse, compute, readonly[^2]
(also removes useless field display_applied_on)

- removes the customer groupby filter from project.view_task_search_form[^3]

[^1]: https://github.com/odoo/odoo/commit/a24fc1d448f21ee09e820967abe3b2e07f96eb2e
[^2]: https://github.com/odoo/odoo/commit/3be9c12084df67ceb9efa357ae4d1c1816e9d8f6
[^3]: https://github.com/odoo/odoo/commit/74d6a5b345f3a1bc90086e4830fe8e25cc70f7b5