### PR TITLE
[IMP] outdoor_activities: update ministock

### DIFF
--- a/outdoor_activities/__manifest__.py
+++ b/outdoor_activities/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Outdoor Activities',
-    'version': '1.2',
+    'version': '1.3',
     'category': 'Health and Fitness',
     'depends': [
         'appointment_account_payment',
@@ -8,7 +8,6 @@
         'event_crm',
         'knowledge',
         'pos_sale',
-        'pos_stock',
         'sale_service',
         'website_appointment',
         'website_crm',
@@ -16,6 +15,7 @@
     ],
     'data': [
         'data/ir_attachment.xml',
+        'data/ir_ui_menu.xml',
         'data/crm_stages.xml',
         'data/crm_tags.xml',
         'data/product_product.xml',

--- a/outdoor_activities/data/ir_ui_menu.xml
+++ b/outdoor_activities/data/ir_ui_menu.xml
@@ -1,0 +1,39 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<odoo>
+  <record id="point_of_sale.menu_point_root" model="ir.ui.menu" forcecreate="0">
+    <field name="sequence">1</field>
+  </record>
+  <record id="event.event_main_menu" model="ir.ui.menu" forcecreate="0">
+    <field name="sequence">2</field>
+  </record>
+  <record id="crm.crm_menu_root" model="ir.ui.menu" forcecreate="0">
+    <field name="sequence">3</field>
+  </record>
+  <record id="sale.sale_menu_root" model="ir.ui.menu" forcecreate="0">
+    <field name="sequence">4</field>
+  </record>
+  <record id="contacts.menu_contacts" model="ir.ui.menu" forcecreate="0">
+    <field name="sequence">5</field>
+  </record>
+  <record id="appointment.main_menu_appointments" model="ir.ui.menu" forcecreate="0">
+    <field name="sequence">6</field>
+  </record>
+  <record id="website.menu_website_configuration" model="ir.ui.menu" forcecreate="0">
+    <field name="sequence">7</field>
+  </record>
+  <record id="account.menu_finance" model="ir.ui.menu" forcecreate="0">
+    <field name="sequence">8</field>
+  </record>
+  <record id="knowledge.knowledge_menu_root" model="ir.ui.menu" forcecreate="0">
+    <field name="sequence">9</field>
+  </record>
+  <record id="mail.menu_root_discuss" model="ir.ui.menu" forcecreate="0">
+    <field name="sequence">10</field>
+  </record>
+  <record id="calendar.mail_menu_calendar" model="ir.ui.menu" forcecreate="0">
+    <field name="sequence">11</field>
+  </record>
+  <record id="spreadsheet_dashboard.spreadsheet_dashboard_menu_root" model="ir.ui.menu" forcecreate="0">
+    <field name="sequence">12</field>
+  </record>
+</odoo>


### PR DESCRIPTION
This commit updates the outdoor activities industry ministock:

- Remove the inventory module.
- Reorder the app sequence.

Task-6432007