### PR TITLE
[FIX] non_profit_organization: avoid partner edition

### DIFF
--- a/non_profit_organization/data/ir_actions_server.xml
+++ b/non_profit_organization/data/ir_actions_server.xml
@@ -12,29 +12,25 @@
     </record>
     <record id="action_create_x_signature" model="ir.actions.server">
         <field name="code"><![CDATA[
+if request.httprequest.method != 'POST': raise UserError("Invalid Request")
 partner = env['res.partner'].sudo().search([('email', '=', request.params.get('email'))], limit=1)
-country = env['res.country'].sudo().search([('id', '=', request.params.get('country_id'))], limit=1)
-if not partner:
-    partner = env['res.partner'].sudo().create({
+if (partner and (existing_signature := env['x_signature'].sudo().search([('x_partner_id', '=', partner.id), ('x_petition_id', '=', int(request.params.get('petition_id')))], limit=1))):
+    response = request.make_json_response({'id': existing_signature.id}, status=200)
+elif (petition_id := request.params.get('petition_id')):
+    partner = partner or env['res.partner'].sudo().create({
         'name': request.params.get('name'), 
         'email': request.params.get('email'), 
-        'country_id': country.id,
+        'country_id': int(request.params.get('country_id')),
     })
-else:
-    partner.write({'name': request.params.get('name'), 'country_id': country.id})
-existing_signature = env['x_signature'].sudo().search([('x_partner_id', '=', partner.id), ('x_petition_id', '=', int(request.params.get('petition_id')))], limit=1)
-if existing_signature:
-    response = request.make_json_response({'id': existing_signature.id}, status=200)
-elif request.params.get('petition_id'):
     new_signature = env['x_signature'].sudo().create({
         "x_partner_id": partner.id,
         "x_date": datetime.datetime.today().strftime('%Y-%m-%d'),
-        "x_petition_id": request.params.get('petition_id'),
+        "x_petition_id": petition_id,
         "x_newsletter": request.params.get('newsletter'),
     })
     #Force compute the amount of signatures
     related_petition = env['x_petition'].sudo().browse([int(request.params.get('petition_id'))])
-    related_petition.write({'x_current_signatures': env['x_signature'].sudo().search_count([('x_petition_id', '=', int(request.params.get('petition_id')))])})
+    related_petition.write({'x_current_signatures': env['x_signature'].sudo().search_count([('x_petition_id', '=', int(petition_id))])})
     message = env['mail.message'].sudo().create({
         'model': 'x_signature',
         'res_id': new_signature.id,


### PR DESCRIPTION
Before this commit, the server action could edit the partner name and country of an existing partner. This commit modifies it to only create new partner for a new signature.

task-6559796