### PR TITLE
[IMP] campsite,hotel: move pos.payment.method to standard

### DIFF
--- a/campsite/data/pos_config.xml
+++ b/campsite/data/pos_config.xml
@@ -8,10 +8,4 @@
         <field name="limit_categories" eval="True"/>
         <field name="iface_available_categ_ids" eval="[Command.link(ref('pos_category_1'))]"/>
     </record>
-    <record id="pos_payment_method_1" model="pos.payment.method">
-        <field name="name">Checkout Payment</field>
-        <field name="type">resource</field>
-        <field name="sequence">5</field>
-        <field name="config_ids" eval="[(6, 0, [ref('point_of_sale.pos_config_retail')])]" />
-    </record>
 </odoo>

--- a/campsite/demo/pos_config.xml
+++ b/campsite/demo/pos_config.xml
@@ -6,7 +6,4 @@
     <function model="pos.config" name="load_onboarding_restaurant_scenario">
         <value name="with_demo_data" eval="True"/>
     </function>
-    <record id="pos_payment_method_1" model="pos.payment.method">
-		<field name="config_ids" eval="[(4, ref('pos_restaurant.pos_config_main_bar')), (4, ref('pos_restaurant.pos_config_main_restaurant'))]"/>
-    </record>
 </odoo>

--- a/hotel/data/pos_config.xml
+++ b/hotel/data/pos_config.xml
@@ -8,10 +8,4 @@
         <field name="limit_categories" eval="True"/>
         <field name="iface_available_categ_ids" eval="[Command.link(ref('pos_category_1'))]"/>
     </record>
-    <record id="pos_payment_method_1" model="pos.payment.method">
-        <field name="name">Checkout Payment</field>
-        <field name="type">resource</field>
-        <field name="sequence">5</field>
-        <field name="config_ids" eval="[(6, 0, [ref('point_of_sale.pos_config_retail')])]" />
-    </record>
 </odoo>

--- a/hotel/demo/pos_config.xml
+++ b/hotel/demo/pos_config.xml
@@ -6,7 +6,4 @@
     <function model="pos.config" name="load_onboarding_restaurant_scenario">
 		<value name="with_demo_data" eval="True"/>
 	</function>
-	<record id="pos_payment_method_1" model="pos.payment.method">
-		<field name="config_ids" eval="[(4, ref('pos_restaurant.pos_config_main_bar')), (4, ref('pos_restaurant.pos_config_main_restaurant'))]"/>
-    </record>
 </odoo>


### PR DESCRIPTION
Before this commit, the pos.payment.method linked to resources was generated in data module. Since there is now a standard payment method automatically created, this record can be removed from industry modules.

task-6396178