### PR TITLE
[FIX] textile_management: fix active settings

### DIFF
--- a/textile_manufacturing/data/res_config_settings.xml
+++ b/textile_manufacturing/data/res_config_settings.xml
@@ -3,8 +3,9 @@
     <data noupdate="1">
         <record id="res_config_setting_textile_manufacturing" model="res.config.settings">
             <field name="group_mrp_routings" eval="1"/>
+            <field name="group_mrp_wo_tablet_timer" eval="1"/>
             <field name="group_project_stages" eval="1"/>
-            <field name="group_stock_production_lot" eval="1"/>
+            <field name="replenish_on_order" eval="1"/>
         </record>
         <function name="execute" model="res.config.settings">
             <value eval="[ref('res_config_setting_textile_manufacturing')]"/>


### PR DESCRIPTION
A recent commit[^1] wrongly introduced a change on activated settings. This commit fixes the issue by activating back right ones.

[^1]: 58a5b145e2bd1f567362ffec9e0b97ed2277b9df